### PR TITLE
[COZY-36] Rule 관련 전체 기능 리팩토링

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/Rule.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/Rule.java
@@ -35,12 +35,9 @@ public class Rule extends BaseTimeEntity {
     @Column(length = 40)
     private String memo;
 
+    // 메모가 nullable이라, 수정할 때 그냥 값을 덮어씌우도록 구성
     public void updateEntity(String content, String memo) {
-        if(content != null) {
             this.content = content;
-        }
-        if(memo != null) {
             this.memo = memo;
-        }
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/Rule.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/Rule.java
@@ -34,4 +34,13 @@ public class Rule extends BaseTimeEntity {
 
     @Column(length = 40)
     private String memo;
+
+    public void updateEntity(String content, String memo) {
+        if(content != null) {
+            this.content = content;
+        }
+        if(memo != null) {
+            this.memo = memo;
+        }
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/controller/RuleController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/controller/RuleController.java
@@ -19,7 +19,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -119,7 +118,8 @@ public class RuleController {
     @Operation(
         summary = "[무빗] 특정 Rule 수정",
         description = "rule의 고유 번호로 수정이 가능합니다.")
-    @SwaggerApiError({})
+    @SwaggerApiError({ErrorStatus._RULE_NOT_FOUND, ErrorStatus._RULE_MATE_MISMATCH,
+        ErrorStatus._MATE_OR_ROOM_NOT_FOUND})
     public ResponseEntity<ApiResponse<String>> updateRule(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @PathVariable @Positive Long roomId,

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/controller/RuleController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/controller/RuleController.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.rule.controller;
 
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleRequestDto.CreateRuleRequestDto;
+import com.cozymate.cozymate_server.domain.rule.dto.RuleRequestDto.UpdateRuleRequestDto;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleResponseDto.CreateRuleResponseDto;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleResponseDto.RuleDetailResponseDto;
 import com.cozymate.cozymate_server.domain.rule.service.RuleCommandService;
@@ -35,10 +36,9 @@ public class RuleController {
 
     /**
      * 특정 방의 Rule 생성
-     *
-     * @param memberDetails        사용자
-     * @param roomId               Rule을 생성하려는 방 Id
-     * @param createRuleRequestDto 생성할 Rule 데이터
+     * @param memberDetails 사용자
+     * @param roomId        Rule을 생성하려는 방 Id
+     * @param requestDto    생성할 Rule 데이터
      * @return String 성공 메시지 반환
      */
     @PostMapping("/{roomId}")
@@ -49,18 +49,17 @@ public class RuleController {
     public ResponseEntity<ApiResponse<CreateRuleResponseDto>> createRule(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @PathVariable @Positive Long roomId,
-        @Valid @RequestBody CreateRuleRequestDto createRuleRequestDto
+        @RequestBody @Valid CreateRuleRequestDto requestDto
     ) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
             ruleCommandService.createRule(
-                memberDetails.getMember(), roomId, createRuleRequestDto
+                memberDetails.getMember(), roomId, requestDto
             )
         ));
     }
 
     /**
      * 특정 방의 Rule 목록 조회
-     *
      * @param memberDetails 사용자
      * @param roomId        Rule 목록을 조회하려는 방
      * @return List<RuleDetailResponseDto> Rule 목록 반환
@@ -81,7 +80,6 @@ public class RuleController {
 
     /**
      * 특정 방의 특정 Rule 삭제
-     *
      * @param memberDetails 사용자
      * @param roomId        삭제하려는 Rule이 속한 방 Id
      * @param ruleId        삭제하려는 Rule Id
@@ -106,7 +104,6 @@ public class RuleController {
 
     /**
      * 특정 Rule 수정
-     *
      * @param memberDetails 사용자
      * @param roomId        수정하고자 하는 rule이 속한 방의 고유 번호
      * @param ruleId        수정하고자 하는 rule의 고유 번호
@@ -117,11 +114,13 @@ public class RuleController {
         summary = "[무빗] 특정 Rule 수정",
         description = "rule의 고유 번호로 수정이 가능합니다.")
     @SwaggerApiError({})
-    public ResponseEntity<ApiResponse<String>> patchRule(
+    public ResponseEntity<ApiResponse<String>> updateRule(
         @AuthenticationPrincipal MemberDetails memberDetails,
-        @PathVariable Long roomId,
-        @PathVariable Long ruleId
+        @PathVariable @Positive Long roomId,
+        @PathVariable @Positive Long ruleId,
+        @RequestBody @Valid UpdateRuleRequestDto requestDto
     ) {
+        ruleCommandService.updateRule(memberDetails.getMember(), roomId, ruleId, requestDto);
         return ResponseEntity.ok(ApiResponse.onSuccess("수정되었습니다."));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/controller/RuleController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/controller/RuleController.java
@@ -2,7 +2,6 @@ package com.cozymate.cozymate_server.domain.rule.controller;
 
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleRequestDto.CreateRuleRequestDto;
-import com.cozymate.cozymate_server.domain.rule.dto.RuleRequestDto.UpdateRuleRequestDto;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleResponseDto.CreateRuleResponseDto;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleResponseDto.RuleDetailResponseDto;
 import com.cozymate.cozymate_server.domain.rule.service.RuleCommandService;
@@ -17,18 +16,21 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/rule")
+@RequestMapping("/rooms")
 public class RuleController {
 
     private final RuleCommandService ruleCommandService;
@@ -36,12 +38,13 @@ public class RuleController {
 
     /**
      * 특정 방의 Rule 생성
+     *
      * @param memberDetails 사용자
      * @param roomId        Rule을 생성하려는 방 Id
      * @param requestDto    생성할 Rule 데이터
      * @return String 성공 메시지 반환
      */
-    @PostMapping("/{roomId}")
+    @PostMapping("/{roomId}/rules")
     @Operation(
         summary = "[무빗] 특정 방의 Rule 생성",
         description = "rule 내용은 필수, memo는 선택입니다.")
@@ -60,11 +63,12 @@ public class RuleController {
 
     /**
      * 특정 방의 Rule 목록 조회
+     *
      * @param memberDetails 사용자
      * @param roomId        Rule 목록을 조회하려는 방
      * @return List<RuleDetailResponseDto> Rule 목록 반환
      */
-    @GetMapping("/{roomId}")
+    @GetMapping("/{roomId}/rules")
     @Operation(
         summary = "[무빗] 특정 방의 Rule 목록 조회",
         description = "Rule에서 memo는 null 반환이 가능합니다.")
@@ -80,12 +84,13 @@ public class RuleController {
 
     /**
      * 특정 방의 특정 Rule 삭제
+     *
      * @param memberDetails 사용자
      * @param roomId        삭제하려는 Rule이 속한 방 Id
      * @param ruleId        삭제하려는 Rule Id
      * @return String 성공 메시지 반환
      */
-    @DeleteMapping("/{roomId}/{ruleId}")
+    @DeleteMapping("/{roomId}/rules/{ruleId}")
     @Operation(
         summary = "[무빗] 특정 Rule 삭제",
         description = "rule의 고유 번호로 삭제가 가능합니다.")
@@ -104,12 +109,13 @@ public class RuleController {
 
     /**
      * 특정 Rule 수정
+     *
      * @param memberDetails 사용자
      * @param roomId        수정하고자 하는 rule이 속한 방의 고유 번호
      * @param ruleId        수정하고자 하는 rule의 고유 번호
      * @return String 성공 메시지 반환
      */
-    @PatchMapping("/{roomId}/{ruleId}")
+    @PutMapping("/{roomId}/rules/{ruleId}")
     @Operation(
         summary = "[무빗] 특정 Rule 수정",
         description = "rule의 고유 번호로 수정이 가능합니다.")
@@ -118,7 +124,7 @@ public class RuleController {
         @AuthenticationPrincipal MemberDetails memberDetails,
         @PathVariable @Positive Long roomId,
         @PathVariable @Positive Long ruleId,
-        @RequestBody @Valid UpdateRuleRequestDto requestDto
+        @RequestBody @Valid CreateRuleRequestDto requestDto
     ) {
         ruleCommandService.updateRule(memberDetails.getMember(), roomId, ruleId, requestDto);
         return ResponseEntity.ok(ApiResponse.onSuccess("수정되었습니다."));

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/controller/RuleController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/controller/RuleController.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.rule.controller;
 
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleRequestDto.CreateRuleRequestDto;
+import com.cozymate.cozymate_server.domain.rule.dto.RuleResponseDto.CreateRuleResponseDto;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleResponseDto.RuleDetailResponseDto;
 import com.cozymate.cozymate_server.domain.rule.service.RuleCommandService;
 import com.cozymate.cozymate_server.domain.rule.service.RuleQueryService;
@@ -10,17 +11,18 @@ import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,48 +33,95 @@ public class RuleController {
     private final RuleCommandService ruleCommandService;
     private final RuleQueryService ruleQueryService;
 
+    /**
+     * 특정 방의 Rule 생성
+     *
+     * @param memberDetails        사용자
+     * @param roomId               Rule을 생성하려는 방 Id
+     * @param createRuleRequestDto 생성할 Rule 데이터
+     * @return String 성공 메시지 반환
+     */
     @PostMapping("/{roomId}")
     @Operation(
         summary = "[무빗] 특정 방의 Rule 생성",
         description = "rule 내용은 필수, memo는 선택입니다.")
     @SwaggerApiError({ErrorStatus._MATE_OR_ROOM_NOT_FOUND, ErrorStatus._RULE_OVER_MAX})
-    public ResponseEntity<ApiResponse<String>> createRule(
+    public ResponseEntity<ApiResponse<CreateRuleResponseDto>> createRule(
         @AuthenticationPrincipal MemberDetails memberDetails,
-        @PathVariable Long roomId,
+        @PathVariable @Positive Long roomId,
         @Valid @RequestBody CreateRuleRequestDto createRuleRequestDto
     ) {
-        ruleCommandService.createRule(memberDetails.getMember(), roomId, createRuleRequestDto);
-        return ResponseEntity.ok(ApiResponse.onSuccess("규칙 생성에 성공했습니다."));
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+            ruleCommandService.createRule(
+                memberDetails.getMember(), roomId, createRuleRequestDto
+            )
+        ));
     }
 
+    /**
+     * 특정 방의 Rule 목록 조회
+     *
+     * @param memberDetails 사용자
+     * @param roomId        Rule 목록을 조회하려는 방
+     * @return List<RuleDetailResponseDto> Rule 목록 반환
+     */
     @GetMapping("/{roomId}")
     @Operation(
         summary = "[무빗] 특정 방의 Rule 목록 조회",
         description = "Rule에서 memo는 null 반환이 가능합니다.")
-    @SwaggerApiError({ErrorStatus._MATE_OR_ROOM_NOT_FOUND, ErrorStatus._RULE_NOT_FOUND,
-        ErrorStatus._RULE_MATE_MISMATCH})
+    @SwaggerApiError({ErrorStatus._MATE_OR_ROOM_NOT_FOUND})
     public ResponseEntity<ApiResponse<List<RuleDetailResponseDto>>> getRuleList(
         @AuthenticationPrincipal MemberDetails memberDetails,
-        @PathVariable Long roomId
+        @PathVariable @Positive Long roomId
     ) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
-            ruleQueryService.getRule(roomId, memberDetails.getMember())
+            ruleQueryService.getRule(memberDetails.getMember(), roomId)
         ));
     }
 
-    @DeleteMapping("/{roomId}")
+    /**
+     * 특정 방의 특정 Rule 삭제
+     *
+     * @param memberDetails 사용자
+     * @param roomId        삭제하려는 Rule이 속한 방 Id
+     * @param ruleId        삭제하려는 Rule Id
+     * @return String 성공 메시지 반환
+     */
+    @DeleteMapping("/{roomId}/{ruleId}")
     @Operation(
-        summary = "[무빗] 특정 방의 특정 Rule 삭제",
+        summary = "[무빗] 특정 Rule 삭제",
         description = "rule의 고유 번호로 삭제가 가능합니다.")
     @SwaggerApiError({ErrorStatus._MATE_OR_ROOM_NOT_FOUND, ErrorStatus._RULE_NOT_FOUND,
         ErrorStatus._RULE_MATE_MISMATCH})
     public ResponseEntity<ApiResponse<String>> deleteRule(
         @AuthenticationPrincipal MemberDetails memberDetails,
-        @PathVariable Long roomId,
-        @RequestParam Long ruleId
+        @PathVariable @Positive Long roomId,
+        @PathVariable @Positive Long ruleId
     ) {
         ruleCommandService.deleteRule(memberDetails.getMember(), roomId, ruleId);
         return ResponseEntity.ok(ApiResponse.onSuccess("삭제되었습니다."));
     }
 
+    // TODO: Rule 수정 API 추가
+
+    /**
+     * 특정 Rule 수정
+     *
+     * @param memberDetails 사용자
+     * @param roomId        수정하고자 하는 rule이 속한 방의 고유 번호
+     * @param ruleId        수정하고자 하는 rule의 고유 번호
+     * @return String 성공 메시지 반환
+     */
+    @PatchMapping("/{roomId}/{ruleId}")
+    @Operation(
+        summary = "[무빗] 특정 Rule 수정",
+        description = "rule의 고유 번호로 수정이 가능합니다.")
+    @SwaggerApiError({})
+    public ResponseEntity<ApiResponse<String>> patchRule(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @PathVariable Long roomId,
+        @PathVariable Long ruleId
+    ) {
+        return ResponseEntity.ok(ApiResponse.onSuccess("수정되었습니다."));
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleRequestDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleRequestDto.java
@@ -1,15 +1,12 @@
 package com.cozymate.cozymate_server.domain.rule.dto;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 public class RuleRequestDto {
 
-    @RequiredArgsConstructor
     @Getter
     public static class CreateRuleRequestDto {
 
@@ -17,6 +14,18 @@ public class RuleRequestDto {
         @Size(min = 1, max = 50, message = "규칙 내용은 1자 이상 50자 이하로 입력해주세요.")
         private String content;
 
+        @Size(max = 40, message = "메모는 40자 이하로 입력해주세요.")
+        private String memo;
+    }
+
+    @Getter
+    public static class UpdateRuleRequestDto {
+
+        @Nullable
+        @Size(min = 1, max = 50, message = "규칙 내용은 1자 이상 50자 이하로 입력해주세요.")
+        private String content;
+
+        @Nullable
         @Size(max = 40, message = "메모는 40자 이하로 입력해주세요.")
         private String memo;
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleRequestDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleRequestDto.java
@@ -1,5 +1,6 @@
 package com.cozymate.cozymate_server.domain.rule.dto;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -12,10 +13,11 @@ public class RuleRequestDto {
     @Getter
     public static class CreateRuleRequestDto {
 
-        @Size(min = 1, max = 50)
+        @NotNull(message = "규칙 내용은 필수로 입력해주세요.")
+        @Size(min = 1, max = 50, message = "규칙 내용은 1자 이상 50자 이하로 입력해주세요.")
         private String content;
 
-        @Size(max = 40)
+        @Size(max = 40, message = "메모는 40자 이하로 입력해주세요.")
         private String memo;
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleRequestDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleRequestDto.java
@@ -4,6 +4,8 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 public class RuleRequestDto {
 
@@ -14,18 +16,6 @@ public class RuleRequestDto {
         @Size(min = 1, max = 50, message = "규칙 내용은 1자 이상 50자 이하로 입력해주세요.")
         private String content;
 
-        @Size(max = 40, message = "메모는 40자 이하로 입력해주세요.")
-        private String memo;
-    }
-
-    @Getter
-    public static class UpdateRuleRequestDto {
-
-        @Nullable
-        @Size(min = 1, max = 50, message = "규칙 내용은 1자 이상 50자 이하로 입력해주세요.")
-        private String content;
-
-        @Nullable
         @Size(max = 40, message = "메모는 40자 이하로 입력해주세요.")
         private String memo;
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class RuleResponseDto {
 
     @Builder
+    @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     public static class CreateRuleResponseDto {

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/RuleResponseDto.java
@@ -10,6 +10,14 @@ import lombok.NoArgsConstructor;
 public class RuleResponseDto {
 
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CreateRuleResponseDto {
+
+            private Long id;
+    }
+
+    @Builder
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/service/RuleCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/service/RuleCommandService.java
@@ -6,6 +6,7 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.rule.Rule;
 import com.cozymate.cozymate_server.domain.rule.converter.RuleConverter;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleRequestDto.CreateRuleRequestDto;
+import com.cozymate.cozymate_server.domain.rule.dto.RuleResponseDto.CreateRuleResponseDto;
 import com.cozymate.cozymate_server.domain.rule.repository.RuleRepository;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
@@ -18,32 +19,50 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class RuleCommandService {
 
+    // Rule 최대 개수
+    private static final int MAX_RULE_COUNT = 10;
+
     private final RuleRepository ruleRepository;
     private final MateRepository mateRepository;
 
-    private static final int MAX_RULE_COUNT = 10;
+    /**
+     * Rule 생성
+     *
+     * @param member     생성 권한을 가진 사용자
+     * @param roomId     규칙을 생성하려는 방
+     * @param requestDto 규칙 내용
+     * return 생성된 규칙의 id
+     */
+    public CreateRuleResponseDto createRule(
+        Member member, Long roomId, CreateRuleRequestDto requestDto) {
+        // Mate 조회
+        Mate mate = findMateByMemberIdAndRoomId(member, roomId);
 
-    public void createRule(Member member, Long roomId, CreateRuleRequestDto requestDto) {
-        Mate mate = mateRepository.findByMemberIdAndRoomId(member.getId(), roomId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_OR_ROOM_NOT_FOUND));
+        // 규칙 최대 개수 초과 여부 확인
+        checkMaxRuleCount(roomId);
 
-        // rule 최대개수 초과 여부 판단
-        int ruleCount = ruleRepository.countAllByRoomId(roomId);
-        if (ruleCount >= MAX_RULE_COUNT) {
-            throw new GeneralException(ErrorStatus._RULE_OVER_MAX);
-        }
+        // 규칙 생성
+        Rule rule = ruleRepository.save(
+            RuleConverter.toEntity(requestDto.getContent(), requestDto.getMemo(), mate.getRoom())
+        );
 
-        ruleRepository.save(
-            RuleConverter.toEntity(requestDto.getContent(), requestDto.getMemo(), mate.getRoom()));
-
+        // 생성된 규칙의 id 반환
+        return CreateRuleResponseDto.builder().id(rule.getId()).build();
     }
 
+    /**
+     * Rule 삭제
+     * @param member 사용자
+     * @param roomId 방 Id
+     * @param ruleId 삭제할 Rule Id
+     */
     public void deleteRule(Member member, Long roomId, Long ruleId) {
-        Mate mate = mateRepository.findByMemberIdAndRoomId(member.getId(), roomId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_OR_ROOM_NOT_FOUND));
-
+        // Rule 조회
         Rule rule = ruleRepository.findById(ruleId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._RULE_NOT_FOUND));
+
+        // Mate 조회 - 해당 조회 기능을 위해 roomId가 필요함
+        Mate mate = findMateByMemberIdAndRoomId(member, roomId);
 
         // 해당 Rule을 지우려는 사람이 Rule이 속한 방에 없으면 예외처리
         if (!rule.getRoom().getId().equals(mate.getRoom().getId())) {
@@ -51,5 +70,27 @@ public class RuleCommandService {
         }
 
         ruleRepository.delete(rule);
+    }
+
+    /**
+     * Rule 최대 개수 초과 여부 확인
+     * @param roomId 확인하려는 방 Id
+     */
+    private void checkMaxRuleCount(Long roomId) {
+        int ruleCount = ruleRepository.countAllByRoomId(roomId);
+        if (ruleCount >= MAX_RULE_COUNT) {
+            throw new GeneralException(ErrorStatus._RULE_OVER_MAX);
+        }
+    }
+
+    /**
+     * Mate 조회
+     * @param member 사용자
+     * @param roomId 방 Id
+     * @return Mate
+     */
+    private Mate findMateByMemberIdAndRoomId(Member member, Long roomId) {
+        return mateRepository.findByMemberIdAndRoomId(member.getId(), roomId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_OR_ROOM_NOT_FOUND));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/service/RuleCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/service/RuleCommandService.java
@@ -6,7 +6,6 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.rule.Rule;
 import com.cozymate.cozymate_server.domain.rule.converter.RuleConverter;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleRequestDto.CreateRuleRequestDto;
-import com.cozymate.cozymate_server.domain.rule.dto.RuleRequestDto.UpdateRuleRequestDto;
 import com.cozymate.cozymate_server.domain.rule.dto.RuleResponseDto.CreateRuleResponseDto;
 import com.cozymate.cozymate_server.domain.rule.repository.RuleRepository;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
@@ -28,10 +27,10 @@ public class RuleCommandService {
 
     /**
      * Rule 생성
+     *
      * @param member     생성 권한을 가진 사용자
      * @param roomId     규칙을 생성하려는 방
-     * @param requestDto 규칙 내용
-     * return 생성된 규칙의 id
+     * @param requestDto 규칙 내용 return 생성된 규칙의 id
      */
     public CreateRuleResponseDto createRule(
         Member member, Long roomId, CreateRuleRequestDto requestDto) {
@@ -52,6 +51,7 @@ public class RuleCommandService {
 
     /**
      * Rule 삭제
+     *
      * @param member 사용자
      * @param roomId 방 Id
      * @param ruleId 삭제할 Rule Id
@@ -70,7 +70,8 @@ public class RuleCommandService {
         ruleRepository.delete(rule);
     }
 
-    public void updateRule(Member member, Long roomId, Long ruleId, UpdateRuleRequestDto requestDto) {
+    public void updateRule(Member member, Long roomId, Long ruleId,
+        CreateRuleRequestDto requestDto) {
         // Rule 조회
         Rule rule = ruleRepository.findById(ruleId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._RULE_NOT_FOUND));
@@ -87,6 +88,7 @@ public class RuleCommandService {
 
     /**
      * Rule 최대 개수 초과 여부 확인
+     *
      * @param roomId 확인하려는 방 Id
      */
     private void checkMaxRuleCount(Long roomId) {
@@ -98,6 +100,7 @@ public class RuleCommandService {
 
     /**
      * Mate 조회
+     *
      * @param member 사용자
      * @param roomId 방 Id
      * @return Mate
@@ -109,6 +112,7 @@ public class RuleCommandService {
 
     /**
      * 해당 Rule을 수정하려는 사람이 Rule이 속한 방에 없으면 예외처리
+     *
      * @param mate 룸메이트
      * @param rule 규칙
      */

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/service/RuleQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/service/RuleQueryService.java
@@ -22,13 +22,33 @@ public class RuleQueryService {
     private final RuleRepository ruleRepository;
     private final MateRepository mateRepository;
 
-    public List<RuleDetailResponseDto> getRule(Long roomId, Member member) {
-        Mate mate = mateRepository.findByMemberIdAndRoomId(member.getId(), roomId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_OR_ROOM_NOT_FOUND));
+    /**
+     * 특정 방의 Rule 목록 조회
+     *
+     * @param member 사용자
+     * @param roomId Rule을 조회하려는 방 Id
+     * @return Rule 목록
+     */
+    public List<RuleDetailResponseDto> getRule(Member member, Long roomId) {
+        // Mate 조회
+        Mate mate = findMateByMemberIdAndRoomId(member, roomId);
 
+        // Rule 목록 조회
         List<Rule> ruleList = ruleRepository.findAllByRoomId(mate.getRoom().getId());
+        // Rule 목록을 RuleDetailResponseDto로 변환하여 반환
         return ruleList.stream().map(RuleConverter::toRuleDetailResponseDto).toList();
 
+    }
+
+    /**
+     * Mate 조회
+     * @param member 사용자
+     * @param roomId 방 Id
+     * @return Mate
+     */
+    private Mate findMateByMemberIdAndRoomId(Member member, Long roomId) {
+        return mateRepository.findByMemberIdAndRoomId(member.getId(), roomId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_OR_ROOM_NOT_FOUND));
     }
 
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
1. 주석을 추가하고 분리할 수 있는 함수를 분리하였습니다.
2. Rule 수정 기능을 추가했습니다.
3. Rule 파트의 엔드포인트를 수정하였고, RESTFul할 수 있을만큼 만들어보았습니다.

## 📝 작업 내용

1. 주석을 추가하고 분리할 수 있는 함수를 분리하였습니다.
- 해당 부분은 코드를 좀 더 읽기 쉽게, 재사용 가능하도록 수정하는 리팩토링이라 코드 변경사항을 확인해주세요.

2. Rule 수정 기능을 추가했습니다.
- Rule의 값을 찾아서 데이터를 덮어씌우는 방식으로 구현했습니다.
- 수정하고자 하는 부분의 데이터만 수정하고자 했을 때 memo의 값이 nullable이라, memo의 데이터를 수정하고싶은지(null로 바꾸고 싶은지) 아니면 데이터를 수정하고싶지 않은지(그대로 두고싶은지)에 대한 판단이 애매하다고 생각했습니다.
- 따라서 프론트에서 content, memo의 값을 모두 다시 주면 해당 값을 덮어씌우는 방식으로 구성되도록 하였습니다.
- 이에 따라 PATCH 방식(일부 수정)으로 보내는 API를 PUT 방식(전체 수정)으로 보내는 API로 변경하였습니다.

3. Rule 파트의 엔드포인트를 수정하였고, RESTFul할 수 있을만큼 일부 수정해보았습니다.
- API의 Endpoint가 명확하지 않다고 느꼈고, RoomId는 항상 Mate를 구하기 위한 필수 데이터였습니다. 따라서 room에 종속되어있다고 보았고, 이에 따라 Endpoint를 계층화 하고자 하였습니다.
- 기존에 `/rules/{roomId}/{ruleId}` 의 형식에서 `/rooms/{roomId}/rules/{ruleId}`의 형식으로 수정하였고, 좀 더 API의 Endpoint에 기능의 의미를 담았다고 생각합니다.

## 동작 확인
동작 확인은 뭐 보여줄게 없는데..
<img width="924" alt="SCR-20241015-lmyr" src="https://github.com/user-attachments/assets/6ce2897d-d4df-429b-b9ec-4cdb386396a5">
<img width="645" alt="SCR-20241015-lmzq" src="https://github.com/user-attachments/assets/39f69e82-71d0-4bb1-bf9a-57c8ea974fba">
수정 요청을 보냈을 때 PATCH가 PUT으로 바뀌면서, memo의 값이 입력되지 않으면 null로 변경되게 됩니다.
이상입니다.

## 💬 리뷰 요구사항(선택)
단순 CRUD라 그렇게 어려운 부분은 없을 것이라 생각합니다.
