### PR TITLE
[COZY-281] feat: Redis 세팅 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,11 @@ dependencies {
     // spring-boot mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.4'
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cozymate/cozymate_server/global/config/SshDataSourceConfig.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/config/SshDataSourceConfig.java
@@ -10,18 +10,24 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
+@EnableJpaRepositories(basePackages = "com.cozymate.cozymate_server.domain")
 public class SshDataSourceConfig {
 
     private final SshTunnelConfig initializer;
 
     @Value("${server}")
     private String isServer;
+
     @Value("${cloud.aws.ec2.database_endpoint}")
     private String databaseEndpoint;
+    @Value("${cloud.aws.ec2.database_port}")
+    private int databasePort;
+
 
     @Bean("dataSource")
     @Primary
@@ -29,9 +35,11 @@ public class SshDataSourceConfig {
         String url = properties.getUrl().replace("localhost", databaseEndpoint);
         url = url.replace("[forwardedPort]", String.valueOf(3306));
         Integer forwardedPort = null;
+
+        // SSH 터널을 통해 RDS에 연결해야 할 경우
         if (isServer.equals("false")) {
             url = properties.getUrl(); // jdbc:mysql://localhost:[forwardedPort]/dev
-            forwardedPort = initializer.buildSshConnection();
+            forwardedPort = initializer.buildSshConnection(databaseEndpoint, databasePort);
             url = url.replace("[forwardedPort]", String.valueOf(forwardedPort));
         }
 

--- a/src/main/java/com/cozymate/cozymate_server/global/config/SshRedisConfig.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/config/SshRedisConfig.java
@@ -1,0 +1,57 @@
+package com.cozymate.cozymate_server.global.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories(basePackages = "com.cozymate.cozymate_server.global.redis")
+public class SshRedisConfig {
+
+    private final SshTunnelConfig initializer;
+
+    @Value("${server}")
+    private String isServer;
+
+    @Value("${cloud.aws.ec2.redis_endpoint}")
+    private String redisEndpoint;
+
+    @Value("${cloud.aws.ec2.redis_port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        String host = redisEndpoint;
+        int port = redisPort;
+
+        // SSH 터널을 통해 Redis에 연결해야 할 경우
+        if (isServer.equals("false")) {
+            Integer forwardedPort = initializer.buildSshConnection(redisEndpoint, redisPort);
+            host = "localhost";
+            port = forwardedPort;
+        }
+
+        log.info("Redis connection through SSH: host={}, port={}", host, port);
+
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/config/SshTunnelConfig.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/config/SshTunnelConfig.java
@@ -26,11 +26,6 @@ public class SshTunnelConfig {
     private String user;
     @Value("${cloud.aws.ec2.private_key_path}")
     private String privateKeyPath;
-    @Value("${cloud.aws.ec2.database_endpoint}")
-    private String databaseEndpoint;
-    @Value("${cloud.aws.ec2.database_port}")
-    private int databasePort;
-
 
     private Session session;
 
@@ -41,12 +36,11 @@ public class SshTunnelConfig {
         }
     }
 
-    public Integer buildSshConnection() {
+    public Integer buildSshConnection(String endpoint, int port) {
         Integer forwardPort = null;
 
         try {
-            log.info("Connecting to SSH with {}@{}:{} using privateKey at {}", user, remoteJumpHost,
-                sshPort, privateKeyPath);
+            log.info("SSH  {}@{}:{}  with {}", user, remoteJumpHost, sshPort, privateKeyPath);
             JSch jsch = new JSch();
 
             jsch.addIdentity(privateKeyPath);
@@ -57,9 +51,9 @@ public class SshTunnelConfig {
             session.connect();
             log.info("SSH session connected");
 
-            forwardPort = session.setPortForwardingL(0, databaseEndpoint, databasePort);
+            forwardPort = session.setPortForwardingL(0, endpoint, port);
             log.info("Port forwarding created on local port {} to remote port {}", forwardPort,
-                databasePort);
+                port);
         } catch (JSchException e) {
             log.error(e.getMessage());
             this.destroy();

--- a/src/main/java/com/cozymate/cozymate_server/global/redis/test/Test.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/redis/test/Test.java
@@ -1,0 +1,24 @@
+package com.cozymate.cozymate_server.global.redis.test;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+
+@Builder
+@Getter
+@RedisHash("Test")
+public class Test {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    public static Test toEntity(Long id, String name) {
+        return Test.builder()
+            .id(id)
+            .name(name)
+            .build();
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/redis/test/TestRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/redis/test/TestRepository.java
@@ -1,0 +1,9 @@
+package com.cozymate.cozymate_server.global.redis.test;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestRepository extends CrudRepository<Test, Long> {
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/redis/test/TestService.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/redis/test/TestService.java
@@ -1,0 +1,25 @@
+package com.cozymate.cozymate_server.global.redis.test;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TestService {
+
+        private final TestRepository testRepository;
+
+        public void saveTestEntity(Long id, String name) {
+            Test testEntity = Test.builder()
+                .id(id)
+                .name(name)
+                .build();
+
+            testRepository.save(testEntity);
+        }
+
+        public Test findTestEntity(Long id) {
+            return testRepository.findById(id).orElse(null);
+        }
+
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
- Redis 관련 정보 서브모듈에 추가
- SSH 터널링을 사용하면서, 접속 config 추가, 기존 코드 수정
- RedisConfig로 템플릿 추가
- global 패키지에 redis 패키지 추가 -> 여기서 key-value로 관리해주세요
- Test 엔티티 추가해서 예시코드 추가 -> 이거 가져다가 변경해서 대충 쓰면 됩니당
## 📝 작업 내용
요약이 곧 내용입니당

## 동작 확인
<img width="1221" alt="image" src="https://github.com/user-attachments/assets/0e0dd218-dc0e-4b43-9b9c-4477e186db18">
대충 컨트롤러에 끼워서 넣으니 잘 동작합니당
이건 키 추가된 결과 (Redis Insight 쓰세요 최고의 관리툴)

## 💬 리뷰 요구사항(선택)
- 음 도메인 구조를 이렇게 해둔 이유는 일단
1. Repository로 등록된 클래스 (JpaRepository, CrudRepository)면 DB에서 인식을 합니다.
2. 나누지 않으면 RDS랑 Redis가 동일한 Repository를 자기가 사용할 인터페이스라고 생각합니다.
3. 그래서 @EnableJpaRepositories를 사용할 때 basePackages를 나눠서 각자 사용할 레포지토리가 있을 위치를 정해줘야합니다.
4. 그러다보니 그냥 domain이랑 global이랑 구분해서 domain에서 사용하는 repository는 JpaRepository이고, global에서 redis 도메인에서 사용하는건 Redis인걸로 처리해뒀습니다.
더 나은 의견, 더 좋은 생각, 잘못된 부분 의견받습니당
