### PR TITLE
[COZY-48] 쪽지방의 쪽지 상세 내역 조회 API

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/controller/ChatController.java
@@ -1,16 +1,21 @@
 package com.cozymate.cozymate_server.domain.chat.controller;
 
 import com.cozymate.cozymate_server.domain.chat.dto.ChatRequestDto;
+import com.cozymate.cozymate_server.domain.chat.dto.ChatResponseDto;
 import com.cozymate.cozymate_server.domain.chat.service.ChatCommandService;
+import com.cozymate.cozymate_server.domain.chat.service.ChatQueryService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
     private final ChatCommandService chatCommandService;
+    private final ChatQueryService chatQueryService;
 
     // TODO: ChatRequestDto의 senderId는 추후 시큐리티 인증 객체에서 받아 오는 것으로 변경 예정
     @PostMapping("/members/{recipientId}")
@@ -27,5 +33,13 @@ public class ChatController {
         @Valid @RequestBody ChatRequestDto chatRequestDto, @PathVariable Long recipientId) {
         chatCommandService.createChat(chatRequestDto, recipientId);
         return ResponseEntity.ok(ApiResponse.onSuccess("쪽지 작성 완료"));
+    }
+
+    // TODO: memberId는 추후 시큐리티 인증 객체에서 받아 오는 것으로 변경 예정
+    @GetMapping("/chatrooms/{chatRoomId}")
+    @Operation(summary = "[베로] 쪽지방의 쪽지 상세 내역 조회", description = "내 memberId, chatRoomId : 조회할 쪽지방 pk값")
+    public ResponseEntity<List<ChatResponseDto>> getChatList(@RequestParam Long memberId,
+        @PathVariable Long chatRoomId) {
+        return ResponseEntity.ok(chatQueryService.getChatList(memberId, chatRoomId));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/controller/ChatController.java
@@ -5,6 +5,8 @@ import com.cozymate.cozymate_server.domain.chat.dto.ChatResponseDto;
 import com.cozymate.cozymate_server.domain.chat.service.ChatCommandService;
 import com.cozymate.cozymate_server.domain.chat.service.ChatQueryService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -38,6 +40,10 @@ public class ChatController {
     // TODO: memberId는 추후 시큐리티 인증 객체에서 받아 오는 것으로 변경 예정
     @GetMapping("/chatrooms/{chatRoomId}")
     @Operation(summary = "[베로] 쪽지방의 쪽지 상세 내역 조회", description = "내 memberId, chatRoomId : 조회할 쪽지방 pk값")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND, ErrorStatus._CHATROOM_NOT_FOUND,
+        ErrorStatus._CHATROOM_MEMBER_MISMATCH
+    })
     public ResponseEntity<List<ChatResponseDto>> getChatList(@RequestParam Long memberId,
         @PathVariable Long chatRoomId) {
         return ResponseEntity.ok(chatQueryService.getChatList(memberId, chatRoomId));

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/converter/ChatConverter.java
@@ -1,8 +1,11 @@
 package com.cozymate.cozymate_server.domain.chat.converter;
 
 import com.cozymate.cozymate_server.domain.chat.Chat;
+import com.cozymate.cozymate_server.domain.chat.dto.ChatResponseDto;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.member.Member;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class ChatConverter {
 
@@ -11,6 +14,17 @@ public class ChatConverter {
             .chatRoom(chatRoom)
             .sender(sender)
             .content(content)
+            .build();
+    }
+
+    public static ChatResponseDto toResponseDto(String nickName, String content, LocalDateTime createdAt) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy.MM.dd | HH:mm");
+        String formattedDateTime = createdAt.format(formatter);
+
+        return ChatResponseDto.builder()
+            .nickName(nickName)
+            .content(content)
+            .dateTime(formattedDateTime)
             .build();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/dto/ChatResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/dto/ChatResponseDto.java
@@ -1,0 +1,14 @@
+package com.cozymate.cozymate_server.domain.chat.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatResponseDto {
+
+    private String nickName;
+    private String content;
+    private String dateTime;
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/repository/ChatRepository.java
@@ -2,12 +2,18 @@ package com.cozymate.cozymate_server.domain.chat.repository;
 
 import com.cozymate.cozymate_server.domain.chat.Chat;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     Optional<Chat> findTopByChatRoomOrderByIdDesc(ChatRoom chatRoom);
 
     void deleteAllByChatRoom(ChatRoom chatRoom);
+
+    @Query("select c from Chat c where c.chatRoom = :chatRoom")
+    List<Chat> findAllByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
@@ -35,7 +35,7 @@ public class ChatQueryService {
 
         if (!member.getId().equals(chatRoom.getMemberA().getId())
             && !member.getId().equals(chatRoom.getMemberB().getId())) {
-            throw new GeneralException(ErrorStatus._CHATROOM_FORBIDDEN);
+            throw new GeneralException(ErrorStatus._CHATROOM_NOT_MEMBER);
         }
 
         List<Chat> filteredChatList = getFilteredChatList(chatRoom, member);

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
@@ -33,6 +33,11 @@ public class ChatQueryService {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
 
+        if (!member.getId().equals(chatRoom.getMemberA().getId())
+            && !member.getId().equals(chatRoom.getMemberB().getId())) {
+            throw new GeneralException(ErrorStatus._CHATROOM_FORBIDDEN);
+        }
+
         List<Chat> filteredChatList = getFilteredChatList(chatRoom, member);
 
         List<ChatResponseDto> chatResponseDtoList = toChatResponseDtoList(filteredChatList,
@@ -45,7 +50,8 @@ public class ChatQueryService {
         List<Chat> findChatList = chatRepository.findAllByChatRoom(chatRoom);
         LocalDateTime memberLastDeleteAt = getMemberLastDeleteAt(chatRoom, member);
         return findChatList.stream()
-            .filter(chat -> memberLastDeleteAt == null || chat.getCreatedAt().isAfter(memberLastDeleteAt))
+            .filter(chat -> memberLastDeleteAt == null || chat.getCreatedAt()
+                .isAfter(memberLastDeleteAt))
             .collect(Collectors.toList());
     }
 
@@ -62,7 +68,8 @@ public class ChatQueryService {
                 String nickName = senderNickName.equals(member.getNickname())
                     ? senderNickName + " (나)"
                     : senderNickName;
-                return ChatConverter.toResponseDto(nickName, chat.getContent(), chat.getCreatedAt());
+                return ChatConverter.toResponseDto(nickName, chat.getContent(),
+                    chat.getCreatedAt());
             })
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
@@ -35,7 +35,7 @@ public class ChatQueryService {
 
         if (!member.getId().equals(chatRoom.getMemberA().getId())
             && !member.getId().equals(chatRoom.getMemberB().getId())) {
-            throw new GeneralException(ErrorStatus._CHATROOM_NOT_MEMBER);
+            throw new GeneralException(ErrorStatus._CHATROOM_MEMBER_MISMATCH);
         }
 
         List<Chat> filteredChatList = getFilteredChatList(chatRoom, member);
@@ -52,7 +52,7 @@ public class ChatQueryService {
         return findChatList.stream()
             .filter(chat -> memberLastDeleteAt == null || chat.getCreatedAt()
                 .isAfter(memberLastDeleteAt))
-            .collect(Collectors.toList());
+            .toList();
     }
 
     private LocalDateTime getMemberLastDeleteAt(ChatRoom chatRoom, Member member) {
@@ -71,6 +71,6 @@ public class ChatQueryService {
                 return ChatConverter.toResponseDto(nickName, chat.getContent(),
                     chat.getCreatedAt());
             })
-            .collect(Collectors.toList());
+            .toList();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
@@ -1,5 +1,18 @@
 package com.cozymate.cozymate_server.domain.chat.service;
 
+import com.cozymate.cozymate_server.domain.chat.Chat;
+import com.cozymate.cozymate_server.domain.chat.converter.ChatConverter;
+import com.cozymate.cozymate_server.domain.chat.dto.ChatResponseDto;
+import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.member.MemberRepository;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +21,44 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ChatQueryService {
+
+    private final ChatRepository chatRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberRepository memberRepository;
+
+    public List<ChatResponseDto> getChatList(Long memberId, Long chatRoomId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        //chatRoomId으로 채팅방 찾아오기
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+
+        //chatRoom의 chat 전부 찾아오기
+        List<Chat> findChatList = chatRepository.findAllByChatRoom(chatRoom);
+
+        //chatRoom에서 내가 delete한 시간 이후에 오고 간 chat만 분류하기
+        LocalDateTime memberLastDeleteAt =
+            chatRoom.getMemberA().getNickname().equals(member.getNickname())
+                ? chatRoom.getMemberALastDeleteAt()
+                : chatRoom.getMemberBLastDeleteAt();
+
+        List<Chat> chatList = findChatList.stream()
+            .filter(chat -> memberLastDeleteAt == null || chat.getCreatedAt()
+                .isAfter(memberLastDeleteAt))
+            .collect(Collectors.toList());
+
+        List<ChatResponseDto> chatResponseDtoList = chatList.stream()
+            .map(chat -> {
+                String senderNickName = chat.getSender().getNickname();
+                String nickName =
+                    senderNickName.equals(member.getNickname()) ? senderNickName + " (나)"
+                        : senderNickName;
+                return ChatConverter.toResponseDto(nickName, chat.getContent(),
+                    chat.getCreatedAt());
+            })
+            .collect(Collectors.toList());
+
+        return chatResponseDtoList;
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
@@ -12,7 +12,6 @@ import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -39,6 +39,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // ChatRoom 관련 애러
     _CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM400", "쪽지방을 찾을 수 없습니다."),
     _CHATROOM_FORBIDDEN(HttpStatus.BAD_REQUEST,"CHATROOM401", "해당 쪽지방을 삭제할 권한이 없습니다."),
+    _CHATROOM_NOT_MEMBER(HttpStatus.BAD_REQUEST, "CHATROOM402", "해당 쪽지방의 멤버가 아닙니다."),
 
     // Mate 관련
     _MATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATE400", "해당하는 메이트 정보가 없습니다."),

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -39,7 +39,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // ChatRoom 관련 애러
     _CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM400", "쪽지방을 찾을 수 없습니다."),
     _CHATROOM_FORBIDDEN(HttpStatus.BAD_REQUEST,"CHATROOM401", "해당 쪽지방을 삭제할 권한이 없습니다."),
-    _CHATROOM_NOT_MEMBER(HttpStatus.BAD_REQUEST, "CHATROOM402", "해당 쪽지방의 멤버가 아닙니다."),
+    _CHATROOM_MEMBER_MISMATCH(HttpStatus.BAD_REQUEST, "CHATROOM402", "해당 쪽지방의 멤버가 아닙니다."),
 
     // Mate 관련
     _MATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATE400", "해당하는 메이트 정보가 없습니다."),

--- a/src/test/java/com/cozymate/cozymate_server/domain/chat/ChatTestBuilder.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chat/ChatTestBuilder.java
@@ -18,6 +18,7 @@ public class ChatTestBuilder {
         return Member.builder()
             .id(SENDER_ID)
             .name("멤버1")
+            .nickname("닉네임1")
             .build();
     }
 
@@ -25,6 +26,7 @@ public class ChatTestBuilder {
         return Member.builder()
             .id(RECIPIENT_ID)
             .name("멤버2")
+            .nickname("닉네임2")
             .build();
     }
 

--- a/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryServiceTest.java
@@ -1,0 +1,188 @@
+package com.cozymate.cozymate_server.domain.chat.service;
+
+import com.cozymate.cozymate_server.domain.chat.Chat;
+import com.cozymate.cozymate_server.domain.chat.ChatTestBuilder;
+import com.cozymate.cozymate_server.domain.chat.dto.ChatResponseDto;
+import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoomTestBuilder;
+import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.member.MemberRepository;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatQueryService 클래스의")
+class ChatQueryServiceTest {
+
+    @Mock
+    ChatRepository chatRepository;
+    @Mock
+    ChatRoomRepository chatRoomRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @InjectMocks
+    ChatQueryService chatQueryService;
+    Member me;
+    Member you;
+    ChatRoom chatRoom;
+    Chat chat;
+    Chat chat2;
+    Chat chat3;
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class getChatList_메서드는 {
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class memberId와_chatRoomId가_유효한_경우 {
+
+            @BeforeEach
+            void setUp() {
+                //상대와 나
+                me = ChatTestBuilder.testSenderBuild();
+                you = ChatTestBuilder.testRecipientBuild();
+
+                //ChatRoom 생성
+                chatRoom = ChatRoomTestBuilder.testChatRoomBuild();
+
+                //chatRoom의 Chat 생성
+                chat = mock(Chat.class);
+                given(chat.getCreatedAt()).willReturn(LocalDateTime.now());
+                given(chat.getContent()).willReturn("Chat1 내용");
+                given(chat.getSender()).willReturn(me);
+
+                chat2 = mock(Chat.class);
+                given(chat2.getCreatedAt()).willReturn(LocalDateTime.now());
+                given(chat2.getContent()).willReturn("Chat2 내용");
+                given(chat2.getSender()).willReturn(you);
+
+                given(memberRepository.findById(me.getId())).willReturn(Optional.of(me));
+                given(chatRoomRepository.findById(chatRoom.getId())).willReturn(
+                    Optional.of(chatRoom));
+                given(chatRepository.findAllByChatRoom(chatRoom)).willReturn(List.of(chat, chat2));
+            }
+
+            @Test
+            @DisplayName("해당 쪽지방의 쪽지 상세 내역을 리스트로 반환한다.")
+            void it_returns_chat_list() {
+                List<ChatResponseDto> result = chatQueryService.getChatList(me.getId(),
+                    chatRoom.getId());
+
+                assertThat(result.size()).isEqualTo(2);
+                assertThat(result.get(0).getNickName()).isEqualTo(me.getNickname() + " (나)");
+                assertThat(result.get(0).getContent()).isEqualTo(chat.getContent());
+                assertThat(result.get(1).getNickName()).isEqualTo(you.getNickname());
+                assertThat(result.get(1).getContent()).isEqualTo(chat2.getContent());
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 내가_해당_방을_나간_후에_쪽지가_오면 {
+
+            @BeforeEach
+            void setUp() {
+                //상대와 나
+                me = ChatTestBuilder.testSenderBuild();
+                you = ChatTestBuilder.testRecipientBuild();
+
+                //ChatRoom 생성
+                chatRoom = ChatRoomTestBuilder.testChatRoomBuild();
+
+                //chatRoom의 Chat 생성
+                chat = mock(Chat.class);
+                given(chat.getCreatedAt()).willReturn(LocalDateTime.now().minusDays(1));
+
+                chat2 = mock(Chat.class);
+                given(chat2.getCreatedAt()).willReturn(LocalDateTime.now().minusDays(1));
+
+                //me가 chatRoom을 나감
+                chatRoom.updateMemberALastDeleteAt();
+
+                //이후 you가 me에게 다시 쪽지를 보냄
+                chat3 = mock(Chat.class);
+                given(chat3.getCreatedAt()).willReturn(LocalDateTime.now().plusDays(1));
+                given(chat3.getContent()).willReturn("나간 후 다시 보냅니다");
+                given(chat3.getSender()).willReturn(you);
+
+                given(memberRepository.findById(me.getId())).willReturn(Optional.of(me));
+                given(chatRoomRepository.findById(chatRoom.getId())).willReturn(
+                    Optional.of(chatRoom));
+                given(chatRepository.findAllByChatRoom(chatRoom)).willReturn(
+                    List.of(chat, chat2, chat3));
+            }
+
+            @Test
+            @DisplayName("나간 후에 온 쪽지 상세 내역만 리스트로 반환한다.")
+            void it_returns_chat_list_after_delete() {
+                List<ChatResponseDto> result = chatQueryService.getChatList(me.getId(),
+                    chatRoom.getId());
+
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy.MM.dd | HH:mm");
+                LocalDateTime parsedDateTime = LocalDateTime.parse(result.get(0).getDateTime(),
+                    formatter);
+
+                assertThat(result.size()).isEqualTo(1);
+                assertThat(result.get(0).getNickName()).isEqualTo(you.getNickname());
+                assertThat(result.get(0).getContent()).isEqualTo(chat3.getContent());
+                assertThat(parsedDateTime).isAfter(chatRoom.getMemberALastDeleteAt());
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class memberId가_유효하지_않는_경우 {
+
+            @BeforeEach
+            void setUp() {
+                given(memberRepository.findById(1L)).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("예외를 발생시킨다.")
+            void it_returns_not_found_member() {
+                assertThatThrownBy(() -> chatQueryService.getChatList(1L, 1L))
+                    .isInstanceOf(GeneralException.class);
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class chatRoomId가_유효하지_않는_경우 {
+
+            @BeforeEach
+            void setUp() {
+                me = ChatTestBuilder.testSenderBuild();
+                given(memberRepository.findById(me.getId())).willReturn(Optional.of(me));
+                given(chatRoomRepository.findById(1L)).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("예외를 발생시킨다.")
+            void it_returns_not_found_chat_room() {
+                assertThatThrownBy(() -> chatQueryService.getChatList(me.getId(), 1L))
+                    .isInstanceOf(GeneralException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryServiceTest.java
@@ -184,5 +184,37 @@ class ChatQueryServiceTest {
                     .isInstanceOf(GeneralException.class);
             }
         }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 쪽지방의_멤버가_아닌_경우 {
+
+            @BeforeEach
+            void setUp() {
+                me = ChatTestBuilder.testSenderBuild();
+                chatRoom = mock(ChatRoom.class);
+
+                Member memberA = Member.builder()
+                    .id(3L)
+                    .build();
+
+                Member memberB = Member.builder()
+                    .id(4L)
+                    .build();
+
+                given(chatRoom.getMemberA()).willReturn(memberA);
+                given(chatRoom.getMemberB()).willReturn(memberB);
+
+                given(memberRepository.findById(me.getId())).willReturn(Optional.of(me));
+                given(chatRoomRepository.findById(1L)).willReturn(Optional.of(chatRoom));
+            }
+
+            @Test
+            @DisplayName("예외를 발생시킨다.")
+            void it_returns_chat_room_not_member() {
+                assertThatThrownBy(() -> chatQueryService.getChatList(me.getId(), 1L))
+                    .isInstanceOf(GeneralException.class);
+            }
+        }
     }
 }

--- a/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryServiceTest.java
@@ -211,7 +211,7 @@ class ChatQueryServiceTest {
 
             @Test
             @DisplayName("예외를 발생시킨다.")
-            void it_returns_chat_room_not_member() {
+            void it_returns_chat_room_member_mismatch() {
                 assertThatThrownBy(() -> chatQueryService.getChatList(me.getId(), 1L))
                     .isInstanceOf(GeneralException.class);
             }


### PR DESCRIPTION
## #️⃣ 요약 설명
쪽지방의 쪽지 상세 내역 조회를 구현했습니다.
## 📝 작업 내용

```java
//ChatController.java
    // TODO: memberId는 추후 시큐리티 인증 객체에서 받아 오는 것으로 변경 예정
    @GetMapping("/chatrooms/{chatRoomId}")
    @Operation(summary = "[베로] 쪽지방의 쪽지 상세 내역 조회", description = "내 memberId, chatRoomId : 조회할 쪽지방 pk값")
    public ResponseEntity<List<ChatResponseDto>> getChatList(@RequestParam Long memberId,
        @PathVariable Long chatRoomId) {
        return ResponseEntity.ok(chatQueryService.getChatList(memberId, chatRoomId));
    }
```

```java
//ChatQueryService.java
public List<ChatResponseDto> getChatList(Long memberId, Long chatRoomId) {
        Member member = memberRepository.findById(memberId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));

        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));

        if (!member.getId().equals(chatRoom.getMemberA().getId())
            && !member.getId().equals(chatRoom.getMemberB().getId())) {
            throw new GeneralException(ErrorStatus._CHATROOM_NOT_MEMBER);
        }

        // 1
        List<Chat> filteredChatList = getFilteredChatList(chatRoom, member);
        // 2
        List<ChatResponseDto> chatResponseDtoList = toChatResponseDtoList(filteredChatList,
            member);

        return chatResponseDtoList;
    }

    private List<Chat> getFilteredChatList(ChatRoom chatRoom, Member member) {
        List<Chat> findChatList = chatRepository.findAllByChatRoom(chatRoom);
        LocalDateTime memberLastDeleteAt = getMemberLastDeleteAt(chatRoom, member);
        return findChatList.stream()
            .filter(chat -> memberLastDeleteAt == null || chat.getCreatedAt().isAfter(memberLastDeleteAt))
            .collect(Collectors.toList());
    }

    private LocalDateTime getMemberLastDeleteAt(ChatRoom chatRoom, Member member) {
        return chatRoom.getMemberA().getNickname().equals(member.getNickname())
            ? chatRoom.getMemberALastDeleteAt()
            : chatRoom.getMemberBLastDeleteAt();
    }

    private List<ChatResponseDto> toChatResponseDtoList(List<Chat> chatList, Member member) {
        return chatList.stream()
            .map(chat -> {
                String senderNickName = chat.getSender().getNickname();
                String nickName = senderNickName.equals(member.getNickname())
                    ? senderNickName + " (나)"
                    : senderNickName;
                return ChatConverter.toResponseDto(nickName, chat.getContent(), chat.getCreatedAt());
            })
            .collect(Collectors.toList());
    }
```
1. chatRoom의 chat 전부 조회해서 해당 chatRoom을 삭제한 적이 있다면 내가 chatRoom을 삭제한 시간 이후에 생성된 chat만 필터링해서 리스트에 담습니다.
2. 닉네임, 내용, 날짜를 담은 ResponseDto로 변환해서 반환합니다.

## 동작 확인
- 포비와의 쪽지방 조회 시
<img width="376" alt="image" src="https://github.com/user-attachments/assets/35322543-4055-4857-b78a-2e3041e1e5f4">

---

- 무빗과의 쪽지방 조회 시 : #20 에서 예시와 이어집니다.  베로가 쪽지방을 삭제한 후 무빗이 다시 베로에게 쪽지를 보낸 상태
<img width="378" alt="image" src="https://github.com/user-attachments/assets/f0ddf850-8c2d-4c6f-b686-6233af2250d6">

---

- 유효하지 않은 memberId인 경우
<img width="380" alt="image" src="https://github.com/user-attachments/assets/378fe65b-dca6-4726-acb9-6d9011812092">

---

- 유효하지 않은 chatRoomId인 경우
<img width="376" alt="image" src="https://github.com/user-attachments/assets/b5f6f027-da04-424d-a329-7073a7928973">

---

- 쪽지방의 멤버가 아닌 memberId인 경우
<img width="378" alt="image" src="https://github.com/user-attachments/assets/f0e34ead-ab69-4ee8-b735-a4fe489c3d1f">


---

- 테스트 코드 결과
<img width="500" alt="image" src="https://github.com/user-attachments/assets/50c6bc59-2d1a-4b4e-bba8-240e164ae4b9">


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
