### PR TITLE
[COZY-39] Swagger Custom Error Annotation 구현

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/controller/TodoController.java
@@ -4,6 +4,8 @@ package com.cozymate.cozymate_server.domain.todo.controller;
 import com.cozymate.cozymate_server.domain.todo.dto.TodoRequestDto.CreateTodoRequestDto;
 import com.cozymate.cozymate_server.domain.todo.service.TodoCommandService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class TodoController {
 
     @PostMapping("/{roomId}")
     @Operation(summary = "[무빗] 특정 방에 본인의 Todo 생성", description = "Todo는 본인한테만 할당할 수 있습니다.")
+    @SwaggerApiError({ErrorStatus._MATE_NOT_FOUND})
     public ResponseEntity<ApiResponse<String>> createTodo(
         @Valid @RequestBody CreateTodoRequestDto createTodoRequestDto, @PathVariable Long roomId,
         @RequestParam Long memberId) {

--- a/src/main/java/com/cozymate/cozymate_server/global/utils/SwaggerApiError.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/utils/SwaggerApiError.java
@@ -1,0 +1,14 @@
+package com.cozymate.cozymate_server.global.utils;
+
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SwaggerApiError {
+
+    ErrorStatus[] value();
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/utils/SwaggerApiErrorCustomizer.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/utils/SwaggerApiErrorCustomizer.java
@@ -1,0 +1,51 @@
+package com.cozymate.cozymate_server.global.utils;
+
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+@Component
+public class SwaggerApiErrorCustomizer implements OperationCustomizer {
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        SwaggerApiError swaggerApiError = handlerMethod.getMethodAnnotation(SwaggerApiError.class);
+        if (swaggerApiError != null) {
+            Map<String, List<Map<String, Object>>> errorDetailsMap = new HashMap<>();
+
+            for (ErrorStatus errorStatus : swaggerApiError.value()) {
+                String statusCode = String.valueOf(errorStatus.getHttpStatus().value());
+                List<Map<String, Object>> errorDetails = errorDetailsMap.getOrDefault(statusCode,
+                    new ArrayList<>());
+
+                Map<String, Object> errorInfo = new HashMap<>();
+                errorInfo.put("isSuccess", false);
+                errorInfo.put("code", errorStatus.getCode());
+                errorInfo.put("message", errorStatus.getMessage());
+                errorDetails.add(errorInfo);
+
+                errorDetailsMap.put(statusCode, errorDetails);
+            }
+
+            errorDetailsMap.forEach((statusCode, errorList) -> {
+                Schema<?> errorSchema = new Schema<>().type("object").example(errorList);
+                Content content = new Content()
+                    .addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                        new MediaType().schema(errorSchema));
+                ApiResponse apiResponse = new ApiResponse().content(content);
+                operation.getResponses().addApiResponse(statusCode, apiResponse);
+            });
+        }
+        return operation;
+    }
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
- Swagger 에러 관련 어노테이션입니다.
- 아래 이미지 참고!

<img width="562" alt="image" src="https://github.com/user-attachments/assets/6bb07c49-7efd-4c02-b95c-813e926b7119">

## 📝 작업 내용
### Custom Annotation
- 어노테이션 관련 세팅입니다.
```java
@Target({ElementType.METHOD})
@Retention(RetentionPolicy.RUNTIME)
public @interface SwaggerApiError {

    ErrorStatus[] value();
}
```
### SwaggerApiErrorCustomizer
- 어노테이션이 들어왔을 때 커스텀합니다.
- SwaggerApiError 값을 가져옵니다.
``` java
@Component
public class SwaggerApiErrorCustomizer implements OperationCustomizer {

    @Override
    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
        SwaggerApiError swaggerApiError = handlerMethod.getMethodAnnotation(SwaggerApiError.class);
```

- 값이 있을 때에만 각각 진행합니다.
``` java
        if (swaggerApiError != null) {
            Map<String, List<Map<String, Object>>> errorDetailsMap = new HashMap<>();

            for (ErrorStatus errorStatus : swaggerApiError.value()) {
                String statusCode = String.valueOf(errorStatus.getHttpStatus().value());
                List<Map<String, Object>> errorDetails = errorDetailsMap.getOrDefault(statusCode,
                    new ArrayList<>());

                Map<String, Object> errorInfo = new HashMap<>();
                errorInfo.put("isSuccess", false);
                errorInfo.put("code", errorStatus.getCode());
                errorInfo.put("message", errorStatus.getMessage());
                errorDetails.add(errorInfo);

                errorDetailsMap.put(statusCode, errorDetails);
            }

            errorDetailsMap.forEach((statusCode, errorList) -> {
                Schema<?> errorSchema = new Schema<>().type("object").example(errorList);
                Content content = new Content()
                    .addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
                        new MediaType().schema(errorSchema));
                ApiResponse apiResponse = new ApiResponse().content(content);
                operation.getResponses().addApiResponse(statusCode, apiResponse);
            });
        }
        return operation;
    }
}
```

## 동작 확인

### ToDo Controller
- 아래처럼 Controller의 각 메서드에 `@SwaggerApiError({ErrorStatus._MATE_NOT_FOUND})` 처럼 써주시면 됩니당.
- 아무것도 없으면 안써도 무방한데, `@SwaggerApiError({})`처럼만 써두는걸 권장합니다.
- 여러개의 에러가 있으면 `@SwaggerApiError({ErrorStatus._MATE_NOT_FOUND, ErrorStatus._INVALID_AUTHORIZATION})`처럼 쉼표를 기준으로 써주시면 됩니다.

``` java
    @PostMapping("/{roomId}")
    @Operation(summary = "[무빗] 특정 방에 본인의 Todo 생성", description = "Todo는 본인한테만 할당할 수 있습니다.")
    @SwaggerApiError({ErrorStatus._MATE_NOT_FOUND})
    public ResponseEntity<ApiResponse<String>> createTodo(
        @Valid @RequestBody CreateTodoRequestDto createTodoRequestDto, @PathVariable Long roomId,
        @RequestParam Long memberId) {
        // TODO: 소셜로그인 구현 후 RequestParam의 userId는 JWT를 인증할 때 수정 예정

        toDoCommandService.createTodo(createTodoRequestDto, roomId, memberId);
        return ResponseEntity.ok(ApiResponse.onSuccess("Todo를 정상 생성하였습니다."));

    }
```


- 아래처럼 동작합니다!

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/1f4e5469-c621-4337-86db-7b07a924f9ce">


## 💬 리뷰 요구사항(선택)

- 기존에 본인이 작성한 코드에도 해당 예외처리 추가 부탁드립니다! 어떤 에러인지 Swagger에 나오면 좋잖아요~
