### PR TITLE
[COZY-29] feat: Todo 삭제 기능 구현

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogQueryService.java
@@ -16,9 +16,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RoomLogQueryService {
 
     private final RoomLogRepository roomLogRepository;

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/service/RuleCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/service/RuleCommandService.java
@@ -11,9 +11,11 @@ import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class RuleCommandService {
 
     private final RuleRepository ruleRepository;

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/controller/TodoController.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -65,6 +66,17 @@ public class TodoController {
         return ResponseEntity.ok(ApiResponse.onSuccess(
             todoQueryService.getTodo(roomId, memberDetails.getMember(), timePoint)
         ));
+    }
+
+    @DeleteMapping("")
+    @Operation(summary = "[무빗] 특정 방의 특정 Todo 삭제", description = "Todo의 고유 번호로 삭제가 가능합니다.")
+    @SwaggerApiError({ErrorStatus._TODO_NOT_VALID, ErrorStatus._TODO_NOT_FOUND})
+    public ResponseEntity<ApiResponse<String>> deleteTodo(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @RequestParam Long todoId
+    ) {
+        todoCommandService.deleteTodo(memberDetails.getMember(), todoId);
+        return ResponseEntity.ok(ApiResponse.onSuccess("삭제되었습니다."));
     }
 
     @PatchMapping("/state")

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
@@ -12,9 +12,11 @@ import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class TodoCommandService {
 
     private static final int MAX_TODO_PER_DAY = 20;
@@ -56,6 +58,19 @@ public class TodoCommandService {
         }
         todo.updateCompleteState(updateTodoCompleteStateRequestDto.getCompleted());
         todoRepository.save(todo);
+    }
+
+    public void deleteTodo(
+        Member member,
+        Long todoId
+    ) {
+        Todo todo = todoRepository.findById(todoId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._TODO_NOT_FOUND));
+
+        if (Boolean.FALSE.equals(todo.getMate().getMember().getId().equals(member.getId()))) {
+            throw new GeneralException(ErrorStatus._TODO_NOT_VALID);
+        }
+        todoRepository.delete(todo);
     }
 
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
- Todo 삭제 기능을 구현했습니다.

## 📝 작업 내용

-TodoId 값을 받아서, 해당 Todo의 주인이 본인이라면 삭제되도록 하고, 아니라면 에러가 반환되도록 했습니다.
<img width="1185" alt="image" src="https://github.com/user-attachments/assets/2cd64de3-f73b-4229-8393-27fdac2b8447">


```java
    public void deleteTodo(
        Member member,
        Long todoId
    ) {
        Todo todo = todoRepository.findById(todoId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._TODO_NOT_FOUND));

        if (Boolean.FALSE.equals(todo.getMate().getMember().getId().equals(member.getId()))) {
            throw new GeneralException(ErrorStatus._TODO_NOT_VALID);
        }
        todoRepository.delete(todo);
    }
```

## 동작 확인
- 아래처럼 9번에 해당하는 투두가 있다고 했을 때
<img width="1185" alt="image" src="https://github.com/user-attachments/assets/9cebed53-6830-4007-81de-9db0900bd762">

- Todo Id로 삭제를 진행하면 200 성공이 반환됩니다.
<img width="589" alt="image" src="https://github.com/user-attachments/assets/40db02de-2801-46e9-afeb-07bfae2de75e">

- 다시 호출하면 이젠 없습니다.
<img width="603" alt="image" src="https://github.com/user-attachments/assets/3413b665-54ff-4447-8253-6f9dbf507334">


## 💬 리뷰 요구사항(선택)
