### PR TITLE
[COZY-234] 방 입장 시 알림, 스케줄러 알림 전송 비동기로 처리

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/dto/FcmPushContentDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/dto/FcmPushContentDto.java
@@ -1,6 +1,7 @@
 package com.cozymate.cozymate_server.domain.fcm.dto;
 
 import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.room.Room;
 import java.util.List;
 import lombok.Getter;
 
@@ -10,11 +11,20 @@ public class FcmPushContentDto {
     private Member member;
     private String roleContent;
     private List<String> todoContents;
+    private Room room;
+
+    private FcmPushContentDto(Member member, Room room) {
+        this.member = member;
+        this.room = room;
+        roleContent = null;
+        todoContents = null;
+    }
 
     private FcmPushContentDto(Member member) {
         this.member = member;
         roleContent = null;
         todoContents = null;
+        room = null;
     }
 
     // 투두 내용 리스트로 전부 줘야하는 경우, 00시 투드 리스트 스케줄러
@@ -22,6 +32,7 @@ public class FcmPushContentDto {
         this.member = member;
         this.todoContents = todoContents;
         roleContent = null;
+        room = null;
     }
 
     // 롤 내용 하나만 줘야하는 경우, 21시 미완료 Role 한개만 리마인더 스케줄러
@@ -29,6 +40,7 @@ public class FcmPushContentDto {
         this.member= member;
         this.roleContent = roleContent;
         todoContents = null;
+        room = null;
     }
 
     private FcmPushContentDto() {
@@ -44,6 +56,10 @@ public class FcmPushContentDto {
 
     public static FcmPushContentDto create(Member member, List<String> todoContents) {
         return new FcmPushContentDto(member, todoContents);
+    }
+
+    public static FcmPushContentDto create(Member member, Room room) {
+        return new FcmPushContentDto(member, room);
     }
 
     // 방이 열렸어요 -> 에서 사용합니다!

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/dto/FcmPushTargetDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/dto/FcmPushTargetDto.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.fcm.dto;
 
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
+import com.cozymate.cozymate_server.domain.room.Room;
 import java.util.List;
 import lombok.Getter;
 
@@ -134,5 +135,25 @@ public class FcmPushTargetDto {
         }
     }
 
+    @Getter
+    public static class GroupRoomNameWithOutMeTargetDto {
 
+        private final Member me;
+        private final List<Member> memberList;
+        private final Room room;
+        private final NotificationType notificationType;
+
+        private GroupRoomNameWithOutMeTargetDto(Member me, List<Member> memberList, Room room,
+            NotificationType notificationType) {
+            this.me = me;
+            this.memberList = memberList;
+            this.room = room;
+            this.notificationType = notificationType;
+        }
+
+        public static GroupRoomNameWithOutMeTargetDto create(Member me, List<Member> memberList,
+            Room room, NotificationType notificationType) {
+            return new GroupRoomNameWithOutMeTargetDto(me, memberList, room, notificationType);
+        }
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmPushService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmPushService.java
@@ -16,19 +16,16 @@ import com.cozymate.cozymate_server.domain.room.Room;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import java.util.HashMap;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class FcmPushService {
 
     private static final String NOTIFICATION_TITLE = "cozymate";
@@ -36,7 +33,7 @@ public class FcmPushService {
     private final NotificationLogRepository notificationLogRepository;
     private final FcmRepository fcmRepository;
 
-    //    @Async
+    @Async
     public void sendNotification(OneTargetDto target) {
         Member member = target.getMember();
 
@@ -51,7 +48,7 @@ public class FcmPushService {
         }
     }
 
-    //    @Async
+    @Async
     public void sendNotification(OneTargetReverseDto target) {
         Member contentMember = target.getContentMember();
         Member recipientMember = target.getRecipientMember();
@@ -59,7 +56,7 @@ public class FcmPushService {
         sendNotificationToMember(contentMember, recipientMember, target.getNotificationType());
     }
 
-    //    @Async
+    @Async
     public void sendNotification(GroupTargetDto target) {
         List<Member> memberList = target.getMemberList();
 
@@ -69,7 +66,7 @@ public class FcmPushService {
         });
     }
 
-    //    @Async
+    @Async
     public void sendNotification(GroupWithOutMeTargetDto target) {
         List<Member> memberList = target.getMemberList();
         Member me = target.getMe();

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -51,4 +51,7 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     List<Mate> findByRoom(Room room);
 
     Optional<Mate> findByMember(Member member);
+
+    @Query("select m from Mate m join fetch m.member")
+    List<Mate> findFetchAll();
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/enums/NotificationType.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/enums/NotificationType.java
@@ -111,6 +111,15 @@ public enum NotificationType {
                 + builder.toString();
         }
     },
+
+    JOIN_ROOM(NotificationCategory.COZY_HOME) {
+        @Override
+        public String generateContent(FcmPushContentDto fcmPushContentDto) {
+            return getNicknameShowFormat(fcmPushContentDto.getRoom().getName()) + "에 "
+                + getNicknameShowFormat(fcmPushContentDto.getMember().getNickname())
+                +"님이 뛰어들어왔어요!";
+        }
+    }
     ;
 
     private NotificationCategory category;

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
@@ -5,6 +5,8 @@ import com.cozymate.cozymate_server.domain.todo.Todo;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
@@ -14,10 +16,13 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     Integer countAllByRoomIdAndMateIdAndTimePoint(Long roomId, Long mateId, LocalDate timePoint);
 
-    List<Todo> findByTimePoint(LocalDate today);
+    @Query("select t from Todo t join fetch t.mate m join fetch m.member where t.timePoint = :today")
+    List<Todo> findByTimePoint(@Param("today") LocalDate today);
 
-    List<Todo> findByTimePointAndRoleIsNotNull(LocalDate today);
+    @Query("select t from Todo t join fetch t.mate m join fetch m.member where t.timePoint = :today and t.role is not null and t.completed is false")
+    List<Todo> findByTimePointAndRoleIsNotNullCompletedFalse(@Param("today") LocalDate today);
+
+    List<Todo>findByTimePointAndRoleIsNotNull(LocalDate today);
 
     boolean existsByMateAndTimePointAndCompletedFalse(Mate mate, LocalDate timePoint);
-
 }

--- a/src/main/java/com/cozymate/cozymate_server/global/event/EventListener.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/event/EventListener.java
@@ -1,5 +1,6 @@
 package com.cozymate.cozymate_server.global.event;
 
+import com.cozymate.cozymate_server.domain.fcm.dto.FcmPushTargetDto.GroupRoomNameWithOutMeTargetDto;
 import com.cozymate.cozymate_server.domain.fcm.dto.FcmPushTargetDto.GroupWithOutMeTargetDto;
 import com.cozymate.cozymate_server.domain.fcm.service.FcmPushService;
 import com.cozymate.cozymate_server.domain.fcm.dto.FcmPushTargetDto.GroupTargetDto;
@@ -50,5 +51,10 @@ public class EventListener {
     @TransactionalEventListener
     public void sendNotification(GroupWithOutMeTargetDto groupWithOutMeTargetDto) {
         fcmPushService.sendNotification(groupWithOutMeTargetDto);
+    }
+
+    @TransactionalEventListener
+    public void sendNotification(GroupRoomNameWithOutMeTargetDto groupRoomNameWithOutMeTargetDto) {
+        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDto);
     }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
방 입장 시 해당 방의 메이트들에게 알림 전송 기능 구현했습니다.
스케줄러에서 FcmPushService의 비동기 메서드 호출 시 -> 트랜잭션 분리로 영속성 컨텍스트가 달라져버려 프록시 초기화 안되는 문제 발생
-> 스케줄러 단에서 조회시 페치 조인으로 가져와서 해결했습니다.

## 📝 작업 내용

> ex) 코드의 흐름이나 중요한 부분을 작성해주세요.
> ex) 기존 calculate 함수의 버그를 수정했습니다.

```java
중요한 코드 부분을 붙여넣어 설명해주세요.
```

## 동작 확인

> ex) 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> ex) 테스트 코드 작성도 좋습니다!

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
