### PR TITLE
[COZY-162] 사용자 탈퇴 API 추가 및 코드 구조 리팩토링, AccessToken 발급 Body로 옮기기

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
@@ -8,21 +8,13 @@ import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.SuccessStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.HttpServletRequest;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.RestTemplate;
 
 
 @RequestMapping("/oauth2/kakao")
@@ -31,12 +23,6 @@ import org.springframework.web.client.RestTemplate;
 @RestController
 public class KakaoController implements SocialLoginController {
 
-    private static final String HTTP_ERROR_MESSAGE_FORMAT = "HTTP Error: %s, Status Code: %s, Response Body: %s";
-    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
-    private String USER_INFO_URI;
-
-    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
-    private String TOKEN_URI;
 
     private final KakaoService kakaoService;
     private final AuthService authService;
@@ -60,51 +46,17 @@ public class KakaoController implements SocialLoginController {
     @GetMapping("/code")
     public ResponseEntity<ApiResponse<AuthResponseDTO.TokenResponseDTO>> callBack(
             @RequestParam(required = false) String code) {
-
-        HttpEntity<MultiValueMap<String, String>> tokenRequest = kakaoService.makeTokenRequest(code);
-
-        RestTemplate tokenRt = new RestTemplate();
-
-        ResponseEntity<String> tokenResponse;
-        try {
-            tokenResponse = tokenRt.exchange(TOKEN_URI, HttpMethod.POST,
-                    tokenRequest, String.class);
-        } catch (HttpClientErrorException | HttpServerErrorException e) {
-            String errorMessage = String.format(HTTP_ERROR_MESSAGE_FORMAT,
-                    e.getMessage(), e.getStatusCode(), e.getResponseBodyAsString());
-            throw new RuntimeException(errorMessage);
-        }
-
         // 인가코드를 기반으로 토큰(Access Token) 발급
-        String accessToken = kakaoService.parseAccessToken(tokenResponse);
+        String token = kakaoService.getTokenByCode(code);
 
         // 토큰을 통해 사용자 정보 조회
-        HttpEntity<MultiValueMap<String, String>> clientInfoRequest = kakaoService.makeMemberInfoRequest(accessToken);
+        String clientId = kakaoService.getClientIdByToken(token);
 
-        RestTemplate clientInfoRt = new RestTemplate();
-        ResponseEntity<String> clientInfoResponse;
+        HttpHeaders headers = authService.generateTokenHeader(clientId);
 
-        try {
-            clientInfoResponse = clientInfoRt.exchange(USER_INFO_URI, HttpMethod.POST,
-                    clientInfoRequest,
-                    String.class);
-        } catch (HttpClientErrorException | HttpServerErrorException e) {
-            String errorMessage = String.format(HTTP_ERROR_MESSAGE_FORMAT,
-                    e.getMessage(), e.getStatusCode(), e.getResponseBodyAsString());
-            throw new RuntimeException(errorMessage);
-        }
+        AuthResponseDTO.TokenResponseDTO socialLoginDTO = authService.socialLogin(clientId); // 바디
 
-        String clientId = kakaoService.getClientId(clientInfoResponse);
-
-        String token = authService.generateToken(clientId);
-
-        HttpHeaders headers = authService.addTokenAtHeader(token);
-
-        AuthResponseDTO.TokenResponseDTO socialLoginDTO = authService.socialLogin(clientId);
-
-        log.info("소셜로그인 사용자: {}",socialLoginDTO.getMemberInfoDTO().getNickname());
-
-
+        log.info("소셜로그인 사용자: {}", socialLoginDTO.getMemberInfoDTO().getNickname());
 
         return ResponseEntity.ok()
                 .headers(headers)

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
@@ -22,8 +22,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RestController
 public class KakaoController implements SocialLoginController {
-
-
     private final KakaoService kakaoService;
     private final AuthService authService;
 
@@ -34,7 +32,7 @@ public class KakaoController implements SocialLoginController {
     public ResponseEntity<ApiResponse<UrlDTO>> signIn() {
         UrlDTO url = kakaoService.getRedirectUrl();
 
-        log.info(url.getRedirectUrl());
+        log.info("redirect url: {}",url.getRedirectUrl());
 
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                 .body(ApiResponse.onSuccess(url));

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
@@ -5,14 +5,12 @@ import com.cozymate.cozymate_server.domain.auth.dto.AuthResponseDTO.UrlDTO;
 import com.cozymate.cozymate_server.domain.auth.service.AuthService;
 import com.cozymate.cozymate_server.domain.auth.service.KakaoService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
-import com.cozymate.cozymate_server.global.response.code.status.SuccessStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,10 +30,9 @@ public class KakaoController implements SocialLoginController {
     public ResponseEntity<ApiResponse<UrlDTO>> signIn() {
         UrlDTO url = kakaoService.getRedirectUrl();
 
-        log.info("redirect url: {}",url.getRedirectUrl());
+        log.info("redirect url: {}", url.getRedirectUrl());
 
-        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
-                .body(ApiResponse.onSuccess(url));
+        return ResponseEntity.ok(ApiResponse.onSuccess(url));
     }
 
     @Override
@@ -50,15 +47,11 @@ public class KakaoController implements SocialLoginController {
         // 토큰을 통해 사용자 정보 조회
         String clientId = kakaoService.getClientIdByToken(token);
 
-        HttpHeaders headers = authService.generateTokenHeader(clientId);
+        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = authService.generateTokenDTO(clientId);
 
-        AuthResponseDTO.TokenResponseDTO socialLoginDTO = authService.socialLogin(clientId); // 바디
+        log.info("소셜로그인 사용자: {}", tokenResponseDTO.getMemberInfoDTO().getNickname());
 
-        log.info("소셜로그인 사용자: {}", socialLoginDTO.getMemberInfoDTO().getNickname());
-
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(ApiResponse.onSuccess(socialLoginDTO));
+        return ResponseEntity.ok(ApiResponse.onSuccess(tokenResponseDTO));
 
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
@@ -9,8 +9,10 @@ import com.cozymate.cozymate_server.global.response.code.status.SuccessStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/KakaoController.java
@@ -59,7 +59,7 @@ public class KakaoController implements SocialLoginController {
             description = "Header : accessToken or 임시 토큰, Body: requestToken or null")
     @GetMapping("/code")
     public ResponseEntity<ApiResponse<AuthResponseDTO.TokenResponseDTO>> callBack(
-            @RequestParam(required = false) String code, HttpServletRequest request) {
+            @RequestParam(required = false) String code) {
 
         HttpEntity<MultiValueMap<String, String>> tokenRequest = kakaoService.makeTokenRequest(code);
 
@@ -102,16 +102,8 @@ public class KakaoController implements SocialLoginController {
 
         AuthResponseDTO.TokenResponseDTO socialLoginDTO = authService.socialLogin(clientId);
 
-
-        log.info("소셜로그인 응답: {}",socialLoginDTO.getMessage());
         log.info("소셜로그인 사용자: {}",socialLoginDTO.getMemberInfoDTO().getNickname());
 
-        String userAgent = request.getHeader("User-Agent");
-        String origin = request.getHeader("Origin");
-        String ip = request.getRemoteAddr();
-        log.info("Client User-Agent: {}", userAgent);
-        log.info("Client Origin: {}", origin);
-        log.info("Client IP: {}", ip);
 
 
         return ResponseEntity.ok()

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/SocialLoginController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/SocialLoginController.java
@@ -5,6 +5,5 @@ import org.springframework.http.ResponseEntity;
 
 public interface SocialLoginController {
     ResponseEntity<?> signIn();
-
     ResponseEntity<?> callBack(String code, HttpServletRequest request);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/SocialLoginController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/controller/SocialLoginController.java
@@ -1,9 +1,8 @@
 package com.cozymate.cozymate_server.domain.auth.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 
 public interface SocialLoginController {
     ResponseEntity<?> signIn();
-    ResponseEntity<?> callBack(String code, HttpServletRequest request);
+    ResponseEntity<?> callBack(String code);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/dto/AuthResponseDTO.java
@@ -23,6 +23,7 @@ public class AuthResponseDTO {
     @NoArgsConstructor
     public static class TokenResponseDTO {
         String message;
+        String accessToken;
         String refreshToken;
         MemberResponseDTO.MemberInfoDTO memberInfoDTO;
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/dto/AuthResponseDTO.java
@@ -1,6 +1,7 @@
 package com.cozymate.cozymate_server.domain.auth.dto;
 
 import com.cozymate.cozymate_server.domain.member.dto.MemberResponseDTO;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/repository/TokenRepository.java
@@ -5,6 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TokenRepository extends JpaRepository<Token, String> {
 
-
-
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/AuthService.java
@@ -5,12 +5,8 @@ import com.cozymate.cozymate_server.domain.auth.dto.AuthResponseDTO;
 import com.cozymate.cozymate_server.domain.auth.repository.TokenRepository;
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.auth.userDetails.TemporaryMember;
-import com.cozymate.cozymate_server.domain.auth.utils.AuthConverter;
 import com.cozymate.cozymate_server.domain.auth.utils.JwtUtil;
 
-import com.cozymate.cozymate_server.domain.member.Member;
-import com.cozymate.cozymate_server.domain.member.converter.MemberConverter;
-import com.cozymate.cozymate_server.domain.member.dto.MemberResponseDTO;
 import com.cozymate.cozymate_server.domain.member.service.MemberQueryService;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
@@ -31,7 +27,7 @@ public class AuthService implements UserDetailsService {
 
     public static final String TEMPORARY_TOKEN_SUCCESS_MESSAGE = "임시 토큰 발급 완료";
 
-    public static final String MEMBER_TOKEN_MESSAGE = "기존 사용자 토큰 발급 성공";
+    public static final String RE_LOGIN_EXISTING_MEMBER_MESSAGE = "기존 사용자 재로그인";
 
     private final JwtUtil jwtUtil;
     private final MemberQueryService memberQueryService;
@@ -54,41 +50,25 @@ public class AuthService implements UserDetailsService {
         return jwtUtil.generateTemporaryToken(userDetails);
     }
 
-
-    public MemberDetails extractMemberInRefreshToken(String refreshToken) {
-        String clientId = jwtUtil.extractUserName(refreshToken);
-        return new MemberDetails(memberQueryService.findByClientId(clientId));
-    }
-
     public HttpHeaders addTokenAtHeader(String token) {
         log.info("발급된 토큰 :" + jwtUtil.extractTokenType(token) + ":" + token);
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", JwtUtil.TOKEN_PREFIX + token);
+        headers.add(JwtUtil.TOKEN_PREFIX, token);
         return headers;
     }
 
-    public AuthResponseDTO.TokenResponseDTO socialLogin(String clientId) {
+    public AuthResponseDTO.SocialLoginDTO socialLogin(String clientId) {
         // 이미 회원인 경우
         if (memberQueryService.isPresent(clientId)) {
-            MemberDetails memberDetails = loadMember(clientId);
-            return generateMemberResponse(memberDetails);
+            return AuthResponseDTO.SocialLoginDTO.builder()
+                    .message(RE_LOGIN_EXISTING_MEMBER_MESSAGE)
+                    .refreshToken(getRefreshToken(loadUserByUsername(clientId)))
+                    .build();
         }
         // 새로 가입한 경우
-        MemberResponseDTO.MemberInfoDTO temporaryMemberInfo = generateTemporaryMember();
-        return AuthConverter.toTokenResponseDTO(temporaryMemberInfo, TEMPORARY_TOKEN_SUCCESS_MESSAGE,
-                clientId);
-    }
-
-    private MemberResponseDTO.MemberInfoDTO generateTemporaryMember(){
-        return MemberConverter.toTemporaryInfoDTO("","","","",0);
-    }
-
-    public AuthResponseDTO.TokenResponseDTO generateMemberResponse(MemberDetails memberDetails) {
-        MemberResponseDTO.MemberInfoDTO memberInfoDTO = MemberConverter.toMemberInfoDTO(memberDetails.getMember());
-        // 이미 회원인 경우
-        return AuthConverter.toTokenResponseDTO(memberInfoDTO
-                , MEMBER_TOKEN_MESSAGE,
-                memberDetails.getUsername());
+        return AuthResponseDTO.SocialLoginDTO.builder()
+                .message(TEMPORARY_TOKEN_SUCCESS_MESSAGE)
+                .build();
     }
 
     public String getRefreshToken(UserDetails userDetails) {
@@ -104,16 +84,11 @@ public class AuthService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String clientId) {
         if (memberQueryService.isPresent(clientId)) {
-            return loadMember(clientId);
+            return new MemberDetails(memberQueryService.findByClientId(clientId));
         } else {
             return new TemporaryMember(clientId);
         }
     }
-
-    private MemberDetails loadMember(String clientId) {
-        return new MemberDetails(memberQueryService.findByClientId(clientId));
-    }
-
 
     @Transactional
     Token findToken(String clientId) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/AuthService.java
@@ -63,7 +63,7 @@ public class AuthService implements UserDetailsService {
                 clientId);
     }
     public AuthResponseDTO.TokenResponseDTO generateMemberResponse(MemberDetails memberDetails) {
-        MemberResponseDTO.MemberInfoDTO memberInfoDTO = MemberConverter.toMemberInfoDTO(memberDetails.getMember());
+        MemberResponseDTO.MemberInfoDTO memberInfoDTO = MemberConverter.toMemberInfoDTO(memberDetails.member());
         return AuthConverter.toTokenResponseDTO(
                 memberInfoDTO, MEMBER_TOKEN_MESSAGE, getRefreshToken(memberDetails));
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/AuthService.java
@@ -5,13 +5,17 @@ import com.cozymate.cozymate_server.domain.auth.dto.AuthResponseDTO;
 import com.cozymate.cozymate_server.domain.auth.repository.TokenRepository;
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.auth.userDetails.TemporaryMember;
+import com.cozymate.cozymate_server.domain.auth.utils.AuthConverter;
 import com.cozymate.cozymate_server.domain.auth.utils.JwtUtil;
-
+import com.cozymate.cozymate_server.domain.member.converter.MemberConverter;
+import com.cozymate.cozymate_server.domain.member.dto.MemberResponseDTO;
 import com.cozymate.cozymate_server.domain.member.service.MemberQueryService;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,7 +31,9 @@ public class AuthService implements UserDetailsService {
 
     public static final String TEMPORARY_TOKEN_SUCCESS_MESSAGE = "임시 토큰 발급 완료";
 
-    public static final String RE_LOGIN_EXISTING_MEMBER_MESSAGE = "기존 사용자 재로그인";
+    public static final String MEMBER_TOKEN_MESSAGE = "기존 사용자 토큰 발급 성공";
+
+    public static final String TOKEN_HEADER_NAME = "Authorization";
 
     private final JwtUtil jwtUtil;
     private final MemberQueryService memberQueryService;
@@ -50,25 +56,40 @@ public class AuthService implements UserDetailsService {
         return jwtUtil.generateTemporaryToken(userDetails);
     }
 
+    public MemberDetails extractMemberInRefreshToken(String refreshToken) {
+        String clientId = jwtUtil.extractUserName(refreshToken);
+        return new MemberDetails(memberQueryService.findByClientId(clientId));
+    }
+
     public HttpHeaders addTokenAtHeader(String token) {
         log.info("발급된 토큰 :" + jwtUtil.extractTokenType(token) + ":" + token);
         HttpHeaders headers = new HttpHeaders();
-        headers.add(JwtUtil.TOKEN_PREFIX, token);
+        headers.add(TOKEN_HEADER_NAME, JwtUtil.TOKEN_PREFIX + token);
         return headers;
     }
 
-    public AuthResponseDTO.SocialLoginDTO socialLogin(String clientId) {
+    public AuthResponseDTO.TokenResponseDTO socialLogin(String clientId) {
         // 이미 회원인 경우
         if (memberQueryService.isPresent(clientId)) {
-            return AuthResponseDTO.SocialLoginDTO.builder()
-                    .message(RE_LOGIN_EXISTING_MEMBER_MESSAGE)
-                    .refreshToken(getRefreshToken(loadUserByUsername(clientId)))
-                    .build();
+            MemberDetails memberDetails = loadMember(clientId);
+            return generateMemberResponse(memberDetails);
         }
         // 새로 가입한 경우
-        return AuthResponseDTO.SocialLoginDTO.builder()
-                .message(TEMPORARY_TOKEN_SUCCESS_MESSAGE)
-                .build();
+        MemberResponseDTO.MemberInfoDTO temporaryMemberInfo = generateTemporaryMember();
+        return AuthConverter.toTokenResponseDTO(temporaryMemberInfo, TEMPORARY_TOKEN_SUCCESS_MESSAGE,
+                clientId);
+    }
+
+    private MemberResponseDTO.MemberInfoDTO generateTemporaryMember() {
+        return MemberConverter.toTemporaryInfoDTO("", "", "", "", 0);
+    }
+
+    public AuthResponseDTO.TokenResponseDTO generateMemberResponse(MemberDetails memberDetails) {
+        MemberResponseDTO.MemberInfoDTO memberInfoDTO = MemberConverter.toMemberInfoDTO(memberDetails.getMember());
+        // 이미 회원인 경우
+        return AuthConverter.toTokenResponseDTO(memberInfoDTO
+                , MEMBER_TOKEN_MESSAGE,
+                memberDetails.getUsername());
     }
 
     public String getRefreshToken(UserDetails userDetails) {
@@ -84,11 +105,16 @@ public class AuthService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String clientId) {
         if (memberQueryService.isPresent(clientId)) {
-            return new MemberDetails(memberQueryService.findByClientId(clientId));
+            return loadMember(clientId);
         } else {
             return new TemporaryMember(clientId);
         }
     }
+
+    private MemberDetails loadMember(String clientId) {
+        return new MemberDetails(memberQueryService.findByClientId(clientId));
+    }
+
 
     @Transactional
     Token findToken(String clientId) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/KakaoService.java
@@ -6,13 +6,14 @@ import com.cozymate.cozymate_server.domain.auth.utils.ClientIdMaker;
 import com.cozymate.cozymate_server.domain.member.enums.SocialType;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -41,7 +42,6 @@ public class KakaoService implements SocialLoginService {
 
     private static final String JSON_ATTRIBUTE_NAME_TOKEN = "access_token";
     private static final String JSON_ATTRIBUTE_NAME_ID = "id";
-
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String KAKAO_CLIENT_ID;

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/KakaoService.java
@@ -74,7 +74,6 @@ public class KakaoService implements SocialLoginService {
                 .build()
                 .toString();
 
-        log.info(url);
         return AuthResponseDTO.UrlDTO.builder().redirectUrl(url).build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/KakaoService.java
@@ -57,6 +57,9 @@ public class KakaoService implements SocialLoginService {
     @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
     private String KAKAO_REDIRECT_URI;
 
+    // 테스트 용
+//    private static final String KAKAO_REDIRECT_URI = "http://localhost:8080/oauth2/kakao/code";
+
     @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
     private String TOKEN_URI;
     @Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/LogoutService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/LogoutService.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class LogoutService implements LogoutHandler {
-
     private static final Integer TOKEN_BEGIN_INDEX = 7;
     private final JwtUtil jwtUtil;
     private final AuthService authService;

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/LogoutService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/LogoutService.java
@@ -21,7 +21,6 @@ public class LogoutService implements LogoutHandler {
 
     private final JwtUtil jwtUtil;
     private final AuthService authService;
-
     @Override
     public void logout(
             HttpServletRequest request,

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/LogoutService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/LogoutService.java
@@ -4,7 +4,6 @@ import com.cozymate.cozymate_server.domain.auth.utils.JwtUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +18,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class LogoutService implements LogoutHandler {
 
+    private static final Integer TOKEN_BEGIN_INDEX = 7;
     private final JwtUtil jwtUtil;
     private final AuthService authService;
     @Override
@@ -32,9 +32,9 @@ public class LogoutService implements LogoutHandler {
         if (authHeader == null ||!authHeader.startsWith(JwtUtil.TOKEN_PREFIX)) {
             return;
         }
-        jwt = authHeader.substring(7);
+        jwt = authHeader.substring(TOKEN_BEGIN_INDEX);
         String username = jwtUtil.extractUserName(jwt);
-        log.info("username: {}", username);
+        log.info("logout: {}", username);
         authService.deleteRefreshToken(username);
         SecurityContextHolder.clearContext();
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/SocialLoginService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/SocialLoginService.java
@@ -8,9 +8,7 @@ import org.springframework.util.MultiValueMap;
 
 @Service
 public interface SocialLoginService {
-
     String CONTENT_TYPE_HEADER_NAME = "Content-type";
-
     String CONTENT_TYPE_HEADER_VALUE = "application/x-www-form-urlencoded;charset=utf-8";
     UrlDTO getRedirectUrl();
     String parseAccessToken(ResponseEntity<String> response);

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/service/SocialLoginService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/service/SocialLoginService.java
@@ -1,21 +1,17 @@
 package com.cozymate.cozymate_server.domain.auth.service;
 
 import com.cozymate.cozymate_server.domain.auth.dto.AuthResponseDTO.UrlDTO;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.ResponseEntity;
+
 import org.springframework.stereotype.Service;
-import org.springframework.util.MultiValueMap;
 
 @Service
 public interface SocialLoginService {
     String CONTENT_TYPE_HEADER_NAME = "Content-type";
     String CONTENT_TYPE_HEADER_VALUE = "application/x-www-form-urlencoded;charset=utf-8";
+
     UrlDTO getRedirectUrl();
-    String parseAccessToken(ResponseEntity<String> response);
+    String getTokenByCode(String code);
 
-    HttpEntity<MultiValueMap<String, String>> makeTokenRequest(String code);
-    HttpEntity<MultiValueMap<String, String>> makeMemberInfoRequest(String accessToken);
-
-    String getClientId(ResponseEntity<String> response);
+    String getClientIdByToken(String token);
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/MemberDetails.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/MemberDetails.java
@@ -3,15 +3,16 @@ package com.cozymate.cozymate_server.domain.auth.userDetails;
 import com.cozymate.cozymate_server.domain.member.Member;
 
 import java.util.Collection;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-@Getter
 @RequiredArgsConstructor
-public record MemberDetails(Member member) implements UserDetails {
+@Getter
+public class MemberDetails implements UserDetails {
+    private final Member member;
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return member.getRole().getAuthorities();

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/MemberDetails.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/MemberDetails.java
@@ -11,9 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
 @RequiredArgsConstructor
-public class MemberDetails implements UserDetails {
-    private final Member member;
-
+public record MemberDetails(Member member) implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return member.getRole().getAuthorities();

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/MemberDetails.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/MemberDetails.java
@@ -1,9 +1,11 @@
 package com.cozymate.cozymate_server.domain.auth.userDetails;
 
 import com.cozymate.cozymate_server.domain.member.Member;
+
 import java.util.Collection;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/TemporaryMember.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/TemporaryMember.java
@@ -2,10 +2,12 @@ package com.cozymate.cozymate_server.domain.auth.userDetails;
 
 import java.util.ArrayList;
 import java.util.Collection;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/TemporaryMember.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/TemporaryMember.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +12,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
 @RequiredArgsConstructor
-@NoArgsConstructor
 public class TemporaryMember implements UserDetails {
     @NonNull
     String clientId;

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/TemporaryMember.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/userDetails/TemporaryMember.java
@@ -15,7 +15,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 @RequiredArgsConstructor
 @NoArgsConstructor
 public class TemporaryMember implements UserDetails {
-
     @NonNull
     String clientId;
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/AuthConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/AuthConverter.java
@@ -6,10 +6,22 @@ import com.cozymate.cozymate_server.domain.member.dto.MemberResponseDTO;
 public class AuthConverter {
     public static AuthResponseDTO.TokenResponseDTO toTokenResponseDTO(MemberResponseDTO.MemberInfoDTO memberInfoDTO,
                                                                       String message,
+                                                                      String accessToken,
                                                                       String refreshToken) {
         return AuthResponseDTO.TokenResponseDTO.builder()
                 .message(message)
+                .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .memberInfoDTO(memberInfoDTO)
+                .build();
+    }
+
+    public static AuthResponseDTO.TokenResponseDTO toTemporaryTokenResponseDTO(MemberResponseDTO.MemberInfoDTO memberInfoDTO,
+                                                                      String message,
+                                                                      String acessToken) {
+        return AuthResponseDTO.TokenResponseDTO.builder()
+                .message(message)
+                .accessToken(acessToken)
                 .memberInfoDTO(memberInfoDTO)
                 .build();
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/ClientIdMaker.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/ClientIdMaker.java
@@ -10,8 +10,7 @@ public class ClientIdMaker {
     public static final String DELIMITER = ":";
 
     public static String makeClientId(String memberId, SocialType socialType) {
-        String userName = memberId + DELIMITER + socialType.toString();
-        return userName;
+        return memberId + DELIMITER + socialType.toString();
     }
 
     public static SocialType getSocialTypeInClientId(String clientId) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/ClientIdMaker.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/ClientIdMaker.java
@@ -1,10 +1,10 @@
 package com.cozymate.cozymate_server.domain.auth.utils;
 
 import com.cozymate.cozymate_server.domain.member.enums.SocialType;
+
 import java.util.Arrays;
 
 public class ClientIdMaker {
-
     public static final int MEMBER_ID_INDEX = 0;
     public static final int SOCIAL_TYPE_INDEX = 1;
     public static final String DELIMITER = ":";

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
@@ -26,7 +26,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 @Slf4j
 public class JwtFilter extends OncePerRequestFilter {
-
     // JWT 검증을 제외할 URL 목록
     private static final List<String> EXCLUDE_URLS = Arrays.asList(
             "/oauth2/kakao/sign-in",

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
@@ -2,11 +2,11 @@ package com.cozymate.cozymate_server.domain.auth.utils;
 
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
@@ -1,13 +1,12 @@
 package com.cozymate.cozymate_server.domain.auth.utils;
 
+import com.cozymate.cozymate_server.domain.auth.enums.TokenType;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
-import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Arrays;
 import java.util.List;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -27,21 +26,23 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class JwtFilter extends OncePerRequestFilter {
     // JWT 검증을 제외할 URL 목록
-    private static final List<String> EXCLUDE_URLS = Arrays.asList(
+    private static final List<String> EXCLUDE_URLS = List.of(
             "/oauth2/kakao/sign-in",
             "/oauth2/naver/sign-in",
-            "/oauth2/apple/sign-in",
-            "/api/v3/member/reissue"
+            "/oauth2/apple/sign-in"
     );
 
     // 임시 토큰으로만 접근 가능한 URL 목록
-    private static final List<String> TEMPORARY_URLS = Arrays.asList(
+    private static final List<String> TEMPORARY_URLS = List.of(
             "/api/v3/member/sign-up",
             "/api/v3/member/check-nickname"
     );
 
+    private static final List<String> REFRESH_URLS = List.of("/api/v3/member/reissue");
     private static final Integer TOKEN_BEGIN_INDEX = 7;
     private static final String REQUEST_ATTRIBUTE_NAME_CLIENT_ID = "client_id";
+
+    private static final String REQUEST_ATTRIBUTE_NAME_REFRESH = "refresh";
 
     private final JwtUtil jwtUtil; // JWT 토큰 발급 검증 클래스
     private final UserDetailsService userDetailsService; // 사용자 상세 정보를 로드하는 서비스
@@ -75,15 +76,27 @@ public class JwtFilter extends OncePerRequestFilter {
             String userName = jwtUtil.extractUserName(jwt);
             UserDetails userDetails = userDetailsService.loadUserByUsername(userName);
 
+            log.info("토큰 타입 : {}", jwtUtil.extractTokenType(jwt));
+
             // 임시 토큰일 경우, 접근을 제한할 URL 목록에 대한 접근 여부 확인
-            if (jwtUtil.isTemporaryToken(jwt)) {
+            if (jwtUtil.equalsTokenTypeWith(jwt, TokenType.TEMPORARY)) {
                 if (isNotAllowTemporary(request)) {
-                    throw new GeneralException(ErrorStatus._TEMPORARY_TOKEN_ACCESS_DENIED_); // 접근 거부 예외 발생
+                    // 임시토큰 접근 거부 예외
+                    throw new RuntimeException(ErrorStatus._TEMPORARY_TOKEN_ACCESS_DENIED_.getMessage());
                 }
+                request.setAttribute(REQUEST_ATTRIBUTE_NAME_CLIENT_ID, userDetails.getUsername());
+            }
+
+            // 리프레시 토큰일 경우, 접근을 제한할 URL 목록에 대한 접근 여부 확인
+            if (jwtUtil.equalsTokenTypeWith(jwt, TokenType.REFRESH)) {
+                if (isNotAllowRefresh(request)) {
+                    // refresh 토큰 접근 거부 예외
+                    throw new RuntimeException(ErrorStatus._REFRESH_TOKEN_ACCESS_DENIED_.getMessage());
+                }
+                request.setAttribute(REQUEST_ATTRIBUTE_NAME_REFRESH, jwt);
             }
 
             // 사용자 정보와 권한을 설정하고 SecurityContext에 인증 정보를 저장
-            request.setAttribute(REQUEST_ATTRIBUTE_NAME_CLIENT_ID, userDetails.getUsername());
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                     userDetails,
                     null,
@@ -100,8 +113,12 @@ public class JwtFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             log.error("필터에서 예외 발생 = {}", e.toString());
             log.error(request.getRequestURI());
-            request.setAttribute("exception", e);
-            throw new GeneralException(ErrorStatus._TOKEN_INVALID); // JWT가 유효하지 않을 경우 예외 발생
+            SecurityContextHolder.clearContext();
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().print("잘못된 토큰");
+
+            log.error(Integer.toString(response.getStatus()));
         }
     }
 
@@ -115,4 +132,7 @@ public class JwtFilter extends OncePerRequestFilter {
         return TEMPORARY_URLS.stream().noneMatch(url -> request.getRequestURI().equals(url));
     }
 
+    private boolean isNotAllowRefresh(HttpServletRequest request) {
+        return REFRESH_URLS.stream().noneMatch(url -> request.getRequestURI().equals(url));
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,7 +21,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
@@ -41,6 +41,7 @@ public class JwtFilter extends OncePerRequestFilter {
             "/api/v3/member/check-nickname"
     );
 
+    private static final Integer TOKEN_BEGIN_INDEX = 7;
     private static final String REQUEST_ATTRIBUTE_NAME_CLIENT_ID = "client_id";
 
     private final JwtUtil jwtUtil; // JWT 토큰 발급 검증 클래스
@@ -67,7 +68,7 @@ public class JwtFilter extends OncePerRequestFilter {
             }
 
             // Authorization 헤더에서 JWT를 추출
-            String jwt = authHeader.substring(7);
+            String jwt = authHeader.substring(TOKEN_BEGIN_INDEX);
             // JWT를 검증
             jwtUtil.validateToken(jwt);
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtUtil.java
@@ -12,9 +12,9 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.function.Function;
 import javax.crypto.SecretKey;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
@@ -107,7 +107,6 @@ public class JwtUtil {
                 .signWith(getSignInKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
-
 
     //토큰이 유효한지 확인
     public boolean isTokenValid(String token, String userName) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtUtil.java
@@ -48,6 +48,9 @@ public class JwtUtil {
         return extractClaim(token, Claims::getSubject);
     }
 
+    public Boolean equalsTokenTypeWith(String token, TokenType tokenType){
+        return extractTokenType(token).equals(tokenType.toString());
+    }
     public String extractTokenType(String token) {
         return extractClaim(token, claims -> claims.get(TOKEN_TYPE_CLAIM_NAME, String.class));
     }
@@ -81,17 +84,6 @@ public class JwtUtil {
                 .parseClaimsJws(token);
     }
 
-    public Boolean isTemporaryToken(String token) {
-        String tokenTypeName =
-                Jwts.parserBuilder()
-                        .setSigningKey(getSignInKey()) // jwtSecret은 토큰 서명에 사용되는 비밀 키
-                        .build()
-                        .parseClaimsJws(token)
-                        .getBody()
-                        .get(TOKEN_TYPE_CLAIM_NAME, String.class);
-
-        return (TokenType.valueOf(tokenTypeName).equals(TokenType.TEMPORARY));
-    }
 
 
     // 주어진 클레임, 사용자 정보, 그리고 만료 시간을 바탕으로 JWT 토큰을 생성

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtUtil.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class JwtUtil {
-
     public final static String TOKEN_PREFIX = "Bearer ";
 
     public final static String TOKEN_TYPE_CLAIM_NAME = "tokenType";

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
@@ -1,15 +1,12 @@
 package com.cozymate.cozymate_server.domain.member.controller;
 
-import com.cozymate.cozymate_server.domain.auth.dto.AuthResponseDTO;
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.member.dto.MemberRequestDTO;
 import com.cozymate.cozymate_server.domain.member.dto.MemberResponseDTO;
 import com.cozymate.cozymate_server.domain.member.service.MemberCommandService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
-import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.code.status.SuccessStatus;
 
-import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,13 +15,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @Slf4j
-@RequestMapping("/api/v3/member")
+@RequestMapping("/api/v3")
 public class MemberController {
     private final MemberCommandService memberCommandService;
 
@@ -45,7 +40,7 @@ public class MemberController {
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus()).body(ApiResponse.onSuccess(isValid));
     }
 
-    @PostMapping("/sign-up")
+    @PostMapping("/join")
     @Operation(summary = "[말즈] 회원가입",
             description = "request Header : Bearer 임시토큰"
                     + "request Body : \"name\": \"John Doe\",\n"
@@ -53,18 +48,15 @@ public class MemberController {
                     + "         *     \"gender\": \"MALE\",\n"
                     + "         *     \"birthday\": \"1990-01-01\"\n"
                     + "         *     \"persona\" : 1")
-    ResponseEntity<ApiResponse<AuthResponseDTO.TokenResponseDTO>> signUp(
+    ResponseEntity<ApiResponse<MemberResponseDTO.TokenResponseDTO>> join(
             @RequestAttribute("client_id") String clientId,
-            @RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO,
-            BindingResult bindingResult
+            @RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO
     ) {
-        log.info("enter MemberController : [post] /member/sign-up");
-        if (bindingResult.hasErrors()) {
-            throw new GeneralException(ErrorStatus._MEMBER_BINDING_FAIL);
-        }
+        // todo : 파라미터 바인딩 검증 로직 추가
+
         MemberDetails memberDetails = memberCommandService.join(clientId, joinRequestDTO);
         HttpHeaders headers = memberCommandService.makeHeader(memberDetails);
-        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeTokenBody(memberDetails);
+        MemberResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeBody(memberDetails);
 
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                 .headers(headers)
@@ -73,13 +65,12 @@ public class MemberController {
 
     @GetMapping("/reissue")
     @Operation(summary = "[말즈] 토큰 재발행",
-            description = "request Header : Bearer refreshToken")
-    ResponseEntity<ApiResponse<AuthResponseDTO.TokenResponseDTO>> reissue(
-            @RequestHeader(value = "Refresh") String refreshToken
+            description = "request Header : Bearer access토큰")
+    ResponseEntity<ApiResponse<MemberResponseDTO.TokenResponseDTO>> reissue(
+            @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        MemberDetails memberDetails = memberCommandService.extractMemberByRefreshToken(refreshToken);
         HttpHeaders headers = memberCommandService.makeHeader(memberDetails);
-        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeTokenBody(memberDetails);
+        MemberResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeBody(memberDetails);
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                 .headers(headers)
                 .body(ApiResponse.onSuccess(tokenResponseDTO));
@@ -97,13 +88,13 @@ public class MemberController {
 
     @Operation(summary = "[말즈] 로그아웃",
             description = "사용자를 로그아웃 시킵니다. 스웨거에서는 동작하지 않습니다!")
-    @GetMapping("/sign-out")
-    public void signOut() {
+    @GetMapping("/logout")
+    public void logout() {
     }
 
-    @Operation(summary = "[말즈] 회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴시킵니다.")
-    @DeleteMapping("/withdraw")
-    public ResponseEntity<ApiResponse<String>> withdraw(@AuthenticationPrincipal MemberDetails memberDetails) {
+    @Operation(summary = "회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴시킵니다.")
+    @DeleteMapping("/delete")
+    public ResponseEntity<ApiResponse<String>> deleteMember(@AuthenticationPrincipal MemberDetails memberDetails) {
         // todo : 회원 탈퇴 api 구현
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                 .body(ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다."));

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
@@ -63,6 +63,7 @@ public class MemberController {
             throw new GeneralException(ErrorStatus._MEMBER_BINDING_FAIL);
         }
         MemberDetails memberDetails = memberCommandService.join(clientId, joinRequestDTO);
+
         HttpHeaders headers = memberCommandService.makeHeader(memberDetails);
         AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeTokenBody(memberDetails);
 
@@ -77,9 +78,11 @@ public class MemberController {
     ResponseEntity<ApiResponse<AuthResponseDTO.TokenResponseDTO>> reissue(
             @RequestHeader(value = "Refresh") String refreshToken
     ) {
-        MemberDetails memberDetails = memberCommandService.extractMemberByRefreshToken(refreshToken);
+        MemberDetails memberDetails = memberCommandService.extractMemberDetailsByRefreshToken(refreshToken);
+
         HttpHeaders headers = memberCommandService.makeHeader(memberDetails);
         AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeTokenBody(memberDetails);
+
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                 .headers(headers)
                 .body(ApiResponse.onSuccess(tokenResponseDTO));

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -73,7 +72,7 @@ public class MemberController {
     @Operation(summary = "[말즈] 토큰 재발행",
             description = "request Header : Bearer refreshToken")
     ResponseEntity<ApiResponse<AuthResponseDTO.TokenResponseDTO>> reissue(
-            @RequestHeader(value = "Refresh") String refreshToken
+            @RequestAttribute("refresh") String refreshToken
     ) {
         MemberDetails memberDetails = memberCommandService.extractMemberDetailsByRefreshToken(refreshToken);
 
@@ -101,7 +100,8 @@ public class MemberController {
 
     @Operation(summary = "[말즈] 회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴시킵니다.")
     @DeleteMapping("/withdraw")
-    public ResponseEntity<ApiResponse<String>> withdraw(@AuthenticationPrincipal MemberDetails memberDetails) {
+    public ResponseEntity<ApiResponse<String>> withdraw(
+            @AuthenticationPrincipal MemberDetails memberDetails) {
         memberCommandService.withdraw(memberDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다."));

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package com.cozymate.cozymate_server.domain.member.controller;
 
+import com.cozymate.cozymate_server.domain.auth.dto.AuthResponseDTO;
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.member.dto.MemberRequestDTO;
 import com.cozymate.cozymate_server.domain.member.dto.MemberResponseDTO;
 import com.cozymate.cozymate_server.domain.member.service.MemberCommandService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.code.status.SuccessStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -15,11 +18,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @Slf4j
-@RequestMapping("/api/v3")
+@RequestMapping("/api/v3/member")
 public class MemberController {
     private final MemberCommandService memberCommandService;
 
@@ -40,7 +45,7 @@ public class MemberController {
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus()).body(ApiResponse.onSuccess(isValid));
     }
 
-    @PostMapping("/join")
+    @PostMapping("/sign-up")
     @Operation(summary = "[말즈] 회원가입",
             description = "request Header : Bearer 임시토큰"
                     + "request Body : \"name\": \"John Doe\",\n"
@@ -48,15 +53,18 @@ public class MemberController {
                     + "         *     \"gender\": \"MALE\",\n"
                     + "         *     \"birthday\": \"1990-01-01\"\n"
                     + "         *     \"persona\" : 1")
-    ResponseEntity<ApiResponse<MemberResponseDTO.TokenResponseDTO>> join(
+    ResponseEntity<ApiResponse<AuthResponseDTO.TokenResponseDTO>> signUp(
             @RequestAttribute("client_id") String clientId,
-            @RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO
+            @RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO,
+            BindingResult bindingResult
     ) {
-        // todo : 파라미터 바인딩 검증 로직 추가
-
+        log.info("enter MemberController : [post] /member/sign-up");
+        if (bindingResult.hasErrors()) {
+            throw new GeneralException(ErrorStatus._MEMBER_BINDING_FAIL);
+        }
         MemberDetails memberDetails = memberCommandService.join(clientId, joinRequestDTO);
         HttpHeaders headers = memberCommandService.makeHeader(memberDetails);
-        MemberResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeBody(memberDetails);
+        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeTokenBody(memberDetails);
 
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                 .headers(headers)
@@ -65,12 +73,13 @@ public class MemberController {
 
     @GetMapping("/reissue")
     @Operation(summary = "[말즈] 토큰 재발행",
-            description = "request Header : Bearer access토큰")
-    ResponseEntity<ApiResponse<MemberResponseDTO.TokenResponseDTO>> reissue(
-            @AuthenticationPrincipal MemberDetails memberDetails
+            description = "request Header : Bearer refreshToken")
+    ResponseEntity<ApiResponse<AuthResponseDTO.TokenResponseDTO>> reissue(
+            @RequestHeader(value = "Refresh") String refreshToken
     ) {
+        MemberDetails memberDetails = memberCommandService.extractMemberByRefreshToken(refreshToken);
         HttpHeaders headers = memberCommandService.makeHeader(memberDetails);
-        MemberResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeBody(memberDetails);
+        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeTokenBody(memberDetails);
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                 .headers(headers)
                 .body(ApiResponse.onSuccess(tokenResponseDTO));
@@ -88,14 +97,14 @@ public class MemberController {
 
     @Operation(summary = "[말즈] 로그아웃",
             description = "사용자를 로그아웃 시킵니다. 스웨거에서는 동작하지 않습니다!")
-    @GetMapping("/logout")
-    public void logout() {
+    @GetMapping("/sign-out")
+    public void signOut() {
     }
 
-    @Operation(summary = "회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴시킵니다.")
-    @DeleteMapping("/delete")
-    public ResponseEntity<ApiResponse<String>> deleteMember(@AuthenticationPrincipal MemberDetails memberDetails) {
-        // todo : 회원 탈퇴 api 구현
+    @Operation(summary = "[말즈] 회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴시킵니다.")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ApiResponse<String>> withdraw(@AuthenticationPrincipal MemberDetails memberDetails) {
+        memberCommandService.withdraw(memberDetails);
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                 .body(ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다."));
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
@@ -15,7 +15,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
@@ -42,6 +41,7 @@ public class MemberController {
             description = "false : 사용 불가, true : 사용 가능")
     ResponseEntity<ApiResponse<Boolean>> checkNickname(@RequestParam String nickname) {
         Boolean isValid = memberCommandService.checkNickname(nickname);
+
         return ResponseEntity.status(SuccessStatus._OK.getHttpStatus()).body(ApiResponse.onSuccess(isValid));
     }
 
@@ -64,12 +64,9 @@ public class MemberController {
         }
         MemberDetails memberDetails = memberCommandService.join(clientId, joinRequestDTO);
 
-        HttpHeaders headers = memberCommandService.makeHeader(memberDetails);
-        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeTokenBody(memberDetails);
+        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.generateTokenDTO(memberDetails);
 
-        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
-                .headers(headers)
-                .body(ApiResponse.onSuccess(tokenResponseDTO));
+        return ResponseEntity.ok(ApiResponse.onSuccess(tokenResponseDTO));
     }
 
     @GetMapping("/reissue")
@@ -80,12 +77,9 @@ public class MemberController {
     ) {
         MemberDetails memberDetails = memberCommandService.extractMemberDetailsByRefreshToken(refreshToken);
 
-        HttpHeaders headers = memberCommandService.makeHeader(memberDetails);
-        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.makeTokenBody(memberDetails);
+        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = memberCommandService.generateTokenDTO(memberDetails);
 
-        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
-                .headers(headers)
-                .body(ApiResponse.onSuccess(tokenResponseDTO));
+        return ResponseEntity.ok(ApiResponse.onSuccess(tokenResponseDTO));
     }
 
     @GetMapping("/member-info")
@@ -95,7 +89,8 @@ public class MemberController {
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         MemberResponseDTO.MemberInfoDTO memberInfoDTO = memberCommandService.getMemberInfo(memberDetails);
-        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus()).body(ApiResponse.onSuccess(memberInfoDTO));
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(memberInfoDTO));
     }
 
     @Operation(summary = "[말즈] 로그아웃",
@@ -108,8 +103,8 @@ public class MemberController {
     @DeleteMapping("/withdraw")
     public ResponseEntity<ApiResponse<String>> withdraw(@AuthenticationPrincipal MemberDetails memberDetails) {
         memberCommandService.withdraw(memberDetails);
-        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
-                .body(ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다."));
+
+        return ResponseEntity.ok(ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다."));
     }
 
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/dto/MemberResponseDTO.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 public class MemberResponseDTO {
     @Getter
     @Builder

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/enums/Gender.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/enums/Gender.java
@@ -1,10 +1,10 @@
 package com.cozymate.cozymate_server.domain.member.enums;
 
 public enum Gender {
+
     MALE,
     FEMALE
     ;
-
     @Override
     public String toString(){
         return name();

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
@@ -45,10 +45,10 @@ public class MemberCommandService {
     }
 
     public MemberResponseDTO.MemberInfoDTO getMemberInfo(MemberDetails memberDetails) {
-        return MemberConverter.toMemberInfoDTO(memberDetails.getMember());
+        return MemberConverter.toMemberInfoDTO(memberDetails.member());
     }
 
     public void withdraw(MemberDetails memberDetails){
-        memberRepository.delete(memberDetails.getMember());
+        memberRepository.delete(memberDetails.member());
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
@@ -1,5 +1,6 @@
 package com.cozymate.cozymate_server.domain.member.service;
 
+import com.cozymate.cozymate_server.domain.auth.dto.AuthResponseDTO;
 import com.cozymate.cozymate_server.domain.auth.service.AuthService;
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.member.Member;
@@ -36,13 +37,20 @@ public class MemberCommandService {
         String token = authService.generateToken(memberDetails.getMember().getClientId());
         return authService.addTokenAtHeader(token);
     }
+    public MemberDetails extractMemberByRefreshToken(String refreshToken){
+        return authService.extractMemberInRefreshToken(refreshToken);
 
-    public MemberResponseDTO.TokenResponseDTO makeBody(MemberDetails memberDetails) {
-        return MemberConverter.toTokenResponseDTO(memberDetails.getMember().getNickname(),
-                authService.getRefreshToken(memberDetails));
+    }
+
+    public AuthResponseDTO.TokenResponseDTO makeTokenBody(MemberDetails memberDetails) {
+        return authService.generateMemberResponse(memberDetails);
     }
 
     public MemberResponseDTO.MemberInfoDTO getMemberInfo(MemberDetails memberDetails) {
         return MemberConverter.toMemberInfoDTO(memberDetails.getMember());
+    }
+
+    public void withdraw(MemberDetails memberDetails){
+        memberRepository.delete(memberDetails.getMember());
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
@@ -11,7 +11,6 @@ import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -33,22 +32,19 @@ public class MemberCommandService {
         return new MemberDetails(member);
     }
 
-    public HttpHeaders makeHeader(MemberDetails memberDetails) {
-        return authService.generateTokenHeader(memberDetails.getUsername());
-    }
     public MemberDetails extractMemberDetailsByRefreshToken(String refreshToken){
         return authService.extractMemberDetailsInRefreshToken(refreshToken);
     }
 
-    public AuthResponseDTO.TokenResponseDTO makeTokenBody(MemberDetails memberDetails) {
-        return authService.generateMemberResponse(memberDetails);
+    public AuthResponseDTO.TokenResponseDTO generateTokenDTO(MemberDetails memberDetails) {
+        return authService.generateTokenDTO(memberDetails.getUsername());
     }
 
     public MemberResponseDTO.MemberInfoDTO getMemberInfo(MemberDetails memberDetails) {
-        return MemberConverter.toMemberInfoDTO(memberDetails.member());
+        return MemberConverter.toMemberInfoDTO(memberDetails.getMember());
     }
 
     public void withdraw(MemberDetails memberDetails){
-        memberRepository.delete(memberDetails.member());
+        memberRepository.delete(memberDetails.getMember());
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
@@ -7,8 +7,8 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.converter.MemberConverter;
 import com.cozymate.cozymate_server.domain.member.dto.MemberRequestDTO;
 import com.cozymate.cozymate_server.domain.member.dto.MemberResponseDTO;
-
 import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -34,12 +34,10 @@ public class MemberCommandService {
     }
 
     public HttpHeaders makeHeader(MemberDetails memberDetails) {
-        String token = authService.generateToken(memberDetails.getMember().getClientId());
-        return authService.addTokenAtHeader(token);
+        return authService.generateTokenHeader(memberDetails.getUsername());
     }
-    public MemberDetails extractMemberByRefreshToken(String refreshToken){
-        return authService.extractMemberInRefreshToken(refreshToken);
-
+    public MemberDetails extractMemberDetailsByRefreshToken(String refreshToken){
+        return authService.extractMemberDetailsInRefreshToken(refreshToken);
     }
 
     public AuthResponseDTO.TokenResponseDTO makeTokenBody(MemberDetails memberDetails) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
@@ -1,9 +1,7 @@
 package com.cozymate.cozymate_server.domain.member.service;
 
-import com.cozymate.cozymate_server.domain.auth.dto.AuthResponseDTO;
 import com.cozymate.cozymate_server.domain.auth.service.AuthService;
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
-import com.cozymate.cozymate_server.domain.auth.utils.AuthConverter;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.converter.MemberConverter;
 import com.cozymate.cozymate_server.domain.member.dto.MemberRequestDTO;
@@ -38,14 +36,10 @@ public class MemberCommandService {
         String token = authService.generateToken(memberDetails.getMember().getClientId());
         return authService.addTokenAtHeader(token);
     }
-    public MemberDetails extractMemberByRefreshToken(String refreshToken){
-        return authService.extractMemberInRefreshToken(refreshToken);
 
-    }
-
-
-    public AuthResponseDTO.TokenResponseDTO makeTokenBody(MemberDetails memberDetails) {
-        return authService.generateMemberResponse(memberDetails);
+    public MemberResponseDTO.TokenResponseDTO makeBody(MemberDetails memberDetails) {
+        return MemberConverter.toTokenResponseDTO(memberDetails.getMember().getNickname(),
+                authService.getRefreshToken(memberDetails));
     }
 
     public MemberResponseDTO.MemberInfoDTO getMemberInfo(MemberDetails memberDetails) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberQueryService.java
@@ -15,13 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberQueryService {
     private final MemberRepository memberRepository;
-
     @Transactional
     public Boolean isValidNickName(String nickname) {
         // todo : 금지 닉네임 로직 추가
         return !memberRepository.existsByNickname(nickname);
     }
-
 
     @Transactional
     public Member findByClientId(String clientId) {

--- a/src/main/java/com/cozymate/cozymate_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/config/SecurityConfig.java
@@ -58,26 +58,7 @@ public class SecurityConfig {
                                 CorsConfiguration configuration = new CorsConfiguration();
                                 configuration.setAllowedOrigins(
                                         Arrays.asList("https://cozymate.store:3000",
-                                                "https://cozymate.store",
-                                                "http://localhost:3000",
-                                                "http://localhost:8080",
-                                                "http://localhost:4441",
-                                                "http://localhost:5037",
-                                                "http://localhost:6463",
-                                                "http://localhost:8380",
-                                                "http://localhost:10530",
-                                                "http://localhost:10531",
-                                                "http://localhost:14098",
-                                                "http://localhost:15397",
-                                                "http://localhost:15398",
-                                                "http://localhost:16105",
-                                                "http://localhost:16106",
-                                                "http://localhost:17173",
-                                                "http://localhost:19891",
-                                                "http://localhost:27060",
-                                                "http://localhost:29891",
-                                                "http://localhost:31026"
-                                        ));
+                                                "https://cozymate.store"));
                                 configuration.setAllowedMethods(Collections.singletonList("*"));
                                 configuration.setAllowCredentials(true);
                                 configuration.setAllowedHeaders(Collections.singletonList("*"));

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -28,7 +28,6 @@ public enum ErrorStatus implements BaseErrorCode {
             HttpStatus.INTERNAL_SERVER_ERROR, "AUTH501", "카카오 accessToken 파싱 실패"),
 
 
-
     // [Member] 관련 에러
     _MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER400", "멤버를 찾을 수 없습니다."),
     _MEMBER_BINDING_FAIL(HttpStatus.BAD_REQUEST, "MEMBER401", "회원가입 요청 바인딩 실패"),
@@ -37,6 +36,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "TOKEN400", "사용자의 리프레시 토큰을 찾을 수 없습니다."),
     _TOKEN_INVALID(HttpStatus.BAD_REQUEST, "TOKEN401", "토큰이 유효하지 않습니다."),
     _TEMPORARY_TOKEN_ACCESS_DENIED_(HttpStatus.BAD_REQUEST, "TOKEN402", "임시토큰으로 접근 할 수 없습니다."),
+    _REFRESH_TOKEN_ACCESS_DENIED_(HttpStatus.BAD_REQUEST, "TOKEN403", "refresh 토큰으로 접근 할 수 없습니다."),
+
     // S3 관련
     _FILE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "FILE_001", "파일 업로드에 실패했습니다."),
     _FILE_DELETE_ERROR(HttpStatus.BAD_REQUEST, "FILE_002", "파일 삭제에 실패했습니다."),
@@ -58,11 +59,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBERSTAT_EXISTS(HttpStatus.BAD_REQUEST, "MEMBERSTAT400", "멤버 상세정보가 이미 존재합니다."),
     _MEMBERSTAT_MERIDIAN_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBERSTAT401", "오전, 오후를 정확하게 입력하세요."),
     _MEMBERSTAT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "MEMBERSTAT402", "멤버 상세정보가 존재하지 않습니다."),
-    _MEMBERSTAT_FILTER_PARAMETER_NOT_VALID(HttpStatus.BAD_REQUEST,"MEMBERSTAT403", "멤버 상세정보 filterList이 잘못되었습니다."),
+    _MEMBERSTAT_FILTER_PARAMETER_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBERSTAT403", "멤버 상세정보 filterList이 잘못되었습니다."),
 
     // ChatRoom 관련 애러
     _CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM400", "쪽지방을 찾을 수 없습니다."),
-    _CHATROOM_FORBIDDEN(HttpStatus.BAD_REQUEST,"CHATROOM401", "해당 쪽지방을 삭제할 권한이 없습니다."),
+    _CHATROOM_FORBIDDEN(HttpStatus.BAD_REQUEST, "CHATROOM401", "해당 쪽지방을 삭제할 권한이 없습니다."),
     _CHATROOM_MEMBER_MISMATCH(HttpStatus.BAD_REQUEST, "CHATROOM402", "해당 쪽지방의 멤버가 아닙니다."),
 
     // Mate 관련
@@ -91,7 +92,6 @@ public enum ErrorStatus implements BaseErrorCode {
     ;
 
 
-
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
@@ -100,10 +100,10 @@ public enum ErrorStatus implements BaseErrorCode {
     @Override
     public ErrorReasonDto getReasonHttpStatus() {
         return ErrorReasonDto.builder()
-            .message(message)
-            .code(code)
-            .isSuccess(false)
-            .httpStatus(httpStatus)
-            .build();
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
- 사용자 탈퇴 API 기능 구현했습니다.
- 소셜로그인 하면서 좁 더럽던 구조 리팩토링 했습니다.
- 토큰 발급 access token 값 response 헤더 말고 바디에 담았습니다.

## 📝 작업 내용

> ex) 코드의 흐름이나 중요한 부분을 작성해주세요.
> ex) 기존 calculate 함수의 버그를 수정했습니다.

### Controller
MemberController
```java
    @Operation(summary = "[말즈] 회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴시킵니다.")
    @DeleteMapping("/withdraw")
    public ResponseEntity<ApiResponse<String>> withdraw(@AuthenticationPrincipal MemberDetails memberDetails) {
        memberCommandService.withdraw(memberDetails);
        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
                .body(ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다."));
    }
```

### Service
MemberService
```java
    public void withdraw(MemberDetails memberDetails){
        memberRepository.delete(memberDetails.getMember());
    }
```

### AuthResponseDTO.TokenResponseDTO.

```java
 @Builder
    @Getter
    @AllArgsConstructor
    @NoArgsConstructor
    public static class TokenResponseDTO {
        String message;
        String accessToken;
        String refreshToken;
        MemberResponseDTO.MemberInfoDTO memberInfoDTO;
    }
```
## 동작 확인
다 해보고 나서 확인한거
![image](https://github.com/user-attachments/assets/5166c786-0647-474f-adc5-720b7b4473da)


## 💬 리뷰 요구사항(선택)

> 무빗을 추앙해 주세요
> 아직 comment 없길래 충돌이 걱정돼서 access token response body 로 옮기는 pr 여기에 합쳤습니다아
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
