### PR TITLE
[COZY-38] feat: Room Log 조회 기능 구현

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -21,7 +21,7 @@ import com.cozymate.cozymate_server.domain.room.dto.RoomCreateRequest;
 import com.cozymate.cozymate_server.domain.room.dto.RoomCreateResponse;
 import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
 import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
-import com.cozymate.cozymate_server.domain.roomlog.RoomLogRepository;
+import com.cozymate.cozymate_server.domain.roomlog.repository.RoomLogRepository;
 import com.cozymate.cozymate_server.domain.rule.repository.RuleRepository;
 import com.cozymate.cozymate_server.domain.todo.repository.TodoRepository;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/RoomLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/RoomLogRepository.java
@@ -1,8 +1,0 @@
-package com.cozymate.cozymate_server.domain.roomlog;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RoomLogRepository extends JpaRepository<RoomLog, Long> {
-    void deleteByRoomId(Long roomId);
-
-}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/controller/RoomLogController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/controller/RoomLogController.java
@@ -1,0 +1,46 @@
+package com.cozymate.cozymate_server.domain.roomlog.controller;
+
+import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
+import com.cozymate.cozymate_server.domain.roomlog.dto.RoomLogResponseDto.RoomLogDetailResponseDto;
+import com.cozymate.cozymate_server.domain.roomlog.service.RoomLogCommandService;
+import com.cozymate.cozymate_server.domain.roomlog.service.RoomLogQueryService;
+import com.cozymate.cozymate_server.global.common.PageResponseDto;
+import com.cozymate.cozymate_server.global.response.ApiResponse;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/roomlog")
+public class RoomLogController {
+
+    private final RoomLogCommandService roomLogCommandService;
+    private final RoomLogQueryService roomLogQueryService;
+
+    @GetMapping("/{roomId}")
+    @Operation(summary = "[무빗] 특정 방에 roomlog 목록 조회", description = "해당 방의 로그가 출력됩니다.")
+    @SwaggerApiError({ErrorStatus._MATE_OR_ROOM_NOT_FOUND})
+    public ResponseEntity<ApiResponse<PageResponseDto<List<RoomLogDetailResponseDto>>>> getRoomLogList(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @PathVariable Long roomId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+            roomLogQueryService.getRoomLogList(roomId, memberDetails.getMember(), page, size)
+        ));
+    }
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/converter/RoomLogConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/converter/RoomLogConverter.java
@@ -1,0 +1,15 @@
+package com.cozymate.cozymate_server.domain.roomlog.converter;
+
+import com.cozymate.cozymate_server.domain.roomlog.RoomLog;
+import com.cozymate.cozymate_server.domain.roomlog.dto.RoomLogResponseDto.RoomLogDetailResponseDto;
+
+public class RoomLogConverter {
+
+
+    public static RoomLogDetailResponseDto toRoomLogDetailResponseDto(RoomLog roomLog) {
+        return RoomLogDetailResponseDto.builder()
+            .content(roomLog.getContent())
+            .createdAt(roomLog.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/dto/RoomLogRequestDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/dto/RoomLogRequestDto.java
@@ -1,0 +1,5 @@
+package com.cozymate.cozymate_server.domain.roomlog.dto;
+
+public class RoomLogRequestDto {
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/dto/RoomLogResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/dto/RoomLogResponseDto.java
@@ -1,0 +1,22 @@
+package com.cozymate.cozymate_server.domain.roomlog.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RoomLogResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RoomLogDetailResponseDto {
+
+        private String content;
+        @JsonFormat(pattern = "MM/dd HH:mm")
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
@@ -1,0 +1,14 @@
+package com.cozymate.cozymate_server.domain.roomlog.repository;
+
+import com.cozymate.cozymate_server.domain.roomlog.RoomLog;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomLogRepository extends JpaRepository<RoomLog, Long> {
+
+    Slice<RoomLog> findAllByRoomIdOrderByCreatedAtDesc(Long roomId, Pageable pageable);
+
+    void deleteByRoomId(Long roomId);
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogCommandService.java
@@ -1,0 +1,10 @@
+package com.cozymate.cozymate_server.domain.roomlog.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomLogCommandService {
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogQueryService.java
@@ -1,0 +1,52 @@
+package com.cozymate.cozymate_server.domain.roomlog.service;
+
+import com.cozymate.cozymate_server.domain.mate.Mate;
+import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.roomlog.RoomLog;
+import com.cozymate.cozymate_server.domain.roomlog.converter.RoomLogConverter;
+import com.cozymate.cozymate_server.domain.roomlog.dto.RoomLogResponseDto.RoomLogDetailResponseDto;
+import com.cozymate.cozymate_server.domain.roomlog.repository.RoomLogRepository;
+import com.cozymate.cozymate_server.global.common.PageResponseDto;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomLogQueryService {
+
+    private final RoomLogRepository roomLogRepository;
+    private final MateRepository mateRepository;
+
+
+    public PageResponseDto<List<RoomLogDetailResponseDto>> getRoomLogList(
+        Long roomId,
+        Member member,
+        int page,
+        int size) {
+
+        // 본인 방에 속한건지 확인
+        Mate mate = mateRepository.findByMemberIdAndRoomId(member.getId(), roomId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_OR_ROOM_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<RoomLog> roomLogSlice = roomLogRepository.findAllByRoomIdOrderByCreatedAtDesc(roomId,
+            pageable);
+
+        List<RoomLogDetailResponseDto> roomLogResponseList = roomLogSlice.getContent().stream()
+            .map(RoomLogConverter::toRoomLogDetailResponseDto)
+            .toList();
+
+        return new PageResponseDto<>(pageable.getPageNumber(), roomLogSlice.hasNext(),
+            roomLogResponseList);
+
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
- Room Log 조회 기능부터 구현했습니다.
- 단순히 가져와서 조회하는 기능이며 + Pagenation이 구현되어있습니다.
- Pagenation의 기본값도 지정해두었습니다.

## 📝 작업 내용
- 단순히 Room Log를 생성일 기준으로 최신순으로 정렬한 후 가져와서 형식에 맞게 반환합니다.
```java
    public PageResponseDto<List<RoomLogDetailResponseDto>> getRoomLogList(
        Long roomId,
        Member member,
        int page,
        int size) {

        // 본인 방에 속한건지 확인
        Mate mate = mateRepository.findByMemberIdAndRoomId(member.getId(), roomId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_OR_ROOM_NOT_FOUND));

        Pageable pageable = PageRequest.of(page, size);

        Slice<RoomLog> roomLogSlice = roomLogRepository.findAllByRoomIdOrderByCreatedAtDesc(roomId,
            pageable);

        List<RoomLogDetailResponseDto> roomLogResponseList = roomLogSlice.getContent().stream()
            .map(RoomLogConverter::toRoomLogDetailResponseDto)
            .toList();

        return new PageResponseDto<>(pageable.getPageNumber(), roomLogSlice.hasNext(),
            roomLogResponseList);

    }
```

## 동작 확인
- Room Log는 여러 Service에서 진행 중 호출해야하기 때문에,반드시 이렇게 넣겠다는 마인드로 진행했습니다.
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/5571b637-78fb-42c4-9872-1540bfed97ae">

- 아래처럼 응답을 받게되고, 날짜 형식도 정해두었습니다.
- 다른 색이 적용되어야하는 부분은 {}로 감싸서 두었습니다.
<img width="686" alt="image" src="https://github.com/user-attachments/assets/5d75d42b-6e7f-467d-961b-5ce99439ad89">


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
