### PR TITLE
[COZY-182] 멤버 상세정보 멤버 ID로 조회 및 일치율 조회 각 OS 별 분리

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
@@ -1,11 +1,8 @@
 package com.cozymate.cozymate_server.domain.memberstat.controller;
 
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
-import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberstat.converter.MemberStatConverter;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatRequestDTO;
-import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityDetailResponseDTO;
-import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.service.MemberStatCommandService;
 import com.cozymate.cozymate_server.domain.memberstat.service.MemberStatQueryService;

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
@@ -4,6 +4,7 @@ import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberstat.converter.MemberStatConverter;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatRequestDTO;
+import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.service.MemberStatCommandService;
@@ -51,7 +52,7 @@ public class MemberStatController {
         ErrorStatus._UNIVERSITY_NOT_FOUND,
         ErrorStatus._MEMBERSTAT_MERIDIAN_NOT_VALID
     })
-    @PostMapping("/")
+    @PostMapping("")
     public ResponseEntity<ApiResponse<Long>> createMemberStat(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @Valid @RequestBody MemberStatRequestDTO.MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
@@ -73,7 +74,7 @@ public class MemberStatController {
         ErrorStatus._MEMBERSTAT_NOT_EXISTS,
         ErrorStatus._MEMBERSTAT_MERIDIAN_NOT_VALID
     })
-    @PutMapping("/")
+    @PutMapping("")
     public ResponseEntity<ApiResponse<Long>> modifyMemberStat(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @Valid @RequestBody MemberStatRequestDTO.MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
@@ -91,12 +92,32 @@ public class MemberStatController {
     @SwaggerApiError({
         ErrorStatus._MEMBERSTAT_NOT_EXISTS
     })
-    @GetMapping("/")
+    @GetMapping("")
     public ResponseEntity<ApiResponse<MemberStatQueryResponseDTO>> getMemberStat(
         @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         MemberStatQueryResponseDTO memberStatQueryResponseDTO = MemberStatConverter.toDto(
             memberStatQueryService.getMemberStat(memberDetails.getMember()));
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(
+                memberStatQueryResponseDTO
+            ));
+    }
+
+    @Operation(
+        summary = "[포비] 사용자 상세정보 조회",
+        description = "사용자 토큰을 넣고, memberId를 PathVariable로 사용합니다.\n\n"
+            + "시간 관련 처리를 유의해주세요."
+    )
+    @SwaggerApiError({
+        ErrorStatus._MEMBERSTAT_NOT_EXISTS
+    })
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ApiResponse<MemberStatQueryResponseDTO>> getMemberStat(
+        @PathVariable Long memberId
+    ) {
+        MemberStatQueryResponseDTO memberStatQueryResponseDTO = MemberStatConverter.toDto(
+            memberStatQueryService.getMemberStatWithId(memberId));
         return ResponseEntity.ok(
             ApiResponse.onSuccess(
                 memberStatQueryResponseDTO
@@ -137,7 +158,7 @@ public class MemberStatController {
         ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID
     })
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<PageResponseDto<List<MemberStatEqualityResponseDTO>>>> getFilteredMemberList(
+    public ResponseEntity<ApiResponse<PageResponseDto<List<?>>>> getFilteredMemberList(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(required = false) List<String> filterList) {
@@ -145,8 +166,57 @@ public class MemberStatController {
         return ResponseEntity.ok(
             ApiResponse.onSuccess(
                 memberStatQueryService.getMemberStatList(
-                    memberDetails.getMember(), filterList, pageable)
+                    memberDetails.getMember(), filterList, pageable, false)
             ));
     }
+
+    @Operation(
+        summary = "[포비] 사용자 상세정보 필터링, 일치율 조회(상세 정보 포함)",
+        description = "사용자의 토큰을 넣어 사용합니다."
+            + "filterList = 필터명1,필터명2,...으로 사용하고, 없을 경우 쿼리문에 아예 filterList를 넣지 않으셔도 됩니다.\n\n"
+            + "사용 가능한 필터명(20개):\n"
+            + "- acceptance : 합격여부\n"
+            + "- admissionYear :  학번\n"
+            + "- major : 전공\n"
+            + "- numOfRoommate : 신청실\n"
+            + "- wakeUpTime : 기상시간\n"
+            + "- sleepingTime : 취침시간\n"
+            + "- turnOffTime : 소등시간\n"
+            + "- smoking : 흡연여부\n"
+            + "- sleepingHabit : 잠버릇\n"
+            + "- airConditioningIntensity : 에어컨 강도\n"
+            + "- heatingIntensity : 히터 강도\n"
+            + "- lifePattern : 생활패턴\n"
+            + "- intimacy : 친밀도\n"
+            + "- canShare : 물건공유\n"
+            + "- isPlayGame : 게임여부\n"
+            + "- isPhoneCall : 전화여부\n"
+            + "- studying : 공부여부\n"
+            + "- intake : 섭취여부\n"
+            + "- cleanSensitivity : 청결예민도\n"
+            + "- noiseSensitivity : 소음예민도\n"
+            + "- cleaningFrequency : 청소예민도\n"
+            + "- personality : 성격\n"
+            + "- mbti : mbti"
+    )
+    @SwaggerApiError({
+        ErrorStatus._MEMBERSTAT_NOT_EXISTS,
+        ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID
+    })
+    @GetMapping("/search/details")
+    public ResponseEntity<ApiResponse<PageResponseDto<List<?>>>> getFilteredMemberListWithMemberDetails(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(required = false) List<String> filterList) {
+
+        Pageable pageable = PageRequest.of(page, 5);
+
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(
+                memberStatQueryService.getMemberStatList(
+                    memberDetails.getMember(), filterList, pageable, true)
+            ));
+    }
+
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -80,4 +80,6 @@ public class MemberStatConverter {
             .options(memberStat.getOptions())
             .build();
     }
+
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatResponseDTO.java
@@ -1,6 +1,7 @@
 package com.cozymate.cozymate_server.domain.memberstat.dto;
 
 import com.cozymate.cozymate_server.domain.member.Member;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -61,5 +62,22 @@ public class MemberStatResponseDTO {
         private Integer memberPersona;
         private Integer numOfRoommate;
         private Integer equality;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberStatEqualityDetailResponseDTO {
+
+        private MemberStatEqualityResponseDTO info;
+        private MemberStatQueryResponseDTO detail;
+
+        @JsonIgnore
+        public MemberStatEqualityResponseDTO getMemberStatEqualityResponseDTO() {
+            return this.info;
+        }
+
+
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -1,14 +1,18 @@
 package com.cozymate.cozymate_server.domain.memberstat.service;
 
 import com.cozymate.cozymate_server.domain.member.Member;
-import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
+import com.cozymate.cozymate_server.domain.memberstat.converter.MemberStatConverter;
+import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO;
+import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityResponseDTO;
+import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.repository.MemberStatRepository;
 import com.cozymate.cozymate_server.domain.memberstat.util.MemberUtil;
 import com.cozymate.cozymate_server.global.common.PageResponseDto;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -35,8 +39,15 @@ public class MemberStatQueryService {
             );
     }
 
-    public PageResponseDto<List<MemberStatEqualityResponseDTO>> getMemberStatList(Member member,
-        List<String> filterList, Pageable pageable) {
+    public MemberStat getMemberStatWithId(Long memberId) {
+        return memberStatRepository.findByMemberId(memberId)
+            .orElseThrow(
+                () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
+            );
+    }
+
+    public PageResponseDto<List<?>> getMemberStatList(Member member,
+        List<String> filterList, Pageable pageable, boolean needsDetail) {
 
         //일치율의 기준이 되는 MemberStat을 가져오고, 유효성을 검사합니다.
         MemberStat criteriaMemberStat = memberStatRepository.findByMemberId(member.getId())
@@ -52,18 +63,43 @@ public class MemberStatQueryService {
             return new PageResponseDto<>(pageable.getPageNumber(), false, Collections.emptyList());
         }
 
-        // 일치율을 계산하고, 정렬합니다.
+        if (needsDetail) {
+            List<MemberStatEqualityDetailResponseDTO> result = filteredResult.stream()
+                .map(memberStat -> {
+                    MemberStatEqualityResponseDTO equalityResponse = MemberUtil.toEqualityResponse(
+                        criteriaMemberStat, memberStat);
+                    MemberStatQueryResponseDTO queryResponse = MemberStatConverter.toDto(
+                        memberStat);
+                    return MemberStatEqualityDetailResponseDTO.builder()
+                        .info(equalityResponse)
+                        .detail(queryResponse)
+                        .build();
+                })
+                .sorted((dto1, dto2) -> Integer.compare(
+                    dto2.getMemberStatEqualityResponseDTO().getEquality(),
+                    dto1.getMemberStatEqualityResponseDTO().getEquality()
+                ))
+                .toList();
+            return toPageResponseDto(result, pageable);
+        }
+
         List<MemberStatEqualityResponseDTO> result = filteredResult
             .stream()
             .map(memberStat -> MemberUtil.toEqualityResponse(criteriaMemberStat, memberStat))
             .sorted(Comparator.comparingInt(MemberStatEqualityResponseDTO::getEquality).reversed())
             .toList();
-
+        // 일치율을 계산하고, 정렬합니다.
         // MemberStat 전체 엔티티를 대상으로 하기 때문에, 우선 Page로 구현했습니다.
         // List를 Page로 변환하기 위해 아래 코드를 사용합니다.
         // 기존에 만들어진 PageResponseDTO를 활용해보려고 노력했습니다.
 
         // 전체 페이지 수 계산
+
+        return toPageResponseDto(result, pageable);
+
+    }
+
+    private PageResponseDto<List<?>> toPageResponseDto(List<?> result, Pageable pageable) {
         int totalPages = (int) Math.ceil((double) result.size() / pageable.getPageSize());
 
         // 요청한 페이지가 범위를 벗어났을 경우 빈 페이지 반환
@@ -78,6 +114,8 @@ public class MemberStatQueryService {
         // 해당 페이지의 데이터만 추출하여 Page로 반환
         return new PageResponseDto<>(pageable.getPageNumber(),
             pageable.getPageNumber() + 1 < totalPages, result.subList(start, end));
+
     }
+
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberUtil.java
@@ -74,6 +74,8 @@ public class MemberUtil {
             .build();
     }
 
+
+
     private static int calculateTimeScore(Integer time1, Integer time2) {
         int timeDifference = Math.abs(time1 - time2);
         return switch (timeDifference) {


### PR DESCRIPTION
## #️⃣ 요약 설명

타인의 멤버 상세정보를 볼 때 멤버 ID를 이용해서 조회하고,
OS 별로 일치율 조회를 위해 필요한 API가 달라 안드로이드가 사용할 수 있는 API를 만들었습니다.

IOS : 기존 API 사용
Android:  일치율 조회에 사용자 상세정보 포함한 API 제작

## 📝 작업 내용

### Service
코드를 재사용하기 위해 다음과 같이 구현했습니다.
```java
    public PageResponseDto<List<?>> getMemberStatList(Member member,
        List<String> filterList, Pageable pageable, boolean needsDetail) {

        //일치율의 기준이 되는 MemberStat을 가져오고, 유효성을 검사합니다.
        MemberStat criteriaMemberStat = memberStatRepository.findByMemberId(member.getId())
            .orElseThrow(
                () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
            );

        //필터링된 리스트들을 가져옵니다. 필터가 없을 경우, 모두 가져옵니다.
        List<MemberStat> filteredResult = memberStatRepository.getFilteredMemberStat(filterList,
            criteriaMemberStat);

        if (filteredResult.isEmpty()) {
            return new PageResponseDto<>(pageable.getPageNumber(), false, Collections.emptyList());
        }

        if (needsDetail) {
            List<MemberStatEqualityDetailResponseDTO> result = filteredResult.stream()
                .map(memberStat -> {
                    MemberStatEqualityResponseDTO equalityResponse = MemberUtil.toEqualityResponse(
                        criteriaMemberStat, memberStat);
                    MemberStatQueryResponseDTO queryResponse = MemberStatConverter.toDto(
                        memberStat);
                    return MemberStatEqualityDetailResponseDTO.builder()
                        .info(equalityResponse)
                        .detail(queryResponse)
                        .build();
                })
                .sorted((dto1, dto2) -> Integer.compare(
                    // 높은 순 정렬
                    dto2.getMemberStatEqualityResponseDTO().getEquality(),
                    dto1.getMemberStatEqualityResponseDTO().getEquality()
                ))
                .toList();
            return toPageResponseDto(result, pageable);
        }

        List<MemberStatEqualityResponseDTO> result = filteredResult
            .stream()
            .map(memberStat -> MemberUtil.toEqualityResponse(criteriaMemberStat, memberStat))
            .sorted(Comparator.comparingInt(MemberStatEqualityResponseDTO::getEquality).reversed())
            .toList();

        return toPageResponseDto(result, pageable);

    }
```
Detail이 필요하면 needsDetail 인자로 구분해 다른 리턴 값을 주도록 했습니다.
Controller도 하나로 사용하면 좋을 것 같았지만, 두 OS를 위해 별도로 분리하는게 좋다고 판단했습니다.

### Controller

```java
    @GetMapping("/search/details")
    public ResponseEntity<ApiResponse<PageResponseDto<List<?>>>> getFilteredMemberListWithMemberDetails(
        @AuthenticationPrincipal MemberDetails memberDetails,
        @RequestParam(defaultValue = "0") int page,
        @RequestParam(required = false) List<String> filterList) {

        Pageable pageable = PageRequest.of(page, 5);

        return ResponseEntity.ok(
            ApiResponse.onSuccess(
                memberStatQueryService.getMemberStatList(
                    memberDetails.getMember(), filterList, pageable, true)
            ));
    }
```
구조는 기존 API와 동일하지만, uri만 다릅니다!

## 동작 확인

ID로 상세정보 조회
![image](https://github.com/user-attachments/assets/f352ecfd-7658-4d8c-99f2-e6d8c4ddf55b)

성공

일치율에 상세정보 포함
![image](https://github.com/user-attachments/assets/c1801578-d9bd-406e-97aa-605c2e2a3f41)

성공

나머지 예외 검사도 했습니다~

## 💬 리뷰 요구사항(선택)

> 감사합니다.
