### PR TITLE
[COZY-202] feat: 방 생성시 피드 자동 생성, 멤버 상세정보 삭제 기능

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/feed/controller/FeedController.java
@@ -31,9 +31,10 @@ public class FeedController {
     private final FeedCommandService feedCommandService;
     private final FeedQueryService feedQueryService;
 
+    @Deprecated
     @Operation(
         summary = "[포비] 피드 정보 등록하기",
-        description = "사용자의 토큰을 넣어 사용하고, body로 룸 ID와 피드 상세정보를 넣어 사용합니다.\n\n"
+        description = "해당 API는 더 이상 사용하지 않습니다"
     )
     @SwaggerApiError({
         ErrorStatus._ROOM_NOT_FOUND,

--- a/src/main/java/com/cozymate/cozymate_server/domain/feed/converter/FeedConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/feed/converter/FeedConverter.java
@@ -23,4 +23,12 @@ public class FeedConverter {
             .build();
     }
 
+    public static Feed toEntity(Room room) {
+        return Feed.builder()
+            .room(room)
+            .name("")
+            .description("")
+            .build();
+    }
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -104,9 +105,9 @@ public class MemberStatController {
     @Operation(
         summary = "[포비] 사용자 상세정보 조회",
         description = "사용자 토큰을 넣고, memberId를 PathVariable로 사용합니다.\n\n"
-            + "시간 관련 처리를 유의해주세요."
     )
     @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._MEMBERSTAT_NOT_EXISTS
     })
     @GetMapping("/{memberId}")
@@ -213,5 +214,24 @@ public class MemberStatController {
             ));
     }
 
+    @Operation(
+        summary = "[포비] 사용자 상세정보 삭제(관리자용)",
+        description = "요청자의 토큰을 넣고, 삭제하고자 하는 사용자의 ID를 넣어 사용합니다.\n\n"
+    )
+    @DeleteMapping("/{memberId}")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._MEMBERSTAT_NOT_EXISTS
+    })
+    public ResponseEntity<ApiResponse<Boolean>> deleteMemberStat(
+        @PathVariable Long memberId
+    ){
+        // TODO : 관리자 권한 분리시 일반 사용자가 삭제하는 것을 제한하기
+        memberStatCommandService.deleteMemberStat(memberId);
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(
+                true
+            ));
+    }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
@@ -62,4 +62,18 @@ public class MemberStatCommandService {
         return updatedMemberStat.getId();
 
     }
+
+    public void deleteMemberStat(Long memberId){
+
+        if(!memberStatRepository.existsById(memberId)){
+            throw new GeneralException(ErrorStatus._MEMBER_NOT_FOUND);
+        }
+
+        MemberStat memberStat = memberStatRepository.findByMemberId(memberId).orElseThrow(
+            () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
+        );
+
+        memberStatRepository.delete(memberStat);
+
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -1,6 +1,7 @@
 package com.cozymate.cozymate_server.domain.room.service;
 
 import com.cozymate.cozymate_server.domain.feed.Feed;
+import com.cozymate.cozymate_server.domain.feed.converter.FeedConverter;
 import com.cozymate.cozymate_server.domain.feed.repository.FeedRepository;
 import com.cozymate.cozymate_server.domain.friend.FriendRepository;
 import com.cozymate.cozymate_server.domain.friend.enums.FriendStatus;
@@ -73,6 +74,9 @@ public class RoomCommandService {
 
         Mate mate = MateConverter.toEntity(room, creator, true);
         mateRepository.save(mate);
+
+        Feed feed = FeedConverter.toEntity(room);
+        feedRepository.save(feed);
 
         return roomQueryService.getRoomById(room.getId(), member.getId());
     }


### PR DESCRIPTION
## #️⃣ 요약 설명

1. 방 생성시 피드 자동 생성
2. 멤버 상세정보 삭제 (APP에서 사용 불가능하게)

2번 상황은 혹시 모를 상황을 대비해서 삭제 API를 구현해놨습니다.
관리자 페이지를 추후에 구현한다면, 거기에서도 사용할 것 같아 구현했습니다.

## 📝 작업 내용

1. Room 코드 수정

```java
        Feed feed = FeedConverter.toEntity(room);
        feedRepository.save(feed);
```

2. MemberStat 삭제 코드

```java
    public void deleteMemberStat(Long memberId){

        if(!memberStatRepository.existsById(memberId)){
            throw new GeneralException(ErrorStatus._MEMBER_NOT_FOUND);
        }

        MemberStat memberStat = memberStatRepository.findByMemberId(memberId).orElseThrow(
            () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
        );

        memberStatRepository.delete(memberStat);

    }
```

Room 삭제 관련해서 Feed 존재 여부를 검사하는 코드가 있는데,
이 부분은 아직 Room이 생성되었어도, Feed가 존재하지 않는 경우가 DB에 남아있어,
추후에 DB를 밀게 되면 그때 변경하면 될 거 같습니다. @suuu0719 

## 동작 확인

### 방 삭제

제 방이 없어 생성했습니다

<img width="289" alt="image" src="https://github.com/user-attachments/assets/ec7bb2d1-dc95-4007-9cd2-a74c4bbbec67">

방 생성시 피드가 잘 생성된 것을 확인했습니다

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/1f6321da-bd26-4d2a-b5e7-25d71835c6c2">


### 멤버 정보 삭제

현재 존재하는 포비 정보
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/db3df607-4492-425b-9dd0-6e42a296e6f8">

삭제.
<img width="302" alt="image" src="https://github.com/user-attachments/assets/76e3a9d1-cc20-4676-8a5f-f93214d8a721">

DB에서 사라진 것을 확인했습니다.



## 💬 리뷰 요구사항(선택)

> 감사합니다~
