### PR TITLE
[COZY-252] feat: 일치율 계산 관련 Util 분리, 성격 일치율 계산에서 제거

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -4,6 +4,7 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat.MemberStatBuilder;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatRequestDTO.MemberStatCommandRequestDTO;
+import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
 import com.cozymate.cozymate_server.domain.university.University;
 import com.cozymate.cozymate_server.global.utils.TimeUtil;
@@ -87,5 +88,15 @@ public class MemberStatConverter {
             .build();
     }
 
-
+    public static MemberStatEqualityResponseDTO toEqualityDto(MemberStat memberStat, int equality){
+        return MemberStatEqualityResponseDTO.builder()
+            .memberId(memberStat.getMember().getId())
+            .memberAge(TimeUtil.calculateAge(memberStat.getMember().getBirthDay()))
+            .memberName(memberStat.getMember().getName())
+            .memberNickName(memberStat.getMember().getNickname())
+            .memberPersona(memberStat.getMember().getPersona())
+            .numOfRoommate(memberStat.getNumOfRoommate())
+            .equality(equality)
+            .build();
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -31,7 +31,6 @@ public class MemberStatQueryService {
     private final MemberStatRepository memberStatRepository;
     private final MemberRepository memberRepository;
 
-    private MemberStatConverter memberStatConverter;
 
 
     public MemberStatQueryResponseDTO getMemberStat(Member member) {
@@ -85,9 +84,9 @@ public class MemberStatQueryService {
         if (needsDetail) {
             List<MemberStatEqualityDetailResponseDTO> result = filteredResult.stream()
                 .map(memberStat -> {
-                    MemberStatEqualityResponseDTO equalityResponse = MemberUtil.toEqualityResponse(
-                        criteriaMemberStat, memberStat);
-                    MemberStatQueryResponseDTO queryResponse = memberStatConverter.toDto(
+                    MemberStatEqualityResponseDTO equalityResponse = MemberStatConverter.toEqualityDto(memberStat, MemberUtil.calculateScore(
+                        criteriaMemberStat, memberStat));
+                    MemberStatQueryResponseDTO queryResponse = MemberStatConverter.toDto(
                         memberStat, memberStat.getMember().getBirthDay().getYear());
                     return MemberStatEqualityDetailResponseDTO.builder()
                         .info(equalityResponse)
@@ -104,7 +103,7 @@ public class MemberStatQueryService {
 
         List<MemberStatEqualityResponseDTO> result = filteredResult
             .stream()
-            .map(memberStat -> MemberUtil.toEqualityResponse(criteriaMemberStat, memberStat))
+            .map(memberStat -> MemberStatConverter.toEqualityDto(memberStat,MemberUtil.calculateScore(criteriaMemberStat, memberStat)))
             .sorted(Comparator.comparingInt(MemberStatEqualityResponseDTO::getEquality).reversed())
             .toList();
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberUtil.java
@@ -8,14 +8,14 @@ public class MemberUtil {
 
     private static final Integer ADDITIONAL_SCORE = 12;
     private static final Integer NO_SCORE = 0;
-    private static final Integer ATTRIBUTE_COUNT = 20;
+    private static final Integer ATTRIBUTE_COUNT = 19;
     private static final Integer HALF_DIVISION = 2;
     private static final Integer QUARTER_DIVISION = 4;
     private static final Integer MULTIPLIER_FOR_PERCENTAGE = 100;
     private static final Integer MAX_SCORE = ADDITIONAL_SCORE * ATTRIBUTE_COUNT;
 
-
-    public static MemberStatEqualityResponseDTO toEqualityResponse(MemberStat criteriaMemberStat,
+    // 두 사용자간 일치율을 비교해야 할 때, 사용하는 util
+    public static int calculateScore(MemberStat criteriaMemberStat,
         MemberStat memberStat) {
 
         int score = NO_SCORE;
@@ -45,8 +45,6 @@ public class MemberUtil {
             ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getCleaningFrequency().equals(memberStat.getCleaningFrequency())
             ? ADDITIONAL_SCORE : NO_SCORE;
-        score += criteriaMemberStat.getPersonality().equals(memberStat.getPersonality())
-            ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getMbti().equals(memberStat.getMbti())
             ? ADDITIONAL_SCORE : NO_SCORE;
 
@@ -63,15 +61,7 @@ public class MemberUtil {
 
         double percent = (double) score / MAX_SCORE * MULTIPLIER_FOR_PERCENTAGE;
 
-        return MemberStatEqualityResponseDTO.builder()
-            .memberId(memberStat.getMember().getId())
-            .memberAge(TimeUtil.calculateAge(memberStat.getMember().getBirthDay()))
-            .memberName(memberStat.getMember().getName())
-            .memberNickName(memberStat.getMember().getNickname())
-            .memberPersona(memberStat.getMember().getPersona())
-            .numOfRoommate(memberStat.getNumOfRoommate())
-            .equality((int) percent)
-            .build();
+        return (int) percent;
     }
 
 


### PR DESCRIPTION
## #️⃣ 요약 설명

다른 도메인에서 사용자 일치율이 사용되는 것 같아, 다른 곳에서 사용할 수 있도록 분리했습니다.
또한 저번 회의에서 반영된 일치율에서 성격을 제거하는 부분을 수정했습니다.

## 📝 작업 내용

toEqualityResponse static 클래스를 calculateScore로 바꾸고, 일치율을 int로 리턴하게 바꿨습니다.

toEqualityResponse에서 Dto를 리턴했었는데, 이를 Converter로 옮겼습니다.

코드도 옮긴거 밖에 없어서 따로 작성하지 않겠습니다.

## 동작 확인

![image](https://github.com/user-attachments/assets/cbcc3be0-faa9-4920-b8af-16bfd3d2d69b)

잘 작동하는 것을 확인했습니다.

## 💬 리뷰 요구사항(선택)

>  방 관련 도메인에서 해당 기능을 사용해야할 거 같아, 인지하고 계시면 되겠습니다. @suuu0719
