### PR TITLE
[COZY-198] 방 정보 조회 시 mateId 포함

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/converter/RoomConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/converter/RoomConverter.java
@@ -3,6 +3,7 @@ package com.cozymate.cozymate_server.domain.room.converter;
 import com.cozymate.cozymate_server.domain.mate.Mate;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.room.Room;
+import com.cozymate.cozymate_server.domain.room.dto.CozymateInfoResponse;
 import com.cozymate.cozymate_server.domain.room.dto.CozymateResponse;
 import com.cozymate.cozymate_server.domain.room.dto.InviteRequest;
 import com.cozymate.cozymate_server.domain.room.dto.RoomCreateRequest;
@@ -35,6 +36,14 @@ public class RoomConverter {
         return CozymateResponse.builder()
             .memberId(member.getId())
             .nickname(member.getNickname())
+            .build();
+    }
+
+    public static CozymateInfoResponse toCozyMateInfoResponse(Mate mate) {
+        return CozymateInfoResponse.builder()
+            .memberId(mate.getMember().getId())
+            .mateId(mate.getId())
+            .nickname(mate.getMember().getNickname())
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/CozymateInfoResponse.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/CozymateInfoResponse.java
@@ -1,0 +1,15 @@
+package com.cozymate.cozymate_server.domain.room.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CozymateInfoResponse {
+
+    private Long memberId;
+    private Long mateId;
+    private String nickname;
+
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/RoomCreateResponse.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/RoomCreateResponse.java
@@ -12,5 +12,5 @@ public class RoomCreateResponse {
     private String name;
     private String inviteCode;
     private Integer profileImage;
-    List<CozymateResponse> mateList;
+    List<CozymateInfoResponse> mateList;
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -10,6 +10,7 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.domain.room.converter.RoomConverter;
+import com.cozymate.cozymate_server.domain.room.dto.CozymateInfoResponse;
 import com.cozymate.cozymate_server.domain.room.dto.CozymateResponse;
 import com.cozymate.cozymate_server.domain.room.dto.InviteRequest;
 import com.cozymate.cozymate_server.domain.room.dto.RoomCreateResponse;
@@ -47,9 +48,9 @@ public class RoomQueryService {
         mateRepository.findByRoomIdAndMemberId(roomId, memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_ROOM_MATE));
 
-        List<CozymateResponse> mates = mateRepository.findByRoomId(roomId).stream()
+        List<CozymateInfoResponse> mates = mateRepository.findByRoomId(roomId).stream()
             .filter(mate->mate.getEntryStatus().equals(EntryStatus.JOINED))
-            .map(mate->RoomConverter.toCozymateResponse(mate.getMember()))
+            .map(RoomConverter::toCozyMateInfoResponse)
             .toList();
 
         return new RoomCreateResponse(room.getId(), room.getName(), room.getInviteCode(), room.getProfileImage(),


### PR DESCRIPTION
## #️⃣ 요약 설명

방 정보 조회 시 mateId 포함했습니다.

## 📝 작업 내용

### Response DTO 하나를 새로 만들었습니다.

```java
@Getter
@Builder
public class CozymateInfoResponse {

    private Long memberId;
    private Long mateId;
    private String nickname;


}
```

나머지 적용 방식은 #70 과 동일합니다.

## 동작 확인

성공~

![image](https://github.com/user-attachments/assets/73cc2b3d-732c-4b0b-9bdc-da52f0533540)


## 💬 리뷰 요구사항(선택)

> 감사합니다
