### PR TITLE
[COZY-232] feat : 메일 인증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     // Firebase Admin SDK
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 
+    // spring-boot mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/ClientIdMaker.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/ClientIdMaker.java
@@ -3,6 +3,7 @@ package com.cozymate.cozymate_server.domain.auth.utils;
 import com.cozymate.cozymate_server.domain.member.enums.SocialType;
 
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.UUID;
 
 /**
@@ -23,7 +24,7 @@ public class ClientIdMaker {
         return memberId + DELIMITER + socialType.toString();
     }
     private static String generateUUID(){
-        return UUID.randomUUID().toString();
+        return Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
     }
     public static SocialType getSocialTypeInClientId(String clientId) {
         String socialTypePart = Arrays.asList(clientId.split(DELIMITER)).get(SOCIAL_TYPE_INDEX);

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/controller/MailController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/controller/MailController.java
@@ -1,0 +1,43 @@
+package com.cozymate.cozymate_server.domain.mail.controller;
+
+
+import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
+import com.cozymate.cozymate_server.domain.mail.dto.MailResponseDTO;
+import com.cozymate.cozymate_server.domain.mail.service.MailService;
+import com.cozymate.cozymate_server.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/mail")
+public class MailController {
+    private final MailService mailService;
+
+    @PostMapping("/{mail-address}")
+    public ResponseEntity sendUniversityAuthenticationCode(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable("mail-address") String mailAddress
+    ) {
+        mailService.sendUniversityAuthenticationCode(memberDetails.getUsername(), mailAddress);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/verify/{code}")
+    public ResponseEntity<ApiResponse<MailResponseDTO.verifyResponseDTO>> verifyAuthenticationCode(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable("code") String code
+
+    ) {
+        MailResponseDTO.verifyResponseDTO verifyResponseDTO = mailService.verifyAuthenticationCode(
+                memberDetails.getUsername(), code);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(verifyResponseDTO));
+    }
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/dto/MailRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/dto/MailRequestDTO.java
@@ -1,0 +1,25 @@
+
+package com.cozymate.cozymate_server.domain.mail.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MailRequestDTO {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class SendRequestDTO{
+        private String emailAddress;
+    }
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class CodeDTO{
+        private String code;
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/dto/MailResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/dto/MailResponseDTO.java
@@ -1,0 +1,18 @@
+package com.cozymate.cozymate_server.domain.mail.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MailResponseDTO {
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class verifyResponseDTO{
+        private String message;
+        private Boolean isVerified;
+    }
+}
+

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -2,7 +2,7 @@ package com.cozymate.cozymate_server.domain.mail.service;
 
 
 import com.cozymate.cozymate_server.domain.mail.dto.MailResponseDTO;
-import com.cozymate.cozymate_server.domain.member.Member;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -22,7 +22,7 @@ public class MailService {
 
     public void sendUniversityAuthenticationCode(String clientId, String mailAddress) {
         SimpleMailMessage message = new SimpleMailMessage();
-        String authCode = UUID.randomUUID().toString().substring(0, 6);
+        String authCode = Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes()).substring(0,6);
         message.setTo(mailAddress);
         message.setSubject("COZYMATE 대학교 메일인증");
         message.setText("COZYMATE 대학교 메일인증 코드입니다 : " + authCode);

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -1,0 +1,51 @@
+package com.cozymate.cozymate_server.domain.mail.service;
+
+
+import com.cozymate.cozymate_server.domain.mail.dto.MailResponseDTO;
+import com.cozymate.cozymate_server.domain.member.Member;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+import org.springframework.mail.javamail.JavaMailSender;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MailService {
+    private final Map<String, String> memberAuthenticationCodeMap = new HashMap<>();
+    private final JavaMailSender mailSender;
+
+    public void sendUniversityAuthenticationCode(String clientId, String mailAddress) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        String authCode = UUID.randomUUID().toString().substring(0, 6);
+        message.setTo(mailAddress);
+        message.setSubject("COZYMATE 대학교 메일인증");
+        message.setText("COZYMATE 대학교 메일인증 코드입니다 : " + authCode);
+        mailSender.send(message);
+
+        memberAuthenticationCodeMap.put(clientId, authCode);
+
+        log.info("auth code : {}", authCode);
+        log.info("member : {}", clientId);
+        log.info("email : {}", mailAddress);
+    }
+
+    public MailResponseDTO.verifyResponseDTO verifyAuthenticationCode(String clientId, String authenticationCode) {
+        if (memberAuthenticationCodeMap.get(clientId).equals(authenticationCode)){
+            return MailResponseDTO.verifyResponseDTO.builder()
+                    .isVerified(true)
+                    .message("성공입니다")
+                    .build();
+        }
+        return MailResponseDTO.verifyResponseDTO.builder()
+                .isVerified(false)
+                .message("인증 코드가 일치하지 않습니다")
+                .build();
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
메일 보내기 기능을 추가했습니다.
아직 메일 패턴적용은 안했구여.. 인증코드 생성해서 메일 보내고, 검증하는 api만 만들었습니다.
일단 지금은 자바 맵으로 구현했습니다.
## 📝 작업 내용

> ex) 코드의 흐름이나 중요한 부분을 작성해주세요.
> ex) 기존 calculate 함수의 버그를 수정했습니다.

```java
public void sendUniversityAuthenticationCode(String clientId, String mailAddress) {
        SimpleMailMessage message = new SimpleMailMessage();
        String authCode = UUID.randomUUID().toString().substring(0, 6);
        message.setTo(mailAddress);
        message.setSubject("COZYMATE 대학교 메일인증");
        message.setText("COZYMATE 대학교 메일인증 코드입니다 : " + authCode);
        mailSender.send(message);

        memberAuthenticationCodeMap.put(clientId, authCode);
    }
```
6자리 코드를 만들어 메일을 보내는 코드입니다.

```java
 public MailResponseDTO.verifyResponseDTO verifyAuthenticationCode(String clientId, String authenticationCode) {
        if (memberAuthenticationCodeMap.get(clientId).equals(authenticationCode)){
            return MailResponseDTO.verifyResponseDTO.builder()
                    .isVerified(true)
                    .message("성공입니다")
                    .build();
        }
        return MailResponseDTO.verifyResponseDTO.builder()
                .isVerified(false)
                .message("인증 코드가 일치하지 않습니다")
                .build();
    }


```
메일로 보낸 인증코드와 사용자가 보낸 코드의 일치여부를 판단하는 메소드 입니다.

Response는 다음과 같습니다.
```java
    @AllArgsConstructor
    @NoArgsConstructor
    @Getter
    @Builder
    public static class verifyResponseDTO{
        private String message;
        private Boolean isVerified;
    }
```

## 동작 확인

![image](https://github.com/user-attachments/assets/9743ce92-ae76-485f-928c-a20b4b298290)


![image](https://github.com/user-attachments/assets/cb0028cd-9bb1-4e5e-9e85-a70a6a34a102)


## 💬 리뷰 요구사항(선택)

도메인의 역할이 단순해서 멤버 도메인에 포함시킬까 고민했습니다.

역할이 많지 않아 Converter를 적용하지 않았는데 적용하라고 하면 하겠습니다!!

추후에 Redis를 사용해볼까 고민중입니다!

