### PR TITLE
[COZY-260] feat : 유저 차단 기능 구현

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/controller/ChatController.java
@@ -38,8 +38,9 @@ public class ChatController {
         @Valid @RequestBody ChatRequestDto chatRequestDto, @PathVariable Long recipientId,
         @AuthenticationPrincipal
         MemberDetails memberDetails) {
-        return ResponseEntity.ok(ApiResponse.onSuccess(chatCommandService.createChat(chatRequestDto, memberDetails.getMember(),
-            recipientId)));
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+            chatCommandService.createChat(chatRequestDto, memberDetails.getMember(),
+                recipientId)));
     }
 
     @GetMapping("/chatrooms/{chatRoomId}")
@@ -52,6 +53,7 @@ public class ChatController {
         @AuthenticationPrincipal MemberDetails memberDetails,
         @PathVariable Long chatRoomId) {
         return ResponseEntity.ok(
-            ApiResponse.onSuccess(chatQueryService.getChatList(memberDetails.getMember(), chatRoomId)));
+            ApiResponse.onSuccess(
+                chatQueryService.getChatList(memberDetails.getMember(), chatRoomId)));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/repository/ChatRoomRepository.java
@@ -10,14 +10,18 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    @Query("select cr from ChatRoom cr "
-        + "where (cr.memberA = :sender and cr.memberB = :recipient) "
-        + "or (cr.memberA = :recipient and cr.memberB = :sender)")
+    @Query("""
+       select cr from ChatRoom cr
+       where (cr.memberA = :sender and cr.memberB = :recipient)
+       or (cr.memberA = :recipient and cr.memberB = :sender)
+      """)
     Optional<ChatRoom> findByMemberAAndMemberB(@Param("sender") Member sender,
         @Param("recipient") Member recipient);
 
-    @Query("select cr from ChatRoom cr "
-        + "where (cr.memberA = :member and cr.memberB not in (select mb.blockedMember from MemberBlock mb where mb.member = :member)) "
-        + "or (cr.memberB = :member and cr.memberA not in (select mb.blockedMember from MemberBlock mb where mb.member = :member))")
+    @Query("""
+       select cr from ChatRoom cr
+       where (cr.memberA = :member and cr.memberB not in (select mb.blockedMember from MemberBlock mb where mb.member = :member))
+       or (cr.memberB = :member and cr.memberA not in (select mb.blockedMember from MemberBlock mb where mb.member = :member))
+        """)
     List<ChatRoom> findAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/repository/ChatRoomRepository.java
@@ -10,10 +10,14 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    @Query("select cr from ChatRoom cr where (cr.memberA = :sender and cr.memberB = :recipient) or (cr.memberA = :recipient and cr.memberB = :sender)")
+    @Query("select cr from ChatRoom cr "
+        + "where (cr.memberA = :sender and cr.memberB = :recipient) "
+        + "or (cr.memberA = :recipient and cr.memberB = :sender)")
     Optional<ChatRoom> findByMemberAAndMemberB(@Param("sender") Member sender,
         @Param("recipient") Member recipient);
 
-    @Query("select cr from ChatRoom cr where cr.memberA = :member or cr.memberB = :member")
+    @Query("select cr from ChatRoom cr "
+        + "where (cr.memberA = :member and cr.memberB not in (select mb.blockedMember from MemberBlock mb where mb.member = :member)) "
+        + "or (cr.memberB = :member and cr.memberA not in (select mb.blockedMember from MemberBlock mb where mb.member = :member))")
     List<ChatRoom> findAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/MemberBlock.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/MemberBlock.java
@@ -1,0 +1,34 @@
+package com.cozymate.cozymate_server.domain.memberblock;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.global.utils.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity
+public class MemberBlock extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    // 차단 당한 멤버
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member blockedMember;
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/controller/MemberBlockController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/controller/MemberBlockController.java
@@ -32,7 +32,7 @@ public class MemberBlockController {
     @PostMapping
     @Operation(summary = "[베로] 멤버 차단", description = "body에 차단할 멤버 id")
     @SwaggerApiError({
-        ErrorStatus._CANNOT_BLOCK_OWN,
+        ErrorStatus._CANNOT_BLOCK_SELF,
         ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._ALREADY_BLOCKED_MEMBER
     })
@@ -53,9 +53,10 @@ public class MemberBlockController {
 
     @DeleteMapping("/{memberId}")
     @Operation(summary = "[베로] 멤버 차단 해제", description = "path에 차단 해제할 멤버 id")
-    @SwaggerApiError(
+    @SwaggerApiError({
+        ErrorStatus._CANNOT_BLOCK_SELF,
         ErrorStatus._ALREADY_NOT_BLOCKED_MEMBER
-    )
+    })
     public ResponseEntity<ApiResponse<String>> deleteMemberBlock(@PathVariable Long memberId,
         @AuthenticationPrincipal MemberDetails memberDetails
     ) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/controller/MemberBlockController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/controller/MemberBlockController.java
@@ -1,0 +1,65 @@
+package com.cozymate.cozymate_server.domain.memberblock.controller;
+
+import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
+import com.cozymate.cozymate_server.domain.memberblock.dto.MemberBlockRequestDto;
+import com.cozymate.cozymate_server.domain.memberblock.dto.MemberBlockResponseDto;
+import com.cozymate.cozymate_server.domain.memberblock.service.MemberBlockCommandService;
+import com.cozymate.cozymate_server.domain.memberblock.service.MemberBlockQueryService;
+import com.cozymate.cozymate_server.global.response.ApiResponse;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/block/member")
+public class MemberBlockController {
+
+    private final MemberBlockCommandService memberBlockCommandService;
+    private final MemberBlockQueryService memberBlockQueryService;
+
+    @PostMapping
+    @Operation(summary = "[베로] 멤버 차단", description = "body에 차단할 멤버 id")
+    @SwaggerApiError({
+        ErrorStatus._CANNOT_BLOCK_OWN,
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._ALREADY_BLOCKED_MEMBER
+    })
+    public ResponseEntity<ApiResponse<String>> saveMemberBlock(
+        @RequestBody MemberBlockRequestDto requestDto,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        memberBlockCommandService.saveMemberBlock(requestDto, memberDetails.getMember());
+        return ResponseEntity.ok(ApiResponse.onSuccess("차단 완료"));
+    }
+
+    @GetMapping
+    @Operation(summary = "[베로] 멤버 차단 목록 조회", description = "")
+    public ResponseEntity<ApiResponse<List<MemberBlockResponseDto>>> getMemberBlockList(
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+            memberBlockQueryService.getMemberBlockList(memberDetails.getMember())));
+    }
+
+    @DeleteMapping("/{memberId}")
+    @Operation(summary = "[베로] 멤버 차단 해제", description = "path에 차단 해제할 멤버 id")
+    @SwaggerApiError(
+        ErrorStatus._ALREADY_NOT_BLOCKED_MEMBER
+    )
+    public ResponseEntity<ApiResponse<String>> deleteMemberBlock(@PathVariable Long memberId,
+        @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        memberBlockCommandService.deleteMemberBlock(memberId, memberDetails.getMember());
+        return ResponseEntity.ok(ApiResponse.onSuccess("차단 해제 완료"));
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/converter/MemberBlockConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/converter/MemberBlockConverter.java
@@ -1,0 +1,22 @@
+package com.cozymate.cozymate_server.domain.memberblock.converter;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.memberblock.MemberBlock;
+import com.cozymate.cozymate_server.domain.memberblock.dto.MemberBlockResponseDto;
+
+public class MemberBlockConverter {
+
+    public static MemberBlock toEntity(Member member, Member blockedMember) {
+        return MemberBlock.builder()
+            .member(member)
+            .blockedMember(blockedMember)
+            .build();
+    }
+
+    public static MemberBlockResponseDto toResponseDto(Member blockedMember) {
+        return MemberBlockResponseDto.builder()
+            .memberId(blockedMember.getId())
+            .nickname(blockedMember.getNickname())
+            .build();
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/dto/MemberBlockRequestDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/dto/MemberBlockRequestDto.java
@@ -1,0 +1,9 @@
+package com.cozymate.cozymate_server.domain.memberblock.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberBlockRequestDto {
+
+    private Long blockedMemberId;
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/dto/MemberBlockResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/dto/MemberBlockResponseDto.java
@@ -1,0 +1,13 @@
+package com.cozymate.cozymate_server.domain.memberblock.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberBlockResponseDto {
+
+    private Long memberId;
+    private String nickname;
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/repository/MemberBlockRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/repository/MemberBlockRepository.java
@@ -1,0 +1,15 @@
+package com.cozymate.cozymate_server.domain.memberblock.repository;
+
+import com.cozymate.cozymate_server.domain.memberblock.MemberBlock;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberBlockRepository extends JpaRepository<MemberBlock, Long> {
+
+    boolean existsByMemberIdAndBlockedMemberId(Long memberId, Long blockedMemberId);
+
+    Optional<MemberBlock> findByMemberIdAndBlockedMemberId(Long memberId, Long blockedMemberId);
+
+    List<MemberBlock> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/service/MemberBlockCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/service/MemberBlockCommandService.java
@@ -21,10 +21,7 @@ public class MemberBlockCommandService {
     private final MemberRepository memberRepository;
 
     public void saveMemberBlock(MemberBlockRequestDto requestDto, Member member) {
-        if (requestDto.getBlockedMemberId().equals(member.getId())) {
-            throw new GeneralException(ErrorStatus._CANNOT_BLOCK_OWN);
-        }
-
+        checkBlockSelf(requestDto.getBlockedMemberId(), member.getId());
         checkDuplicatedBlock(requestDto, member);
 
         Member blockedMember = memberRepository.findById(requestDto.getBlockedMemberId())
@@ -36,11 +33,19 @@ public class MemberBlockCommandService {
     }
 
     public void deleteMemberBlock(Long blockedMemberId, Member member) {
+        checkBlockSelf(blockedMemberId, member.getId());
+
         MemberBlock memberBlock = memberBlockRepository.findByMemberIdAndBlockedMemberId(
                 member.getId(), blockedMemberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._ALREADY_NOT_BLOCKED_MEMBER));
 
         memberBlockRepository.delete(memberBlock);
+    }
+
+    private void checkBlockSelf(Long blockedMemberId, Long memberId) {
+        if (blockedMemberId.equals(memberId)) {
+            throw new GeneralException(ErrorStatus._CANNOT_BLOCK_SELF);
+        }
     }
 
     private void checkDuplicatedBlock(MemberBlockRequestDto requestDto, Member member) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/service/MemberBlockCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/service/MemberBlockCommandService.java
@@ -1,0 +1,54 @@
+package com.cozymate.cozymate_server.domain.memberblock.service;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
+import com.cozymate.cozymate_server.domain.memberblock.MemberBlock;
+import com.cozymate.cozymate_server.domain.memberblock.converter.MemberBlockConverter;
+import com.cozymate.cozymate_server.domain.memberblock.dto.MemberBlockRequestDto;
+import com.cozymate.cozymate_server.domain.memberblock.repository.MemberBlockRepository;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberBlockCommandService {
+
+    private final MemberBlockRepository memberBlockRepository;
+    private final MemberRepository memberRepository;
+
+    public void saveMemberBlock(MemberBlockRequestDto requestDto, Member member) {
+        if (requestDto.getBlockedMemberId().equals(member.getId())) {
+            throw new GeneralException(ErrorStatus._CANNOT_BLOCK_OWN);
+        }
+
+        checkDuplicatedBlock(requestDto, member);
+
+        Member blockedMember = memberRepository.findById(requestDto.getBlockedMemberId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        MemberBlock memberBlock = MemberBlockConverter.toEntity(member, blockedMember);
+
+        memberBlockRepository.save(memberBlock);
+    }
+
+    public void deleteMemberBlock(Long blockedMemberId, Member member) {
+        MemberBlock memberBlock = memberBlockRepository.findByMemberIdAndBlockedMemberId(
+                member.getId(), blockedMemberId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._ALREADY_NOT_BLOCKED_MEMBER));
+
+        memberBlockRepository.delete(memberBlock);
+    }
+
+    private void checkDuplicatedBlock(MemberBlockRequestDto requestDto, Member member) {
+        boolean alreadyBlocked = memberBlockRepository.existsByMemberIdAndBlockedMemberId(member.getId(),
+            requestDto.getBlockedMemberId());
+
+        if (alreadyBlocked) {
+            throw new GeneralException(ErrorStatus._ALREADY_BLOCKED_MEMBER);
+        }
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberblock/service/MemberBlockQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberblock/service/MemberBlockQueryService.java
@@ -1,0 +1,35 @@
+package com.cozymate.cozymate_server.domain.memberblock.service;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.memberblock.MemberBlock;
+import com.cozymate.cozymate_server.domain.memberblock.converter.MemberBlockConverter;
+import com.cozymate.cozymate_server.domain.memberblock.dto.MemberBlockResponseDto;
+import com.cozymate.cozymate_server.domain.memberblock.repository.MemberBlockRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberBlockQueryService {
+
+    private final MemberBlockRepository memberBlockRepository;
+
+    public List<MemberBlockResponseDto> getMemberBlockList(Member member) {
+        List<MemberBlock> memberBlockList = memberBlockRepository.findByMemberId(member.getId());
+
+        if (memberBlockList.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<MemberBlockResponseDto> memberBlockResponseDtoList = memberBlockList.stream()
+            .map(memberBlock -> MemberBlockConverter.toResponseDto(memberBlock.getBlockedMember()))
+            .toList();
+
+        return memberBlockResponseDtoList;
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -106,6 +106,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Post Comment 
     _POST_COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT400", "댓글이 존재하지 않습니다."),
+
+    // MemberBlock 관련
+    _ALREADY_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK400", "이미 차단된 사용자입니다."),
+    _CANNOT_BLOCK_OWN(HttpStatus.BAD_REQUEST, "MEMBERBLOCK401", "자신을 차단할 수 없습니다."),
+    _ALREADY_NOT_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK402", "이미 차단되지 않은 사용자입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -109,7 +109,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // MemberBlock 관련
     _ALREADY_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK400", "이미 차단된 사용자입니다."),
-    _CANNOT_BLOCK_OWN(HttpStatus.BAD_REQUEST, "MEMBERBLOCK401", "자신을 차단할 수 없습니다."),
+    _CANNOT_BLOCK_SELF(HttpStatus.BAD_REQUEST, "MEMBERBLOCK401", "자신에 대해 차단 관련 요청을 할 수 없습니다."),
     _ALREADY_NOT_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK402", "이미 차단되지 않은 사용자입니다."),
     ;
 


### PR DESCRIPTION
## #️⃣ 요약 설명
화면은 아직 안나왔지만,
1. 차단, 차단 해제, 차단 목록 조회를 구현했습니다.

2. 쪽지방 목록 조회에 차단에 대한 처리를 추가했습니다.

## 📝 작업 내용

> ex) 코드의 흐름이나 중요한 부분을 작성해주세요.
> ex) 기존 calculate 함수의 버그를 수정했습니다.

```java
// MemberBlockCommandService.java (차단)
public void saveMemberBlock(MemberBlockRequestDto requestDto, Member member) {
        // 1
        if (requestDto.getBlockedMemberId().equals(member.getId())) {
            throw new GeneralException(ErrorStatus._CANNOT_BLOCK_OWN);
        }
        // 2
        checkDuplicatedBlock(requestDto, member);
        // 3
        Member blockedMember = memberRepository.findById(requestDto.getBlockedMemberId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
        // 4
        MemberBlock memberBlock = MemberBlockConverter.toEntity(member, blockedMember);

        memberBlockRepository.save(memberBlock);
    }

private void checkDuplicatedBlock(MemberBlockRequestDto requestDto, Member member) {
        boolean alreadyBlocked = memberBlockRepository.existsByMemberIdAndBlockedMemberId(member.getId(),
            requestDto.getBlockedMemberId());

        if (alreadyBlocked) {
            throw new GeneralException(ErrorStatus._ALREADY_BLOCKED_MEMBER);
        }
    }
```
1. 본인 id와 차단 대상 유저 id가 동일한 경우 예외처리
2. 이미 차단된 유저인 경우 예외처리
3. 차단 대상 유저 조회, 없으면 예외처리
4. MemberBlock 테이블에 저장

---

```java
// MemberBlockCommandService.java (차단 해제)
    public void deleteMemberBlock(Long blockedMemberId, Member member) {
        // 1
        MemberBlock memberBlock = memberBlockRepository.findByMemberIdAndBlockedMemberId(
                member.getId(), blockedMemberId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._ALREADY_NOT_BLOCKED_MEMBER));
        // 2
        memberBlockRepository.delete(memberBlock);
    }
```
1. 이미 차단이 아닌 경우 예외처리
2. 차단 해제

---

```java
// MemberBlockQueryService.java (차단 유저 목록 조회)
    public List<MemberBlockResponseDto> getMemberBlockList(Member member) {
        List<MemberBlock> memberBlockList = memberBlockRepository.findByMemberId(member.getId());

        if (memberBlockList.isEmpty()) {
            return new ArrayList<>();
        }

        List<MemberBlockResponseDto> memberBlockResponseDtoList = memberBlockList.stream()
            .map(memberBlock -> MemberBlockConverter.toResponseDto(memberBlock.getBlockedMember()))
            .toList();

        return memberBlockResponseDtoList;
    }
```

---

```java
// ChatRoomRepository.java (쪽지방 목록 조회 쿼리 수정)
    @Query("select cr from ChatRoom cr "
        + "where (cr.memberA = :member and cr.memberB not in (select mb.blockedMember from MemberBlock mb where mb.member = :member)) "
        + "or (cr.memberB = :member and cr.memberA not in (select mb.blockedMember from MemberBlock mb where mb.member = :member))")
    List<ChatRoom> findAllByMember(@Param("member") Member member);
```
쪽지방 목록 조회에서 차단된 유저에 대한 처리를 위해
not in (서브쿼리)를 추가해서 차단한 유저가 아닌 조건을 추가했습니다.
## 동작 확인

차단 전 쪽지방 목록 조회
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2e4d68f4-5327-44ac-92cb-63d625fb3b40">

memberId 5번 포비를 차단
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f0249eac-10b6-4090-9e8c-6ab81f049afb">

차단 후 쪽지방 목록 조회 - 포비와의 쪽지방이 목록에서 사라짐
<img width="300" alt="image" src="https://github.com/user-attachments/assets/512caee3-b599-4dba-970e-ca6dae80d13c">

memberId 3번 말즈도 차단
<img width="400" alt="image" src="https://github.com/user-attachments/assets/60c988c3-5a8a-4306-a35c-7fc41297c2bb">

차단 후 쪽지방 목록 조회 - 말즈와의 쪽지방도 목록에서 사라짐
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e75684a0-576c-4ada-8e6d-e3baa8617978">

차단 유저 목록 조회
<img width="282" alt="image" src="https://github.com/user-attachments/assets/e36b627e-e044-4b64-aa8a-823a49e832a2">

말즈 포비 차단 해제
<img width="281" alt="image" src="https://github.com/user-attachments/assets/4066e5ab-bc01-460f-9890-b5b4267653ea">
<img width="277" alt="image" src="https://github.com/user-attachments/assets/1225199a-0962-4f69-8e35-23fea847616e">

차단 해제 후 쪽지방 목록 다시 조회 - 포비, 말즈 쪽지방이 목록에서 조회됌
<img width="300" alt="image" src="https://github.com/user-attachments/assets/55169569-63af-48b8-96d5-e2efe7a3fa9e">

차단 유저 목록
<img width="276" alt="image" src="https://github.com/user-attachments/assets/3a3d047b-3c9e-4a78-a671-7e53946beb0f">

---
예외처리 1
<img width="300" alt="image" src="https://github.com/user-attachments/assets/93bc1c34-5349-4e01-b946-5e60c30960e4">

예외처리 2
<img width="300" alt="image" src="https://github.com/user-attachments/assets/06db3f21-033f-409f-af3d-6bfbe518b4ff">

예외처리 3
<img width="300" alt="image" src="https://github.com/user-attachments/assets/74b2cc71-418e-4553-a41a-0b5deb7a0eeb">

예외처리 4
<img width="300" alt="image" src="https://github.com/user-attachments/assets/6e22beae-c349-40d6-88f3-7e8e999ba5f2">





## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

차단 정책이 확정은 아니라서 변경되면 수정하겠습니다~
