### PR TITLE
[COZY-264] 멤버 상세정보 기획 변경, 상세 필터링 검색 기능 구현, 멤버 상세정보 일치율 엔티티 분리 및 조회, 저장, 업데이트 방식 변경

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
@@ -71,11 +71,11 @@ public class MemberStat extends BaseTimeEntity{
 
     private String intimacy;
 
-    private Boolean canShare;
+    private String canShare;
 
-    private Boolean isPlayGame;
+    private String isPlayGame;
 
-    private Boolean isPhoneCall;
+    private String isPhoneCall;
 
     private String studying;
 
@@ -86,6 +86,8 @@ public class MemberStat extends BaseTimeEntity{
     private Integer noiseSensitivity;
 
     private String cleaningFrequency;
+
+    private String drinkingFrequency;
 
     private String personality;
 
@@ -119,7 +121,8 @@ public class MemberStat extends BaseTimeEntity{
         this.cleanSensitivity = memberStatCommandRequestDTO.getCleanSensitivity();
         this.noiseSensitivity = memberStatCommandRequestDTO.getNoiseSensitivity();
         this.cleaningFrequency = memberStatCommandRequestDTO.getCleaningFrequency();
-        this.personality = memberStatCommandRequestDTO.getPersonality();
+        this.drinkingFrequency = memberStatCommandRequestDTO.getDrinkingFrequency();
+        this.personality = String.join(",", memberStatCommandRequestDTO.getPersonality()) + ",";
         this.mbti = memberStatCommandRequestDTO.getMbti();
         this.options = memberStatCommandRequestDTO.getOptions();
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
@@ -93,9 +93,7 @@ public class MemberStat extends BaseTimeEntity{
 
     private String mbti;
 
-    @Type(JsonType.class)
-    @Column(columnDefinition = "json")
-    private Map<String, List<String>> options;
+    private String selfIntroduction;
 
     public void update(Member member, University university, MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
         this.member = member;
@@ -108,7 +106,7 @@ public class MemberStat extends BaseTimeEntity{
         this.sleepingTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getSleepingMeridian(),memberStatCommandRequestDTO.getSleepingTime());
         this.turnOffTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getTurnOffMeridian(),memberStatCommandRequestDTO.getTurnOffTime());
         this.smoking = memberStatCommandRequestDTO.getSmokingState();
-        this.sleepingHabit = memberStatCommandRequestDTO.getSleepingHabit();
+        this.sleepingHabit = String.join(",", memberStatCommandRequestDTO.getSleepingHabit()) + ",";
         this.airConditioningIntensity = memberStatCommandRequestDTO.getAirConditioningIntensity();
         this.heatingIntensity = memberStatCommandRequestDTO.getHeatingIntensity();
         this.lifePattern = memberStatCommandRequestDTO.getLifePattern();
@@ -124,6 +122,6 @@ public class MemberStat extends BaseTimeEntity{
         this.drinkingFrequency = memberStatCommandRequestDTO.getDrinkingFrequency();
         this.personality = String.join(",", memberStatCommandRequestDTO.getPersonality()) + ",";
         this.mbti = memberStatCommandRequestDTO.getMbti();
-        this.options = memberStatCommandRequestDTO.getOptions();
+        this.selfIntroduction = memberStatCommandRequestDTO.getSelfIntroduction();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
@@ -31,7 +31,7 @@ import org.hibernate.annotations.Type;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Entity
-public class MemberStat extends BaseTimeEntity{
+public class MemberStat extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -95,16 +95,20 @@ public class MemberStat extends BaseTimeEntity{
 
     private String selfIntroduction;
 
-    public void update(Member member, University university, MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
+    public void update(Member member, University university,
+        MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
         this.member = member;
         this.university = university;
         this.acceptance = memberStatCommandRequestDTO.getAcceptance();
         this.admissionYear = Integer.parseInt(memberStatCommandRequestDTO.getAdmissionYear());
         this.major = memberStatCommandRequestDTO.getMajor();
         this.numOfRoommate = memberStatCommandRequestDTO.getNumOfRoommate();
-        this.wakeUpTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getWakeUpMeridian(),memberStatCommandRequestDTO.getWakeUpTime());
-        this.sleepingTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getSleepingMeridian(),memberStatCommandRequestDTO.getSleepingTime());
-        this.turnOffTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getTurnOffMeridian(),memberStatCommandRequestDTO.getTurnOffTime());
+        this.wakeUpTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getWakeUpMeridian(),
+            memberStatCommandRequestDTO.getWakeUpTime());
+        this.sleepingTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getSleepingMeridian(),
+            memberStatCommandRequestDTO.getSleepingTime());
+        this.turnOffTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getTurnOffMeridian(),
+            memberStatCommandRequestDTO.getTurnOffTime());
         this.smoking = memberStatCommandRequestDTO.getSmokingState();
         this.sleepingHabit = String.join(",", memberStatCommandRequestDTO.getSleepingHabit()) + ",";
         this.airConditioningIntensity = memberStatCommandRequestDTO.getAirConditioningIntensity();

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.memberstat;
 
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatRequestDTO.MemberStatCommandRequestDTO;
+import com.cozymate.cozymate_server.domain.memberstat.util.MemberStatUtil;
 import com.cozymate.cozymate_server.domain.university.University;
 import com.cozymate.cozymate_server.global.utils.BaseTimeEntity;
 import com.cozymate.cozymate_server.global.utils.TimeUtil;
@@ -110,7 +111,7 @@ public class MemberStat extends BaseTimeEntity {
         this.turnOffTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getTurnOffMeridian(),
             memberStatCommandRequestDTO.getTurnOffTime());
         this.smoking = memberStatCommandRequestDTO.getSmokingState();
-        this.sleepingHabit = String.join(",", memberStatCommandRequestDTO.getSleepingHabit()) + ",";
+        this.sleepingHabit = MemberStatUtil.toSortedString(memberStatCommandRequestDTO.getSleepingHabit());
         this.airConditioningIntensity = memberStatCommandRequestDTO.getAirConditioningIntensity();
         this.heatingIntensity = memberStatCommandRequestDTO.getHeatingIntensity();
         this.lifePattern = memberStatCommandRequestDTO.getLifePattern();
@@ -124,7 +125,7 @@ public class MemberStat extends BaseTimeEntity {
         this.noiseSensitivity = memberStatCommandRequestDTO.getNoiseSensitivity();
         this.cleaningFrequency = memberStatCommandRequestDTO.getCleaningFrequency();
         this.drinkingFrequency = memberStatCommandRequestDTO.getDrinkingFrequency();
-        this.personality = String.join(",", memberStatCommandRequestDTO.getPersonality()) + ",";
+        this.personality = MemberStatUtil.toSortedString(memberStatCommandRequestDTO.getPersonality());
         this.mbti = memberStatCommandRequestDTO.getMbti();
         this.selfIntroduction = memberStatCommandRequestDTO.getSelfIntroduction();
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
@@ -131,12 +131,11 @@ public class MemberStatController {
             + "(미정일 때는 다른 인실 상세 필터링 가능, 아닐 경우 자신이 입력한 인실에 대한 결과를 반환)"
     )
     @SwaggerApiError({
-        ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._MEMBERSTAT_NOT_EXISTS
     })
     @GetMapping("/numOfRoommate")
     public ResponseEntity<ApiResponse<Integer>> getNumOfRoommateStatus(
-         @AuthenticationPrincipal MemberDetails memberDetails
+        @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         return ResponseEntity.ok(
             ApiResponse.onSuccess(
@@ -171,13 +170,14 @@ public class MemberStatController {
             + "- cleanSensitivity : 청결예민도\n"
             + "- noiseSensitivity : 소음예민도\n"
             + "- cleaningFrequency : 청소 빈도\n"
-            + "- drinkingFrequency : 음주 빈도"
+            + "- drinkingFrequency : 음주 빈도\n"
             + "- personality : 성격\n"
             + "- mbti : mbti"
     )
     @SwaggerApiError({
         ErrorStatus._MEMBERSTAT_NOT_EXISTS,
-        ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID
+        ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID,
+        ErrorStatus._MEMBERSTAT_FILTER_CANNOT_FILTER_ROOMMATE
     })
     @GetMapping("/filter")
     public ResponseEntity<ApiResponse<PageResponseDto<List<?>>>> getFilteredMemberList(
@@ -185,7 +185,7 @@ public class MemberStatController {
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(required = false) List<String> filterList,
         @RequestParam(defaultValue = "false", required = false) boolean needsDetail
-        ) {
+    ) {
         Pageable pageable = PageRequest.of(page, 5);
         return ResponseEntity.ok(
             ApiResponse.onSuccess(
@@ -222,7 +222,8 @@ public class MemberStatController {
             "- **intimacy** (친밀도) : `[Integer]` 예) `[1, 5]` (1~5 사이의 숫자)\n" +
             "- **canShare** (물건 공유 가능여부) : `[String]` 예) `[\"아무것도 공유하고싶지 않아요\"]`\n" +
             "- **isPlayGame** (게임여부) : `[String]` 예) `[\"아예 하지 않았으면 좋겠어요\"]`\n" +
-            "- **isPhoneCall** (전화여부) : `[String]` 예) `[\"아예 하지 않았으면 좋겠어요\", \"부모님과의 전화는 괜찮아요\"]`\n" +
+            "- **isPhoneCall** (전화여부) : `[String]` 예) `[\"아예 하지 않았으면 좋겠어요\", \"부모님과의 전화는 괜찮아요\"]`\n"
+            +
             "- **studying** (공부여부) : `[String]` 예) `[\"아예 하지 않았으면 좋겠어요\"]`\n" +
             "- **intake** (음식 섭취 여부) : `[String]` 예) `[\"간단한 간식은 괜찮아요\"]`\n" +
             "- **cleanSensitivity** (청결 예민도) : `[Integer]` 예) `[3, 4]` (1~5 사이의 숫자)\n" +
@@ -234,7 +235,8 @@ public class MemberStatController {
     )
     @SwaggerApiError({
         ErrorStatus._MEMBERSTAT_NOT_EXISTS,
-        ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID
+        ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID,
+        ErrorStatus._MEMBERSTAT_FILTER_CANNOT_FILTER_ROOMMATE
     })
     @PostMapping("/filter/search/count")
     public ResponseEntity<ApiResponse<Integer>> getSizeOfAdvancedFilteredMemberList(
@@ -252,7 +254,7 @@ public class MemberStatController {
     @Operation(
         summary = "[포비] 사용자 상세정보를 키-값으로 필터링하고, 사용자 목록 받아오기(일치율 포함)",
         description = "사용자의 토큰을 넣어 사용합니다. " +
-            "filterMap은 RequestBody에 다음과 같은 형식으로 전달됩니다:\n\n" +
+            "검색하고자 하는 정보를 RequestBody에 다음과 같은 형식으로 전달하면 됩니다:\n\n" +
             "```json\n" +
             "{\n" +
             "  \"birthYear\": [1995, 1996],\n" +
@@ -277,7 +279,8 @@ public class MemberStatController {
             "- **intimacy** (친밀도) : `[Integer]` 예) `[1, 5]` (1~5 사이의 숫자)\n" +
             "- **canShare** (물건 공유 가능여부) : `[String]` 예) `[\"아무것도 공유하고싶지 않아요\"]`\n" +
             "- **isPlayGame** (게임여부) : `[String]` 예) `[\"아예 하지 않았으면 좋겠어요\"]`\n" +
-            "- **isPhoneCall** (전화여부) : `[String]` 예) `[\"아예 하지 않았으면 좋겠어요\", \"부모님과의 전화는 괜찮아요\"]`\n" +
+            "- **isPhoneCall** (전화여부) : `[String]` 예) `[\"아예 하지 않았으면 좋겠어요\", \"부모님과의 전화는 괜찮아요\"]`\n"
+            +
             "- **studying** (공부여부) : `[String]` 예) `[\"아예 하지 않았으면 좋겠어요\"]`\n" +
             "- **intake** (음식 섭취 여부) : `[String]` 예) `[\"간단한 간식은 괜찮아요\"]`\n" +
             "- **cleanSensitivity** (청결 예민도) : `[Integer]` 예) `[3, 4]` (1~5 사이의 숫자)\n" +
@@ -285,11 +288,14 @@ public class MemberStatController {
             "- **cleaningFrequency** (청소 빈도) : `[String]` 예) `[\"주1회\", \"월2회\"]`\n" +
             "- **drinkingFrequency** (음주 빈도) : `[String]` 예) `[\"거의 안 마셔요\",\"한 달에 한 두번 마셔요\"]`" +
             "- **personality** (성격) : `[String]` 예) `[\"외향적\", \"내향적\"]`\n" +
-            "- **mbti** (MBTI, 대소 무관) : `[String]` 예) `[\"INTJ\", \"ENTP\"]`\n"
-        )
+            "- **mbti** (MBTI, 대소 무관) : `[String]` 예) `[\"INTJ\", \"ENTP\"]`\n" +
+            "Key는 넣어도 되고, 안 넣어도 됩니다. 다만 Value의 정보가 없을 때는 빈 배열로 주시면 됩니다."
+
+    )
     @SwaggerApiError({
         ErrorStatus._MEMBERSTAT_NOT_EXISTS,
-        ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID
+        ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID,
+        ErrorStatus._MEMBERSTAT_FILTER_CANNOT_FILTER_ROOMMATE
     })
     @PostMapping("/filter/search")
     public ResponseEntity<ApiResponse<PageResponseDto<List<?>>>> getAdvancedFilteredMemberList(
@@ -306,7 +312,6 @@ public class MemberStatController {
             )
         );
     }
-
 
 
     @Deprecated(since = "2024-10-15, 상세정보 검색 기능 Update")
@@ -370,7 +375,7 @@ public class MemberStatController {
     })
     public ResponseEntity<ApiResponse<Boolean>> deleteMemberStat(
         @PathVariable Long memberId
-    ){
+    ) {
         // TODO : 관리자 권한 분리시 일반 사용자가 삭제하는 것을 제한하기
         memberStatCommandService.deleteMemberStat(memberId);
         return ResponseEntity.ok(

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
@@ -123,6 +123,28 @@ public class MemberStatController {
     }
 
     @Operation(
+        summary = "[포비] 기숙사 인원 미정 여부 조회",
+        description = "사용자 토큰을 넣고 사용합니다. 결과 값으로 정수를 리턴합니다.\n\n"
+            + "- 미정일 경우 : 0 반환\n"
+            + "- 인실이 정해져 있을 경우 : 사용자의 인실 반환\n"
+            + "- 필터링 기능에서 사용하면 됩니다.\n"
+            + "(미정일 때는 다른 인실 상세 필터링 가능, 아닐 경우 자신이 입력한 인실에 대한 결과를 반환)"
+    )
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._MEMBERSTAT_NOT_EXISTS
+    })
+    @GetMapping("/numOfRoommate")
+    public ResponseEntity<ApiResponse<Integer>> getNumOfRoommateStatus(
+         @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(
+                memberStatQueryService.getNumOfRoommateStatus(memberDetails.getMember().getId())
+            ));
+    }
+
+    @Operation(
         summary = "[포비] 사용자 상세정보 완전 일치 필터링 및 일치율 조회",
         description = "사용자의 토큰을 넣어 사용합니다."
             + "filterList = 필터명1,필터명2,...으로 사용하고, 없을 경우 쿼리문에 아예 filterList를 넣지 않으셔도 됩니다.\n\n"
@@ -284,6 +306,8 @@ public class MemberStatController {
             )
         );
     }
+
+
 
     @Deprecated(since = "2024-10-15, 상세정보 검색 기능 Update")
     @Operation(

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -18,8 +18,13 @@ public class MemberStatConverter {
         Long memberStatId, Member member, University university, MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
 
         // 입력 시 정렬된 상태를 유지, 검색을 쉽게 하기 위해 넣었음.
-        List<String> personalityList = memberStatCommandRequestDTO.getPersonality().stream().sorted(
-            Comparator.naturalOrder()).toList();
+        List<String> personalityList = memberStatCommandRequestDTO.getPersonality().stream()
+            .sorted(Comparator.naturalOrder())
+            .toList();
+
+        List<String> sleepHabitList = memberStatCommandRequestDTO.getSleepingHabit().stream()
+            .sorted(Comparator.naturalOrder())
+            .toList();
 
         MemberStatBuilder builder = MemberStat.builder()
             .member(member)
@@ -32,7 +37,7 @@ public class MemberStatConverter {
             .sleepingTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getSleepingMeridian(), memberStatCommandRequestDTO.getSleepingTime()))
             .turnOffTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getTurnOffMeridian(), memberStatCommandRequestDTO.getTurnOffTime()))
             .smoking(memberStatCommandRequestDTO.getSmokingState())
-            .sleepingHabit(memberStatCommandRequestDTO.getSleepingHabit())
+            .sleepingHabit(String.join(",", sleepHabitList + ","))
             .airConditioningIntensity(memberStatCommandRequestDTO.getAirConditioningIntensity())
             .heatingIntensity(memberStatCommandRequestDTO.getHeatingIntensity())
             .lifePattern(memberStatCommandRequestDTO.getLifePattern())
@@ -48,7 +53,7 @@ public class MemberStatConverter {
             .drinkingFrequency(memberStatCommandRequestDTO.getDrinkingFrequency())
             .personality(String.join(",", personalityList + ","))
             .mbti(memberStatCommandRequestDTO.getMbti())
-            .options(memberStatCommandRequestDTO.getOptions());
+            .selfIntroduction(memberStatCommandRequestDTO.getSelfIntroduction());
 
         if (memberStatId != null) {
             builder.id(memberStatId);
@@ -74,7 +79,7 @@ public class MemberStatConverter {
             .turnOffMeridian(TimeUtil.convertToMeridian(memberStat.getTurnOffTime()))
             .turnOffTime(TimeUtil.convertToTime(memberStat.getTurnOffTime()))
             .smokingState(memberStat.getSmoking())
-            .sleepingHabit(memberStat.getSleepingHabit())
+            .sleepingHabit(Arrays.asList(memberStat.getSleepingHabit().replaceAll(",$", "").split(",")))
             .airConditioningIntensity(memberStat.getAirConditioningIntensity())
             .heatingIntensity(memberStat.getHeatingIntensity())
             .lifePattern(memberStat.getLifePattern())
@@ -90,7 +95,7 @@ public class MemberStatConverter {
             .drinkingFrequency(memberStat.getDrinkingFrequency())
             .personality(Arrays.asList(memberStat.getPersonality().replaceAll(",$", "").split(",")))
             .mbti(memberStat.getMbti())
-            .options(memberStat.getOptions())
+            .selfIntroduction(memberStat.getSelfIntroduction())
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -6,6 +6,7 @@ import com.cozymate.cozymate_server.domain.memberstat.MemberStat.MemberStatBuild
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatRequestDTO.MemberStatCommandRequestDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
+import com.cozymate.cozymate_server.domain.memberstat.util.MemberStatUtil;
 import com.cozymate.cozymate_server.domain.university.University;
 import com.cozymate.cozymate_server.global.utils.TimeUtil;
 import java.util.Arrays;
@@ -15,16 +16,8 @@ import java.util.List;
 public class MemberStatConverter {
 
     public static MemberStat toEntity(
-        Long memberStatId, Member member, University university, MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
-
-        // 입력 시 정렬된 상태를 유지, 검색을 쉽게 하기 위해 넣었음.
-        List<String> personalityList = memberStatCommandRequestDTO.getPersonality().stream()
-            .sorted(Comparator.naturalOrder())
-            .toList();
-
-        List<String> sleepHabitList = memberStatCommandRequestDTO.getSleepingHabit().stream()
-            .sorted(Comparator.naturalOrder())
-            .toList();
+        Long memberStatId, Member member, University university,
+        MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
 
         MemberStatBuilder builder = MemberStat.builder()
             .member(member)
@@ -33,11 +26,15 @@ public class MemberStatConverter {
             .major(memberStatCommandRequestDTO.getMajor())
             .numOfRoommate(memberStatCommandRequestDTO.getNumOfRoommate())
             .acceptance(memberStatCommandRequestDTO.getAcceptance())
-            .wakeUpTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getWakeUpMeridian(), memberStatCommandRequestDTO.getWakeUpTime()))
-            .sleepingTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getSleepingMeridian(), memberStatCommandRequestDTO.getSleepingTime()))
-            .turnOffTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getTurnOffMeridian(), memberStatCommandRequestDTO.getTurnOffTime()))
+            .wakeUpTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getWakeUpMeridian(),
+                memberStatCommandRequestDTO.getWakeUpTime()))
+            .sleepingTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getSleepingMeridian(),
+                memberStatCommandRequestDTO.getSleepingTime()))
+            .turnOffTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getTurnOffMeridian(),
+                memberStatCommandRequestDTO.getTurnOffTime()))
             .smoking(memberStatCommandRequestDTO.getSmokingState())
-            .sleepingHabit(String.join(",", sleepHabitList + ","))
+            .sleepingHabit(
+                MemberStatUtil.toSortedString(memberStatCommandRequestDTO.getSleepingHabit()))
             .airConditioningIntensity(memberStatCommandRequestDTO.getAirConditioningIntensity())
             .heatingIntensity(memberStatCommandRequestDTO.getHeatingIntensity())
             .lifePattern(memberStatCommandRequestDTO.getLifePattern())
@@ -51,7 +48,8 @@ public class MemberStatConverter {
             .noiseSensitivity(memberStatCommandRequestDTO.getNoiseSensitivity())
             .cleaningFrequency(memberStatCommandRequestDTO.getCleaningFrequency())
             .drinkingFrequency(memberStatCommandRequestDTO.getDrinkingFrequency())
-            .personality(String.join(",", personalityList + ","))
+            .personality(
+                MemberStatUtil.toSortedString(memberStatCommandRequestDTO.getPersonality()))
             .mbti(memberStatCommandRequestDTO.getMbti())
             .selfIntroduction(memberStatCommandRequestDTO.getSelfIntroduction());
 
@@ -63,8 +61,7 @@ public class MemberStatConverter {
     }
 
 
-
-    public static MemberStatQueryResponseDTO toDto(MemberStat memberStat, Integer birthYear){
+    public static MemberStatQueryResponseDTO toDto(MemberStat memberStat, Integer birthYear) {
         return MemberStatQueryResponseDTO.builder()
             .universityId(memberStat.getUniversity().getId())
             .admissionYear(memberStat.getAdmissionYear())
@@ -79,7 +76,7 @@ public class MemberStatConverter {
             .turnOffMeridian(TimeUtil.convertToMeridian(memberStat.getTurnOffTime()))
             .turnOffTime(TimeUtil.convertToTime(memberStat.getTurnOffTime()))
             .smokingState(memberStat.getSmoking())
-            .sleepingHabit(Arrays.asList(memberStat.getSleepingHabit().replaceAll(",$", "").split(",")))
+            .sleepingHabit(MemberStatUtil.fromStringToList(memberStat.getSleepingHabit()))
             .airConditioningIntensity(memberStat.getAirConditioningIntensity())
             .heatingIntensity(memberStat.getHeatingIntensity())
             .lifePattern(memberStat.getLifePattern())
@@ -93,13 +90,13 @@ public class MemberStatConverter {
             .noiseSensitivity(memberStat.getNoiseSensitivity())
             .cleaningFrequency(memberStat.getCleaningFrequency())
             .drinkingFrequency(memberStat.getDrinkingFrequency())
-            .personality(Arrays.asList(memberStat.getPersonality().replaceAll(",$", "").split(",")))
+            .personality(MemberStatUtil.fromStringToList(memberStat.getPersonality()))
             .mbti(memberStat.getMbti())
             .selfIntroduction(memberStat.getSelfIntroduction())
             .build();
     }
 
-    public static MemberStatEqualityResponseDTO toEqualityDto(MemberStat memberStat, int equality){
+    public static MemberStatEqualityResponseDTO toEqualityDto(MemberStat memberStat, int equality) {
         return MemberStatEqualityResponseDTO.builder()
             .memberId(memberStat.getMember().getId())
             .memberAge(TimeUtil.calculateAge(memberStat.getMember().getBirthDay()))
@@ -110,4 +107,6 @@ public class MemberStatConverter {
             .equality(equality)
             .build();
     }
+
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -8,15 +8,19 @@ import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
 import com.cozymate.cozymate_server.domain.university.University;
 import com.cozymate.cozymate_server.global.utils.TimeUtil;
-import java.sql.Time;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 
 public class MemberStatConverter {
 
     public static MemberStat toEntity(
         Long memberStatId, Member member, University university, MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
+
+        // 입력 시 정렬된 상태를 유지, 검색을 쉽게 하기 위해 넣었음.
+        List<String> personalityList = memberStatCommandRequestDTO.getPersonality().stream().sorted(
+            Comparator.naturalOrder()).toList();
+
         MemberStatBuilder builder = MemberStat.builder()
             .member(member)
             .university(university)
@@ -41,7 +45,8 @@ public class MemberStatConverter {
             .cleanSensitivity(memberStatCommandRequestDTO.getCleanSensitivity())
             .noiseSensitivity(memberStatCommandRequestDTO.getNoiseSensitivity())
             .cleaningFrequency(memberStatCommandRequestDTO.getCleaningFrequency())
-            .personality(memberStatCommandRequestDTO.getPersonality())
+            .drinkingFrequency(memberStatCommandRequestDTO.getDrinkingFrequency())
+            .personality(String.join(",", personalityList + ","))
             .mbti(memberStatCommandRequestDTO.getMbti())
             .options(memberStatCommandRequestDTO.getOptions());
 
@@ -82,7 +87,8 @@ public class MemberStatConverter {
             .cleanSensitivity(memberStat.getCleanSensitivity())
             .noiseSensitivity(memberStat.getNoiseSensitivity())
             .cleaningFrequency(memberStat.getCleaningFrequency())
-            .personality(memberStat.getPersonality())
+            .drinkingFrequency(memberStat.getDrinkingFrequency())
+            .personality(Arrays.asList(memberStat.getPersonality().replaceAll(",$", "").split(",")))
             .mbti(memberStat.getMbti())
             .options(memberStat.getOptions())
             .build();

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
@@ -57,7 +57,7 @@ public class MemberStatRequestDTO {
                 @NotBlank
                 private String smokingState;
                 @NotBlank
-                private String sleepingHabit;
+                private List<String> sleepingHabit;
                 @NotNull
                 @Min(0)
                 @Max(3)
@@ -97,7 +97,8 @@ public class MemberStatRequestDTO {
                 @NotBlank
                 @Size(max=4, min=4)
                 private String mbti;
-                private Map<String, List<String>> options;
+                @NotBlank
+                private String selfIntroduction;
         }
 
         @Getter
@@ -142,7 +143,7 @@ public class MemberStatRequestDTO {
                 @NotBlank
                 private String smokingState;
                 @NotBlank
-                private String sleepingHabit;
+                private List<String> sleepingHabit;
                 @NotNull
                 @Min(1)
                 @Max(3)
@@ -182,6 +183,7 @@ public class MemberStatRequestDTO {
                 @NotBlank
                 @Size(max=4, min=4)
                 private String mbti;
-                private Map<String, List<String>> options;
+                @NotBlank
+                private String selfIntroduction;
         }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -71,9 +70,12 @@ public class MemberStatRequestDTO {
                 private String lifePattern;
                 @NotBlank
                 private String intimacy;
-                private Boolean canShare;
-                private Boolean isPlayGame;
-                private Boolean isPhoneCall;
+                @NotBlank
+                private String canShare;
+                @NotBlank
+                private String isPlayGame;
+                @NotBlank
+                private String isPhoneCall;
                 @NotBlank
                 private String studying;
                 @NotBlank
@@ -89,7 +91,9 @@ public class MemberStatRequestDTO {
                 @NotBlank
                 private String cleaningFrequency;
                 @NotBlank
-                private String personality;
+                private String drinkingFrequency;
+                @NotBlank
+                private List<String> personality;
                 @NotBlank
                 @Size(max=4, min=4)
                 private String mbti;
@@ -151,9 +155,12 @@ public class MemberStatRequestDTO {
                 private String lifePattern;
                 @NotBlank
                 private String intimacy;
-                private Boolean canShare;
-                private Boolean isPlayGame;
-                private Boolean isPhoneCall;
+                @NotBlank
+                private String canShare;
+                @NotBlank
+                private String isPlayGame;
+                @NotBlank
+                private String isPhoneCall;
                 @NotBlank
                 private String studying;
                 @NotBlank
@@ -168,6 +175,8 @@ public class MemberStatRequestDTO {
                 private Integer noiseSensitivity;
                 @NotBlank
                 private String cleaningFrequency;
+                @NotBlank
+                private String drinkingFrequency;
                 @NotBlank
                 private String personality;
                 @NotBlank

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
@@ -14,176 +14,178 @@ import lombok.NoArgsConstructor;
 
 public class MemberStatRequestDTO {
 
-        // Create, Update를 Command DTO로 관리하기
-        @Getter
-        @NoArgsConstructor
-        @AllArgsConstructor
-        public static class MemberStatCommandRequestDTO {
-                @NotNull
-                private Long universityId;
-                //학번의 경우 처리하기 애매한 부분이 있어, String 2자리로 통일함. EX) 09 학번 -> "09"
-                @NotBlank
-                @Size(min=2,max=2)
-                private String admissionYear;
-                @NotBlank
-                private String major;
-                @NotNull
-                @Min(2)
-                @Max(6)
-                private Integer numOfRoommate;
-                @NotBlank
-                private String acceptance;
-                @NotBlank
-                @Size(min=2,max=2)
-                private String wakeUpMeridian;
-                @NotNull
-                @Min(1)
-                @Max(12)
-                private Integer wakeUpTime;
-                @NotBlank
-                @Size(min=2,max=2)
-                private String sleepingMeridian;
-                @NotNull
-                @Min(1)
-                @Max(12)
-                private Integer sleepingTime;
-                @NotBlank
-                @Size(min=2,max=2)
-                private String turnOffMeridian;
-                @NotNull
-                @Min(1)
-                @Max(12)
-                private Integer turnOffTime;
-                @NotBlank
-                private String smokingState;
-                @NotBlank
-                private List<String> sleepingHabit;
-                @NotNull
-                @Min(0)
-                @Max(3)
-                private Integer airConditioningIntensity;
-                @NotNull
-                @Min(0)
-                @Max(3)
-                private Integer heatingIntensity;
-                @NotBlank
-                private String lifePattern;
-                @NotBlank
-                private String intimacy;
-                @NotBlank
-                private String canShare;
-                @NotBlank
-                private String isPlayGame;
-                @NotBlank
-                private String isPhoneCall;
-                @NotBlank
-                private String studying;
-                @NotBlank
-                private String intake;
-                @NotNull
-                @Min(1)
-                @Max(5)
-                private Integer cleanSensitivity;
-                @NotNull
-                @Min(1)
-                @Max(5)
-                private Integer noiseSensitivity;
-                @NotBlank
-                private String cleaningFrequency;
-                @NotBlank
-                private String drinkingFrequency;
-                @NotBlank
-                private List<String> personality;
-                @NotBlank
-                @Size(max=4, min=4)
-                private String mbti;
-                @NotBlank
-                private String selfIntroduction;
-        }
+    // Create, Update를 Command DTO로 관리하기
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberStatCommandRequestDTO {
 
-        @Getter
-        @NoArgsConstructor
-        @AllArgsConstructor
-        public static class MemberStatSearchRequestDTO {
-                @NotNull
-                private Long universityId;
-                //학번의 경우 처리하기 애매한 부분이 있어, String 2자리로 통일함. EX) 09 학번 -> "09"
-                @NotBlank
-                @Size(min=2,max=2)
-                private String admissionYear;
-                @NotBlank
-                private String major;
-                @NotNull
-                @Min(2)
-                @Max(6)
-                private Integer numOfRoommate;
-                @NotBlank
-                private String acceptance;
-                @NotBlank
-                @Size(min=2,max=2)
-                private String wakeUpMeridian;
-                @NotNull
-                @Min(1)
-                @Max(12)
-                private Integer wakeUpTime;
-                @NotBlank
-                @Size(min=2,max=2)
-                private String sleepingMeridian;
-                @NotNull
-                @Min(1)
-                @Max(12)
-                private Integer sleepingTime;
-                @NotBlank
-                @Size(min=2,max=2)
-                private String turnOffMeridian;
-                @NotNull
-                @Min(1)
-                @Max(12)
-                private Integer turnOffTime;
-                @NotBlank
-                private String smokingState;
-                @NotBlank
-                private List<String> sleepingHabit;
-                @NotNull
-                @Min(1)
-                @Max(3)
-                private Integer airConditioningIntensity;
-                @NotNull
-                @Min(1)
-                @Max(3)
-                private Integer heatingIntensity;
-                @NotBlank
-                private String lifePattern;
-                @NotBlank
-                private String intimacy;
-                @NotBlank
-                private String canShare;
-                @NotBlank
-                private String isPlayGame;
-                @NotBlank
-                private String isPhoneCall;
-                @NotBlank
-                private String studying;
-                @NotBlank
-                private String intake;
-                @NotNull
-                @Min(1)
-                @Max(5)
-                private Integer cleanSensitivity;
-                @NotNull
-                @Min(1)
-                @Max(5)
-                private Integer noiseSensitivity;
-                @NotBlank
-                private String cleaningFrequency;
-                @NotBlank
-                private String drinkingFrequency;
-                @NotBlank
-                private String personality;
-                @NotBlank
-                @Size(max=4, min=4)
-                private String mbti;
-                @NotBlank
-                private String selfIntroduction;
-        }
+        @NotNull
+        private Long universityId;
+        //학번의 경우 처리하기 애매한 부분이 있어, String 2자리로 통일함. EX) 09 학번 -> "09"
+        @NotBlank
+        @Size(min = 2, max = 2)
+        private String admissionYear;
+        @NotBlank
+        private String major;
+        @NotNull
+        @Min(2)
+        @Max(6)
+        private Integer numOfRoommate;
+        @NotBlank
+        private String acceptance;
+        @NotBlank
+        @Size(min = 2, max = 2)
+        private String wakeUpMeridian;
+        @NotNull
+        @Min(1)
+        @Max(12)
+        private Integer wakeUpTime;
+        @NotBlank
+        @Size(min = 2, max = 2)
+        private String sleepingMeridian;
+        @NotNull
+        @Min(1)
+        @Max(12)
+        private Integer sleepingTime;
+        @NotBlank
+        @Size(min = 2, max = 2)
+        private String turnOffMeridian;
+        @NotNull
+        @Min(1)
+        @Max(12)
+        private Integer turnOffTime;
+        @NotBlank
+        private String smokingState;
+        @NotBlank
+        private List<String> sleepingHabit;
+        @NotNull
+        @Min(0)
+        @Max(3)
+        private Integer airConditioningIntensity;
+        @NotNull
+        @Min(0)
+        @Max(3)
+        private Integer heatingIntensity;
+        @NotBlank
+        private String lifePattern;
+        @NotBlank
+        private String intimacy;
+        @NotBlank
+        private String canShare;
+        @NotBlank
+        private String isPlayGame;
+        @NotBlank
+        private String isPhoneCall;
+        @NotBlank
+        private String studying;
+        @NotBlank
+        private String intake;
+        @NotNull
+        @Min(1)
+        @Max(5)
+        private Integer cleanSensitivity;
+        @NotNull
+        @Min(1)
+        @Max(5)
+        private Integer noiseSensitivity;
+        @NotBlank
+        private String cleaningFrequency;
+        @NotBlank
+        private String drinkingFrequency;
+        @NotBlank
+        private List<String> personality;
+        @NotBlank
+        @Size(max = 4, min = 4)
+        private String mbti;
+        @NotBlank
+        private String selfIntroduction;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberStatSearchRequestDTO {
+
+        @NotNull
+        private Long universityId;
+        //학번의 경우 처리하기 애매한 부분이 있어, String 2자리로 통일함. EX) 09 학번 -> "09"
+        @NotBlank
+        @Size(min = 2, max = 2)
+        private String admissionYear;
+        @NotBlank
+        private String major;
+        @NotNull
+        @Min(2)
+        @Max(6)
+        private Integer numOfRoommate;
+        @NotBlank
+        private String acceptance;
+        @NotBlank
+        @Size(min = 2, max = 2)
+        private String wakeUpMeridian;
+        @NotNull
+        @Min(1)
+        @Max(12)
+        private Integer wakeUpTime;
+        @NotBlank
+        @Size(min = 2, max = 2)
+        private String sleepingMeridian;
+        @NotNull
+        @Min(1)
+        @Max(12)
+        private Integer sleepingTime;
+        @NotBlank
+        @Size(min = 2, max = 2)
+        private String turnOffMeridian;
+        @NotNull
+        @Min(1)
+        @Max(12)
+        private Integer turnOffTime;
+        @NotBlank
+        private String smokingState;
+        @NotBlank
+        private List<String> sleepingHabit;
+        @NotNull
+        @Min(1)
+        @Max(3)
+        private Integer airConditioningIntensity;
+        @NotNull
+        @Min(1)
+        @Max(3)
+        private Integer heatingIntensity;
+        @NotBlank
+        private String lifePattern;
+        @NotBlank
+        private String intimacy;
+        @NotBlank
+        private String canShare;
+        @NotBlank
+        private String isPlayGame;
+        @NotBlank
+        private String isPhoneCall;
+        @NotBlank
+        private String studying;
+        @NotBlank
+        private String intake;
+        @NotNull
+        @Min(1)
+        @Max(5)
+        private Integer cleanSensitivity;
+        @NotNull
+        @Min(1)
+        @Max(5)
+        private Integer noiseSensitivity;
+        @NotBlank
+        private String cleaningFrequency;
+        @NotBlank
+        private String drinkingFrequency;
+        @NotBlank
+        private String personality;
+        @NotBlank
+        @Size(max = 4, min = 4)
+        private String mbti;
+        @NotBlank
+        private String selfIntroduction;
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
@@ -57,7 +57,6 @@ public class MemberStatRequestDTO {
         private Integer turnOffTime;
         @NotBlank
         private String smokingState;
-        @NotBlank
         private List<String> sleepingHabit;
         @NotNull
         @Min(0)
@@ -93,7 +92,6 @@ public class MemberStatRequestDTO {
         private String cleaningFrequency;
         @NotBlank
         private String drinkingFrequency;
-        @NotBlank
         private List<String> personality;
         @NotBlank
         @Size(max = 4, min = 4)
@@ -144,7 +142,6 @@ public class MemberStatRequestDTO {
         private Integer turnOffTime;
         @NotBlank
         private String smokingState;
-        @NotBlank
         private List<String> sleepingHabit;
         @NotNull
         @Min(1)
@@ -180,8 +177,7 @@ public class MemberStatRequestDTO {
         private String cleaningFrequency;
         @NotBlank
         private String drinkingFrequency;
-        @NotBlank
-        private String personality;
+        private List<String> personality;
         @NotBlank
         @Size(max = 4, min = 4)
         private String mbti;

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatResponseDTO.java
@@ -1,12 +1,10 @@
 package com.cozymate.cozymate_server.domain.memberstat.dto;
 
-import com.cozymate.cozymate_server.domain.member.Member;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,15 +35,16 @@ public class MemberStatResponseDTO {
         private Integer heatingIntensity;
         private String lifePattern;
         private String intimacy;
-        private Boolean canShare;
-        private Boolean isPlayGame;
-        private Boolean isPhoneCall;
+        private String canShare;
+        private String isPlayGame;
+        private String isPhoneCall;
         private String studying;
         private String intake;
         private Integer cleanSensitivity;
         private Integer noiseSensitivity;
         private String cleaningFrequency;
-        private String personality;
+        private String drinkingFrequency;
+        private List<String> personality;
         private String mbti;
         private Map<String, List<String>> options;
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatResponseDTO.java
@@ -30,7 +30,7 @@ public class MemberStatResponseDTO {
         private String turnOffMeridian;
         private Integer turnOffTime;
         private String smokingState;
-        private String sleepingHabit;
+        private List<String> sleepingHabit;
         private Integer airConditioningIntensity;
         private Integer heatingIntensity;
         private String lifePattern;
@@ -46,7 +46,7 @@ public class MemberStatResponseDTO {
         private String drinkingFrequency;
         private List<String> personality;
         private String mbti;
-        private Map<String, List<String>> options;
+        private String selfIntroduction;
     }
 
     @Getter

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
@@ -1,19 +1,29 @@
 package com.cozymate.cozymate_server.domain.memberstat.repository;
 
+import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.enums.Gender;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 import com.cozymate.cozymate_server.domain.memberstat.repository.querydsl.MemberStatQueryRepository;
+import jakarta.persistence.Tuple;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberStatRepository extends
     JpaRepository<MemberStat, Long>,
     MemberStatQueryRepository {
     Optional<MemberStat> findByMemberId(Long memberId);
 
-    Boolean existsByMemberId(Long memberId);
+    @Query("SELECT ms, ms.member.id FROM MemberStat ms WHERE ms.member.id IN :memberIds")
+    List<Tuple> findMemberStatsAndMemberIdsByMemberIds(@Param("memberIds") Set<Long> memberIds);
+
+    //Eager Fetch가 필요한 경우
+    @Query("SELECT ms FROM MemberStat ms JOIN FETCH ms.member")
+    List<MemberStat> findAllWithMember();
 
     List<MemberStat> findByMember_GenderAndUniversity_Id(Gender gender, Long universityId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
@@ -16,6 +16,7 @@ import org.springframework.data.repository.query.Param;
 public interface MemberStatRepository extends
     JpaRepository<MemberStat, Long>,
     MemberStatQueryRepository {
+
     Optional<MemberStat> findByMemberId(Long memberId);
 
     @Query("SELECT ms, ms.member.id FROM MemberStat ms WHERE ms.member.id IN :memberIds")

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
@@ -1,13 +1,19 @@
 package com.cozymate.cozymate_server.domain.memberstat.repository;
 
+import com.cozymate.cozymate_server.domain.member.enums.Gender;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 import com.cozymate.cozymate_server.domain.memberstat.repository.querydsl.MemberStatQueryRepository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberStatRepository extends
     JpaRepository<MemberStat, Long>,
     MemberStatQueryRepository {
     Optional<MemberStat> findByMemberId(Long memberId);
+
+    Boolean existsByMemberId(Long memberId);
+
+    List<MemberStat> findByMember_GenderAndUniversity_Id(Gender gender, Long universityId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepository.java
@@ -10,6 +10,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface MemberStatQueryRepository {
 
-    Map<Member, MemberStat> getFilteredMemberStat(List<String> filterList, MemberStat criteriaMemberStat);
-    Map<Member, MemberStat> getAdvancedFilteredMemberStat(HashMap<String, List<?>> filterMap, MemberStat criteriaMemberStat);
+    Map<Member, MemberStat> getFilteredMemberStat(List<String> filterList,
+        MemberStat criteriaMemberStat);
+
+    Map<Member, MemberStat> getAdvancedFilteredMemberStat(HashMap<String, List<?>> filterMap,
+        MemberStat criteriaMemberStat);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepository.java
@@ -1,13 +1,15 @@
 package com.cozymate.cozymate_server.domain.memberstat.repository.querydsl;
 
+import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MemberStatQueryRepository {
 
-    List<MemberStat> getFilteredMemberStat(List<String> filterList, MemberStat criteriaMemberStat);
-
+    Map<Member, MemberStat> getFilteredMemberStat(List<String> filterList, MemberStat criteriaMemberStat);
+    Map<Member, MemberStat> getAdvancedFilteredMemberStat(HashMap<String, List<?>> filterMap, MemberStat criteriaMemberStat);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
@@ -175,7 +175,7 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
             return values.stream()
                 .map(String::valueOf)
                 .map(value -> path.like("%" + value + "%"))
-                .reduce(BooleanExpression::and)
+                .reduce(BooleanExpression::or)
                 .orElse(null);
         }
         return null;

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
@@ -192,7 +192,7 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
             // 나머지는 자신의 인실에 맞춰서 보여줌
             return path.eq(value);
         } else if (filterValue instanceof List<?> values) {
-            if(criteriaMemberStat.getNumOfRoommate().equals(NUM_OF_ROOMMATE_NOT_DETERMINED)){
+            if (criteriaMemberStat.getNumOfRoommate().equals(NUM_OF_ROOMMATE_NOT_DETERMINED)) {
                 // 미정을 선택한 사용자는 자유롭게 필터링 가능
                 return path.in((List<Integer>) values);
             }
@@ -240,10 +240,9 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
     private BooleanExpression handleDateFilter(DatePath<LocalDate> path, Object filterValue) {
         if (filterValue instanceof Integer value) {
             return Expressions.numberTemplate(Integer.class, "year({0})", path).eq(value);
-        }  else if(filterValue instanceof LocalDate value) {
+        } else if (filterValue instanceof LocalDate value) {
             return Expressions.numberTemplate(Integer.class, "year({0})", path).eq(value.getYear());
-        }
-        else if (filterValue instanceof List<?> values) {
+        } else if (filterValue instanceof List<?> values) {
             List<Integer> value = values.stream()
                 .map(Integer.class::cast)
                 .toList();

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
@@ -29,6 +29,8 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
     private final JPAQueryFactory queryFactory;
     private static final Integer NUM_OF_ROOMMATE_NOT_DETERMINED = 0;
     private static final String PERSONALITY = "personality";
+    private static final String SLEEPING_HABIT = "sleepingHabit";
+    private static final String NUM_OF_ROOMMATE = "numOfRoommate";
 
     private JPAQuery<Tuple> createBaseQuery(MemberStat criteriaMemberStat) {
         return queryFactory
@@ -39,7 +41,8 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
     }
 
     @Override
-    public Map<Member, MemberStat> getFilteredMemberStat(List<String> filterList, MemberStat criteriaMemberStat) {
+    public Map<Member, MemberStat> getFilteredMemberStat(List<String> filterList,
+        MemberStat criteriaMemberStat) {
         // Tuple로 MemberStat과 Member를 함께 조회
         List<Tuple> results = createBaseQuery(criteriaMemberStat)
             .where(applyFilters(filterList, criteriaMemberStat))
@@ -54,10 +57,11 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
     }
 
     @Override
-    public Map<Member, MemberStat> getAdvancedFilteredMemberStat(HashMap<String, List<?>> filterMap, MemberStat criteriaMemberStat) {
+    public Map<Member, MemberStat> getAdvancedFilteredMemberStat(HashMap<String, List<?>> filterMap,
+        MemberStat criteriaMemberStat) {
         // Tuple로 MemberStat과 Member를 함께 조회
         List<Tuple> results = createBaseQuery(criteriaMemberStat)
-            .where(applyFilters(filterMap))
+            .where(applyFilters(filterMap, criteriaMemberStat))
             .fetch();
 
         // 결과를 Map<Member, MemberStat>으로 변환
@@ -83,30 +87,42 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
         return builder;
     }
 
-    // 단순 필터링 (완전 일치)
+    // 단순 필터링 (criteriaMemberStat과 각 필드의 값이 일치하는지 확인)
     private BooleanBuilder applyFilters(List<String> filterList, MemberStat criteriaMemberStat) {
         BooleanBuilder builder = new BooleanBuilder();
-        if (filterList != null) {
-            filterList.forEach(filter -> applyFilter(builder, filter, criteriaMemberStat));
-        }
-        return builder;
-    }
 
-    // 상세 검색 필터링 (key : value) 필터링
-    private BooleanBuilder applyFilters(HashMap<String, List<?>> filterMap) {
-        BooleanBuilder builder = new BooleanBuilder();
-        if (filterMap != null) {
-            filterMap.forEach((key, value) -> {
-                // value가 빈 배열이 아닐때만 적용
-                if (value != null && !value.isEmpty()) {
-                    applyFilter(builder, key, value);
+        // filterList가 주어진 경우에만 필터링 수행
+        if (filterList != null) {
+            filterList.forEach(filter -> {
+                // 기존의 getPathByKey를 사용하여 동적 필터링을 적용
+                Path<?> path = getPathByKey(filter);
+                Object criteriaValue = getFieldValueByKey(criteriaMemberStat, filter);
+
+                if (path != null && criteriaValue != null) {
+                    applyFilter(builder, filter, criteriaValue, criteriaMemberStat);
                 }
             });
         }
         return builder;
     }
 
-    private void applyFilter(BooleanBuilder builder, String filterKey, Object filterValue) {
+    // 상세 검색 필터링 (key : value) 필터링
+    private BooleanBuilder applyFilters(HashMap<String, List<?>> filterMap,
+        MemberStat criteriaMemberStat) {
+        BooleanBuilder builder = new BooleanBuilder();
+        if (filterMap != null) {
+            filterMap.forEach((key, value) -> {
+                // value가 빈 배열이 아닐때만 적용
+                if (value != null && !value.isEmpty()) {
+                    applyFilter(builder, key, value, criteriaMemberStat);
+                }
+            });
+        }
+        return builder;
+    }
+
+    private void applyFilter(BooleanBuilder builder, String filterKey, Object filterValue,
+        MemberStat criteriaMemberStat) {
 
         if (Objects.isNull(filterValue)) {
             return;
@@ -122,7 +138,8 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
             case "StringPath" ->
                 handleStringPathFilter(builder, (StringPath) path, filterKey, filterValue);
             case "NumberPath" ->
-                builder.and(handleNumberFilter((NumberPath<Integer>) path, filterValue));
+                handleNumberPathFilter(builder, (NumberPath<Integer>) path, filterKey, filterValue,
+                    criteriaMemberStat);
             case "BooleanPath" -> builder.and(handleBooleanFilter((BooleanPath) path, filterValue));
             case "DatePath" ->
                 builder.and(handleDateFilter((DatePath<LocalDate>) path, filterValue));
@@ -133,24 +150,57 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
 
     private void handleStringPathFilter(BooleanBuilder builder, StringPath stringPath,
         String filterKey, Object filterValue) {
-        if (filterKey.equals(PERSONALITY)) {
-            builder.and(handlePersonalityFilter(stringPath, filterValue));
-        }
-        else {
+        // 다중 선택 요소들의 경우
+        if (filterKey.equals(PERSONALITY) || filterKey.equals(SLEEPING_HABIT)) {
+            builder.and(handleMultiStringContentFilter(stringPath, filterValue));
+        } else {
             builder.and(handleStringFilter(stringPath, filterValue));
         }
     }
 
+    private void handleNumberPathFilter(BooleanBuilder builder, NumberPath<Integer> numberPath,
+        String filterKey, Object filterValue, MemberStat criteriaMemberStat) {
+        if (filterKey.equals(NUM_OF_ROOMMATE)) {
+            builder.and(handleNumberOfRoommateFilter(numberPath, filterValue, criteriaMemberStat));
+        } else {
+            builder.and(handleNumberFilter(numberPath, filterValue));
+        }
+    }
+
     // 성격은 다중 선택으로 String의 조합으로 저장됨. 따라서 일반 String 필터링과 분리함.
-    private BooleanExpression handlePersonalityFilter(StringPath path, Object filterValue) {
+    private BooleanExpression handleMultiStringContentFilter(StringPath path, Object filterValue) {
         if (filterValue instanceof String value) {
-            return path.eq(value);  // 단일 문자열 비교
+            return path.eq(value);
         } else if (filterValue instanceof List<?> values) {
             return values.stream()
                 .map(String::valueOf)
                 .map(value -> path.like("%" + value + "%"))
                 .reduce(BooleanExpression::and)
                 .orElse(null);
+        }
+        return null;
+    }
+
+
+    private BooleanExpression handleNumberOfRoommateFilter(NumberPath<Integer> path,
+        Object filterValue, MemberStat criteriaMemberStat) {
+        if (filterValue instanceof Integer value) {
+            // 미정일 경우 모든 조건을 보여줘야 함
+            if (value.equals(0)) {
+                return null;
+            }
+            // 나머지는 자신의 인실에 맞춰서 보여줌
+            return path.eq(value);
+        } else if (filterValue instanceof List<?> values) {
+            if(criteriaMemberStat.getNumOfRoommate().equals(NUM_OF_ROOMMATE_NOT_DETERMINED)){
+                // 미정을 선택한 사용자는 자유롭게 필터링 가능
+                return path.in((List<Integer>) values);
+            }
+            // 특정 인실을 선택한 사용자는 필터링 불가능
+
+            throw new GeneralException((ErrorStatus._MEMBERSTAT_FILTER_CANNOT_FILTER_ROOMMATE));
+
+            // return null;
         }
         return null;
     }
@@ -167,6 +217,7 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
 
     // Integer 형식을 다루는 Boolean Expression
     private BooleanExpression handleNumberFilter(NumberPath<Integer> path, Object filterValue) {
+
         if (filterValue instanceof Integer value) {
             return path.eq(value);
         } else if (filterValue instanceof List<?> values) {
@@ -189,7 +240,10 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
     private BooleanExpression handleDateFilter(DatePath<LocalDate> path, Object filterValue) {
         if (filterValue instanceof Integer value) {
             return Expressions.numberTemplate(Integer.class, "year({0})", path).eq(value);
-        } else if (filterValue instanceof List<?> values) {
+        }  else if(filterValue instanceof LocalDate value) {
+            return Expressions.numberTemplate(Integer.class, "year({0})", path).eq(value.getYear());
+        }
+        else if (filterValue instanceof List<?> values) {
             List<Integer> value = values.stream()
                 .map(Integer.class::cast)
                 .toList();
@@ -209,6 +263,7 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
             case "turnOffTime" -> memberStat.turnOffTime;
             case "smoking" -> memberStat.smoking;
             case "sleepingHabit" -> memberStat.sleepingHabit;
+            case "numOfRoommate" -> memberStat.numOfRoommate;
             case "airConditioningIntensity" -> memberStat.airConditioningIntensity;
             case "heatingIntensity" -> memberStat.heatingIntensity;
             case "lifePattern" -> memberStat.lifePattern;
@@ -227,6 +282,38 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
             case "birthYear" -> member.birthDay;
             default ->
                 throw new GeneralException(ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID);
+        };
+    }
+
+    private Object getFieldValueByKey(MemberStat criteriaMemberStat, String key) {
+
+        return switch (key) {
+            case "acceptance" -> criteriaMemberStat.getAcceptance();
+            case "admissionYear" -> criteriaMemberStat.getAdmissionYear();
+            case "major" -> criteriaMemberStat.getMajor();
+            case "wakeUpTime" -> criteriaMemberStat.getWakeUpTime();
+            case "sleepingTime" -> criteriaMemberStat.getSleepingTime();
+            case "turnOffTime" -> criteriaMemberStat.getTurnOffTime();
+            case "smoking" -> criteriaMemberStat.getSmoking();
+            case "sleepingHabit" -> criteriaMemberStat.getSleepingHabit();
+            case "numOfRoommate" -> criteriaMemberStat.getNumOfRoommate();
+            case "airConditioningIntensity" -> criteriaMemberStat.getAirConditioningIntensity();
+            case "heatingIntensity" -> criteriaMemberStat.getHeatingIntensity();
+            case "lifePattern" -> criteriaMemberStat.getLifePattern();
+            case "intimacy" -> criteriaMemberStat.getIntimacy();
+            case "canShare" -> criteriaMemberStat.getCanShare();
+            case "isPlayGame" -> criteriaMemberStat.getIsPlayGame();
+            case "isPhoneCall" -> criteriaMemberStat.getIsPhoneCall();
+            case "studying" -> criteriaMemberStat.getStudying();
+            case "intake" -> criteriaMemberStat.getIntake();
+            case "cleanSensitivity" -> criteriaMemberStat.getCleanSensitivity();
+            case "noiseSensitivity" -> criteriaMemberStat.getNoiseSensitivity();
+            case "cleaningFrequency" -> criteriaMemberStat.getCleaningFrequency();
+            case "personality" -> criteriaMemberStat.getPersonality();
+            case "drinkingFrequency" -> criteriaMemberStat.getDrinkingFrequency();
+            case "mbti" -> criteriaMemberStat.getMbti();
+            case "birthYear" -> criteriaMemberStat.getMember().getBirthDay();
+            default -> null;
         };
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
@@ -3,136 +3,230 @@ package com.cozymate.cozymate_server.domain.memberstat.repository.querydsl;
 import static com.cozymate.cozymate_server.domain.member.QMember.member;
 import static com.cozymate.cozymate_server.domain.memberstat.QMemberStat.memberStat;
 
+import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.BooleanPath;
-import com.querydsl.core.types.dsl.NumberPath;
-import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
-public class MemberStatQueryRepositoryImpl implements
-    MemberStatQueryRepository {
+public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private static final Integer NUM_OF_ROOMMATE_NOT_DETERMINED = 0;
+    private static final String PERSONALITY = "personality";
+
+    private JPAQuery<Tuple> createBaseQuery(MemberStat criteriaMemberStat) {
+        return queryFactory
+            .select(memberStat, member)
+            .from(memberStat)
+            .join(memberStat.member, member)
+            .where(initDefaultQuery(criteriaMemberStat));
+    }
 
     @Override
-    public List<MemberStat> getFilteredMemberStat(List<String> filterList, MemberStat criteriaMemberStat) {
-        JPAQuery<MemberStat> baseQuery = queryFactory.selectFrom(memberStat);
+    public Map<Member, MemberStat> getFilteredMemberStat(List<String> filterList, MemberStat criteriaMemberStat) {
+        // Tuple로 MemberStat과 Member를 함께 조회
+        List<Tuple> results = createBaseQuery(criteriaMemberStat)
+            .where(applyFilters(filterList, criteriaMemberStat))
+            .fetch();
 
+        // 결과를 Map<Member, MemberStat>으로 변환
+        return results.stream()
+            .collect(Collectors.toMap(
+                tuple -> tuple.get(member),         // key: Member
+                tuple -> tuple.get(memberStat)      // value: MemberStat
+            ));
+    }
+
+    @Override
+    public Map<Member, MemberStat> getAdvancedFilteredMemberStat(HashMap<String, List<?>> filterMap, MemberStat criteriaMemberStat) {
+        // Tuple로 MemberStat과 Member를 함께 조회
+        List<Tuple> results = createBaseQuery(criteriaMemberStat)
+            .where(applyFilters(filterMap))
+            .fetch();
+
+        // 결과를 Map<Member, MemberStat>으로 변환
+        return results.stream()
+            .collect(Collectors.toMap(
+                tuple -> tuple.get(member),         // key: Member
+                tuple -> tuple.get(memberStat)      // value: MemberStat
+            ));
+    }
+
+    private BooleanBuilder initDefaultQuery(MemberStat criteriaMemberStat) {
+
+        BooleanBuilder builder = new BooleanBuilder()
+            .and(memberStat.id.ne(criteriaMemberStat.getId()))
+            .and(member.gender.eq(criteriaMemberStat.getMember().getGender()))
+            .and(memberStat.university.id.eq(criteriaMemberStat.getUniversity().getId()));
+
+        // '미정'인 경우 인실 조건을 무시, 그렇지 않으면 인실 조건 추가
+        if (!criteriaMemberStat.getNumOfRoommate().equals(NUM_OF_ROOMMATE_NOT_DETERMINED)) {
+            builder.and(memberStat.numOfRoommate.eq(criteriaMemberStat.getNumOfRoommate()));
+        }
+
+        return builder;
+    }
+
+    // 단순 필터링 (완전 일치)
+    private BooleanBuilder applyFilters(List<String> filterList, MemberStat criteriaMemberStat) {
         BooleanBuilder builder = new BooleanBuilder();
-
-        //criteriaMemberStat은 제외하기
-        builder.and(memberStat.id.ne(criteriaMemberStat.getId()));
-        //성별이 틀리면 제외
-        builder.and(member.gender.eq(criteriaMemberStat.getMember().getGender()));
-        // 대학이 틀리면 제외
-        builder.and(memberStat.university.id.eq(criteriaMemberStat.getUniversity().getId()));
-
         if (filterList != null) {
             filterList.forEach(filter -> applyFilter(builder, filter, criteriaMemberStat));
         }
-
-        return baseQuery
-            .join(memberStat.member, member)
-            .where(builder)
-            .fetch();
+        return builder;
     }
 
-    private void applyFilter(BooleanBuilder builder, String filter, MemberStat criteriaMemberStat) {
-        switch (filter) {
-            case "acceptance":
-                builder.and(stringEquals(criteriaMemberStat.getAcceptance(), memberStat.acceptance));
-                break;
-            case "admissionYear":
-                builder.and(integerEquals(criteriaMemberStat.getAdmissionYear(), memberStat.admissionYear));
-                break;
-            case "major":
-                builder.and(stringEquals(criteriaMemberStat.getMajor(), memberStat.major));
-                break;
-            case "numOfRoommate":
-                builder.and(integerEquals(criteriaMemberStat.getNumOfRoommate(), memberStat.numOfRoommate));
-                break;
-            case "wakeUpTime":
-                builder.and(integerEquals(criteriaMemberStat.getWakeUpTime(), memberStat.wakeUpTime));
-                break;
-            case "sleepingTime":
-                builder.and(integerEquals(criteriaMemberStat.getSleepingTime(), memberStat.sleepingTime));
-                break;
-            case "turnOffTime":
-                builder.and(integerEquals(criteriaMemberStat.getTurnOffTime(), memberStat.turnOffTime));
-                break;
-            case "smoking":
-                builder.and(stringEquals(criteriaMemberStat.getSmoking(), memberStat.smoking));
-                break;
-            case "sleepingHabit":
-                builder.and(stringEquals(criteriaMemberStat.getSleepingHabit(), memberStat.sleepingHabit));
-                break;
-            case "airConditioningIntensity":
-                builder.and(integerEquals(criteriaMemberStat.getAirConditioningIntensity(), memberStat.airConditioningIntensity));
-                break;
-            case "heatingIntensity":
-                builder.and(integerEquals(criteriaMemberStat.getHeatingIntensity(), memberStat.heatingIntensity));
-                break;
-            case "lifePattern":
-                builder.and(stringEquals(criteriaMemberStat.getLifePattern(), memberStat.lifePattern));
-                break;
-            case "intimacy":
-                builder.and(stringEquals(criteriaMemberStat.getIntimacy(), memberStat.intimacy));
-                break;
-            case "canShare":
-                builder.and(booleanEquals(criteriaMemberStat.getCanShare(), memberStat.canShare));
-                break;
-            case "isPlayGame":
-                builder.and(booleanEquals(criteriaMemberStat.getIsPlayGame(), memberStat.isPlayGame));
-                break;
-            case "isPhoneCall":
-                builder.and(booleanEquals(criteriaMemberStat.getIsPhoneCall(), memberStat.isPhoneCall));
-                break;
-            case "studying":
-                builder.and(stringEquals(criteriaMemberStat.getStudying(), memberStat.studying));
-                break;
-            case "intake":
-                builder.and(stringEquals(criteriaMemberStat.getIntake(), memberStat.intake));
-                break;
-            case "cleanSensitivity":
-                builder.and(integerEquals(criteriaMemberStat.getCleanSensitivity(), memberStat.cleanSensitivity));
-                break;
-            case "noiseSensitivity":
-                builder.and(integerEquals(criteriaMemberStat.getNoiseSensitivity(), memberStat.noiseSensitivity));
-                break;
-            case "cleaningFrequency":
-                builder.and(stringEquals(criteriaMemberStat.getCleaningFrequency(), memberStat.cleaningFrequency));
-                break;
-            case "personality":
-                builder.and(stringEquals(criteriaMemberStat.getPersonality(), memberStat.personality));
-                break;
-            case "mbti":
-                builder.and(stringEquals(criteriaMemberStat.getMbti(), memberStat.mbti));
-                break;
-            default:
+    // 상세 검색 필터링 (key : value) 필터링
+    private BooleanBuilder applyFilters(HashMap<String, List<?>> filterMap) {
+        BooleanBuilder builder = new BooleanBuilder();
+        if (filterMap != null) {
+            filterMap.forEach((key, value) -> {
+                // value가 빈 배열이 아닐때만 적용
+                if (value != null && !value.isEmpty()) {
+                    applyFilter(builder, key, value);
+                }
+            });
+        }
+        return builder;
+    }
+
+    private void applyFilter(BooleanBuilder builder, String filterKey, Object filterValue) {
+
+        if (Objects.isNull(filterValue)) {
+            return;
+        }
+
+        Path<?> path = getPathByKey(filterKey);
+
+        if (path == null) {
+            throw new GeneralException(ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID);
+        }
+
+        switch (path.getClass().getSimpleName()) {
+            case "StringPath" ->
+                handleStringPathFilter(builder, (StringPath) path, filterKey, filterValue);
+            case "NumberPath" ->
+                builder.and(handleNumberFilter((NumberPath<Integer>) path, filterValue));
+            case "BooleanPath" -> builder.and(handleBooleanFilter((BooleanPath) path, filterValue));
+            case "DatePath" ->
+                builder.and(handleDateFilter((DatePath<LocalDate>) path, filterValue));
+            default ->
                 throw new GeneralException(ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID);
         }
     }
 
-    private BooleanExpression stringEquals(String value, StringPath path) {
-        return value == null ? null : path.eq(value);
+    private void handleStringPathFilter(BooleanBuilder builder, StringPath stringPath,
+        String filterKey, Object filterValue) {
+        if (filterKey.equals(PERSONALITY)) {
+            builder.and(handlePersonalityFilter(stringPath, filterValue));
+        }
+        else {
+            builder.and(handleStringFilter(stringPath, filterValue));
+        }
     }
 
-    private BooleanExpression integerEquals(Integer value, NumberPath<Integer> path) {
-        return value == null ? null : path.eq(value);
+    // 성격은 다중 선택으로 String의 조합으로 저장됨. 따라서 일반 String 필터링과 분리함.
+    private BooleanExpression handlePersonalityFilter(StringPath path, Object filterValue) {
+        if (filterValue instanceof String value) {
+            return path.eq(value);  // 단일 문자열 비교
+        } else if (filterValue instanceof List<?> values) {
+            return values.stream()
+                .map(String::valueOf)
+                .map(value -> path.like("%" + value + "%"))
+                .reduce(BooleanExpression::and)
+                .orElse(null);
+        }
+        return null;
     }
 
-    private BooleanExpression booleanEquals(Boolean value, BooleanPath path) {
-        return value == null ? null : path.eq(value);
+    // 일반 String을 다루는 BooleanExpression
+    private BooleanExpression handleStringFilter(StringPath path, Object filterValue) {
+        if (filterValue instanceof String value) {
+            return path.eq(value);
+        } else if (filterValue instanceof List<?> values) {
+            return path.in((List<String>) values);
+        }
+        return null;
     }
 
+    // Integer 형식을 다루는 Boolean Expression
+    private BooleanExpression handleNumberFilter(NumberPath<Integer> path, Object filterValue) {
+        if (filterValue instanceof Integer value) {
+            return path.eq(value);
+        } else if (filterValue instanceof List<?> values) {
+            return path.in((List<Integer>) values);
+        }
+        return null;
+    }
+
+    // Boolean 형식을 다루는 Boolean Expression
+    private BooleanExpression handleBooleanFilter(BooleanPath path, Object filterValue) {
+        if (filterValue instanceof Boolean value) {
+            return path.eq(value);
+        } else if (filterValue instanceof List<?> values) {
+            return path.in((List<Boolean>) values);
+        }
+        return null;
+    }
+
+    // Date 형식(출생 년도)를 다루는 Boolean Expression
+    private BooleanExpression handleDateFilter(DatePath<LocalDate> path, Object filterValue) {
+        if (filterValue instanceof Integer value) {
+            return Expressions.numberTemplate(Integer.class, "year({0})", path).eq(value);
+        } else if (filterValue instanceof List<?> values) {
+            List<Integer> value = values.stream()
+                .map(Integer.class::cast)
+                .toList();
+            return Expressions.numberTemplate(Integer.class, "year({0})", path).in(value);
+        }
+        return null;
+    }
+
+
+    private Path<?> getPathByKey(String key) {
+        return switch (key) {
+            case "acceptance" -> memberStat.acceptance;
+            case "admissionYear" -> memberStat.admissionYear;
+            case "major" -> memberStat.major;
+            case "wakeUpTime" -> memberStat.wakeUpTime;
+            case "sleepingTime" -> memberStat.sleepingTime;
+            case "turnOffTime" -> memberStat.turnOffTime;
+            case "smoking" -> memberStat.smoking;
+            case "sleepingHabit" -> memberStat.sleepingHabit;
+            case "airConditioningIntensity" -> memberStat.airConditioningIntensity;
+            case "heatingIntensity" -> memberStat.heatingIntensity;
+            case "lifePattern" -> memberStat.lifePattern;
+            case "intimacy" -> memberStat.intimacy;
+            case "canShare" -> memberStat.canShare;
+            case "isPlayGame" -> memberStat.isPlayGame;
+            case "isPhoneCall" -> memberStat.isPhoneCall;
+            case "studying" -> memberStat.studying;
+            case "intake" -> memberStat.intake;
+            case "cleanSensitivity" -> memberStat.cleanSensitivity;
+            case "noiseSensitivity" -> memberStat.noiseSensitivity;
+            case "cleaningFrequency" -> memberStat.cleaningFrequency;
+            case "personality" -> memberStat.personality;
+            case "drinkingFrequency" -> memberStat.drinkingFrequency;
+            case "mbti" -> memberStat.mbti;
+            case "birthYear" -> member.birthDay;
+            default ->
+                throw new GeneralException(ErrorStatus._MEMBERSTAT_FILTER_PARAMETER_NOT_VALID);
+        };
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
@@ -72,9 +72,9 @@ public class MemberStatCommandService {
 
     }
 
-    public void deleteMemberStat(Long memberId){
+    public void deleteMemberStat(Long memberId) {
 
-        if(!memberStatRepository.existsById(memberId)){
+        if (!memberStatRepository.existsById(memberId)) {
             throw new GeneralException(ErrorStatus._MEMBER_NOT_FOUND);
         }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
@@ -1,16 +1,15 @@
 package com.cozymate.cozymate_server.domain.memberstat.service;
 
 import com.cozymate.cozymate_server.domain.member.Member;
-import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 import com.cozymate.cozymate_server.domain.memberstat.converter.MemberStatConverter;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatRequestDTO.MemberStatCommandRequestDTO;
 import com.cozymate.cozymate_server.domain.memberstat.repository.MemberStatRepository;
+import com.cozymate.cozymate_server.domain.memberstatequality.service.MemberStatEqualityCommandService;
 import com.cozymate.cozymate_server.domain.university.University;
 import com.cozymate.cozymate_server.domain.university.UniversityRepository;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,6 +23,7 @@ public class MemberStatCommandService {
 
     private final MemberStatRepository memberStatRepository;
     private final UniversityRepository universityRepository;
+    private final MemberStatEqualityCommandService memberStatEqualityCommandService;
 
     public Long createMemberStat(
         Member member, MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
@@ -43,6 +43,10 @@ public class MemberStatCommandService {
             )
         );
 
+        memberStatEqualityCommandService.createMemberStatEqualities(
+            saveMemberStat
+        );
+
         return saveMemberStat.getId();
     }
 
@@ -59,6 +63,11 @@ public class MemberStatCommandService {
             );
 
         updatedMemberStat.update(member, university, memberStatCommandRequestDTO);
+
+        memberStatEqualityCommandService.updateMemberStatEqualities(
+            updatedMemberStat
+        );
+
         return updatedMemberStat.getId();
 
     }
@@ -71,6 +80,10 @@ public class MemberStatCommandService {
 
         MemberStat memberStat = memberStatRepository.findByMemberId(memberId).orElseThrow(
             () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
+        );
+
+        memberStatEqualityCommandService.deleteMemberStatEqualities(
+            memberStat
         );
 
         memberStatRepository.delete(memberStat);

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -67,6 +67,15 @@ public class MemberStatQueryService {
         );
     }
 
+    public Integer getNumOfRoommateStatus(Long memberId) {
+
+        MemberStat memberStat = memberStatRepository.findByMemberId(memberId).orElseThrow(
+            () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
+        );
+
+        return memberStat.getNumOfRoommate();
+    }
+
     public PageResponseDto<List<?>> getMemberStatList(Member member,
         List<String> filterList, Pageable pageable, boolean needsDetail) {
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -8,13 +8,15 @@ import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.repository.MemberStatRepository;
-import com.cozymate.cozymate_server.domain.memberstat.util.MemberUtil;
+import com.cozymate.cozymate_server.domain.memberstatequality.service.MemberStatEqualityQueryService;
 import com.cozymate.cozymate_server.global.common.PageResponseDto;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +34,7 @@ public class MemberStatQueryService {
     private final MemberRepository memberRepository;
 
 
+    private final MemberStatEqualityQueryService memberStatEqualityQueryService;
 
     public MemberStatQueryResponseDTO getMemberStat(Member member) {
 
@@ -67,48 +70,139 @@ public class MemberStatQueryService {
     public PageResponseDto<List<?>> getMemberStatList(Member member,
         List<String> filterList, Pageable pageable, boolean needsDetail) {
 
-        //일치율의 기준이 되는 MemberStat을 가져오고, 유효성을 검사합니다.
-        MemberStat criteriaMemberStat = memberStatRepository.findByMemberId(member.getId())
-            .orElseThrow(
-                () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
-            );
+        MemberStat criteriaMemberStat = getCriteriaMemberStat(member);
 
-        //필터링된 리스트들을 가져옵니다. 필터가 없을 경우, 모두 가져옵니다.
-        List<MemberStat> filteredResult = memberStatRepository.getFilteredMemberStat(filterList,
+        // List<MemberStat> -> Map<Member,MemberStat>으로 변경,
+        // LazyFetch로 인해서 N+1 문제 발생해, 쿼리를 한번에 처리하기로 결정.
+        Map<Member, MemberStat> filteredResult = memberStatRepository.getFilteredMemberStat(filterList,
             criteriaMemberStat);
 
-        if (filteredResult.isEmpty()) {
-            return new PageResponseDto<>(pageable.getPageNumber(), false, Collections.emptyList());
+        if (filteredResult.isEmpty()){
+            return createEmptyPageResponse(pageable);
         }
 
+        //N+1 문제 발생, 해결 위해 MAP을 활용한 방식 적용
+        //Filtering 시 Member와 MemberStat을 join을 하기 때문에, Member를 Select하는 것을 추가한다고
+        // 자원 소모의차이가 크지 않을 것이라고 생각했음.
+
+//        Map<Long,Integer> memberStatEqualities = memberStatEqualityQueryService.getEquality(
+//            criteriaMemberStat.getMember().getId(),
+//            filteredResult.stream().map(memberStat -> memberStat.getMember().getId()).toList()
+//        );
+
+
+        List<Long> memberIds = filteredResult.keySet().stream()
+            .map(Member::getId)
+            .toList();
+
+
+        Map<Long,Integer> memberStatEqualities = memberStatEqualityQueryService.getEquality(member.getId(), memberIds);
+
+        // 이 부분 이후는 DB 안 건들고, Application 내에서 계산.
+        // 쿼리는 필터링은 한번,
+        // 일치율 조회 한번으로 줄이고(N+1 Problem -> 조회 1회), 응답속도를 비약적으로 개선함.
         if (needsDetail) {
-            List<MemberStatEqualityDetailResponseDTO> result = filteredResult.stream()
-                .map(memberStat -> {
-                    MemberStatEqualityResponseDTO equalityResponse = MemberStatConverter.toEqualityDto(memberStat, MemberUtil.calculateScore(
-                        criteriaMemberStat, memberStat));
-                    MemberStatQueryResponseDTO queryResponse = MemberStatConverter.toDto(
-                        memberStat, memberStat.getMember().getBirthDay().getYear());
-                    return MemberStatEqualityDetailResponseDTO.builder()
-                        .info(equalityResponse)
-                        .detail(queryResponse)
-                        .build();
-                })
-                .sorted((dto1, dto2) -> Integer.compare(
-                    dto2.getMemberStatEqualityResponseDTO().getEquality(),
-                    dto1.getMemberStatEqualityResponseDTO().getEquality()
-                ))
-                .toList();
+            List<MemberStatEqualityDetailResponseDTO> result =
+                createDetailedResponse(filteredResult, memberStatEqualities);
             return toPageResponseDto(result, pageable);
         }
 
-        List<MemberStatEqualityResponseDTO> result = filteredResult
-            .stream()
-            .map(memberStat -> MemberStatConverter.toEqualityDto(memberStat,MemberUtil.calculateScore(criteriaMemberStat, memberStat)))
-            .sorted(Comparator.comparingInt(MemberStatEqualityResponseDTO::getEquality).reversed())
-            .toList();
-
+        List<MemberStatEqualityResponseDTO> result =
+            createEqualityResponse(filteredResult, memberStatEqualities);
         return toPageResponseDto(result, pageable);
 
+    }
+
+    public PageResponseDto<List<?>> getSearchedAndFilteredMemberStatList(Member member, HashMap<String, List<?>> filterMap, Pageable pageable, boolean needsDetail) {
+
+        MemberStat criteriaMemberStat = getCriteriaMemberStat(member);
+
+        Map<Member,MemberStat> filteredResult = memberStatRepository.getAdvancedFilteredMemberStat(filterMap,
+            criteriaMemberStat);
+
+        if (filteredResult.isEmpty()) {
+            return createEmptyPageResponse(pageable);
+        }
+
+        List<Long> memberIds = filteredResult.keySet().stream()
+            .map(Member::getId)
+            .toList();
+
+        Map<Long,Integer> memberStatEqualities = memberStatEqualityQueryService.getEquality(member.getId(), memberIds);
+
+        if (needsDetail) {
+            List<MemberStatEqualityDetailResponseDTO> result =
+                createDetailedResponse(filteredResult, memberStatEqualities);
+            return toPageResponseDto(result, pageable);
+        }
+
+        List<MemberStatEqualityResponseDTO> result =
+            createEqualityResponse(filteredResult, memberStatEqualities);
+        return toPageResponseDto(result, pageable);
+
+    }
+
+    public Integer getNumOfSearchedAndFilteredMemberStatList(Member member, HashMap<String, List<?>> filterMap) {
+        // 여기서 드는 의문.. 쿼리 개수 vs 쿼리 무게
+        MemberStat criteriaMemberStat = getCriteriaMemberStat(member);
+
+        Map<Member,MemberStat> filteredResult = memberStatRepository.getAdvancedFilteredMemberStat(filterMap,
+            criteriaMemberStat);
+
+        return filteredResult.size();
+
+
+    }
+
+    private List<MemberStatEqualityDetailResponseDTO> createDetailedResponse(
+        Map<Member, MemberStat> memberStats, Map<Long, Integer> memberStatEqualities) {
+
+        List<MemberStatEqualityResponseDTO> memberStatEqualityResponseDTOList = createEqualityResponse(memberStats,memberStatEqualities);
+
+        return memberStatEqualityResponseDTOList.stream()
+            .map(equalityResponse -> {
+
+                MemberStat memberStat = memberStats.values().stream()
+                    .filter(stat -> stat.getMember().getId().equals(equalityResponse.getMemberId()))
+                    .findFirst()
+                    .orElse(null);
+
+                MemberStatQueryResponseDTO queryResponse = MemberStatConverter.toDto(
+                    memberStat, memberStat.getMember().getBirthDay().getYear()
+                );
+
+                return MemberStatEqualityDetailResponseDTO.builder()
+                    .info(equalityResponse)
+                    .detail(queryResponse)
+                    .build();
+            })
+            .toList();
+    }
+
+    private List<MemberStatEqualityResponseDTO> createEqualityResponse(
+        Map<Member, MemberStat> memberStats, Map<Long, Integer> memberStatEqualities) {
+
+        return memberStats.entrySet().stream()
+            .map(entry -> {
+                Member member = entry.getKey();
+                MemberStat memberStat = entry.getValue();
+
+                return MemberStatConverter.toEqualityDto(
+                    memberStat,
+                    memberStatEqualities.getOrDefault(member.getId(), 0)
+                );
+            })
+            .sorted(Comparator.comparingInt(MemberStatEqualityResponseDTO::getEquality).reversed())
+            .toList();
+    }
+
+    private MemberStat getCriteriaMemberStat(Member member) {
+        return memberStatRepository.findByMemberId(member.getId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS));
+    }
+
+    private PageResponseDto<List<?>> createEmptyPageResponse(Pageable pageable) {
+        return new PageResponseDto<>(pageable.getPageNumber(), false, Collections.emptyList());
     }
 
     private PageResponseDto<List<?>> toPageResponseDto(List<?> result, Pageable pageable) {
@@ -129,6 +223,4 @@ public class MemberStatQueryService {
             pageable.getPageNumber() + 1 < totalPages, result.subList(start, end));
 
     }
-
-
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberStatUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberStatUtil.java
@@ -9,7 +9,7 @@ public class MemberStatUtil {
     public static String toSortedString(List<String> list) {
         return list.stream()
             .sorted()
-            .collect(Collectors.joining(",")) + ",";
+            .collect(Collectors.joining(","));
     }
 
     public static List<String> fromStringToList(String str) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberStatUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberStatUtil.java
@@ -1,0 +1,19 @@
+package com.cozymate.cozymate_server.domain.memberstat.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MemberStatUtil {
+
+    public static String toSortedString(List<String> list) {
+        return list.stream()
+            .sorted()
+            .collect(Collectors.joining(",")) + ",";
+    }
+
+    public static List<String> fromStringToList(String str) {
+        return Arrays.stream(str.replaceAll(",$", "").split(","))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/MemberStatEquality.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/MemberStatEquality.java
@@ -1,0 +1,41 @@
+package com.cozymate.cozymate_server.domain.memberstatequality;
+
+import com.cozymate.cozymate_server.global.utils.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity
+@Table(name = "member_stat_equality",
+    indexes = {
+        @Index(name = "idx_member_a_id", columnList = "memberAId")
+    })
+public class MemberStatEquality {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberAId;
+
+    private Long memberBId;
+
+    private Integer equality;
+
+    public void updateEquality(Integer equality) {
+        this.equality = equality;
+    }
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/MemberStatEquality.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/MemberStatEquality.java
@@ -34,8 +34,9 @@ public class MemberStatEquality {
 
     private Integer equality;
 
-    public void updateEquality(Integer equality) {
+    public MemberStatEquality updateEquality(Integer equality) {
         this.equality = equality;
+        return this;
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/controller/MemberStatEqualityController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/controller/MemberStatEqualityController.java
@@ -77,6 +77,7 @@ public class MemberStatEqualityController {
             ));
     }
 
+    @Deprecated(forRemoval = true)
     @Operation(
         summary = "[포비] 일치율 업데이트(관리자용)",
         description = "요청자의 토큰을 넣고, 일치율 정책이 바뀌어 재계산이 필요할 때 사용합니다.\n\n"
@@ -87,6 +88,7 @@ public class MemberStatEqualityController {
         ErrorStatus._MEMBERSTAT_NOT_EXISTS
     })
     public ResponseEntity<ApiResponse<Boolean>> updateMemberStatEqualityWithMemberId(
+
     ) {
         memberStatEqualityCommandService.recalculateAllMemberStatEquality();
         return ResponseEntity.ok(

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/controller/MemberStatEqualityController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/controller/MemberStatEqualityController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +26,7 @@ public class MemberStatEqualityController {
         summary = "[포비] 일치율 계산(관리자용)",
         description = "요청자의 토큰을 넣고, 일치율을 생성하고자 하는 멤버의 정보를 넣어 사용합니다.\n\n"
     )
-    @PostMapping("")
+    @PostMapping("/generate")
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._MEMBERSTAT_NOT_EXISTS
@@ -33,6 +34,61 @@ public class MemberStatEqualityController {
     public ResponseEntity<ApiResponse<Boolean>> generateMemberStatEquality(
     ) {
         memberStatEqualityCommandService.generateAllMemberStatEquality();
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(
+                true
+            ));
+    }
+
+    @Operation(
+        summary = "[포비] 일치율 삭제(관리자용)",
+        description = "요청자의 토큰을 넣고, 일치율을 삭제하고자 하는 멤버의 정보를 넣어 사용합니다.\n\n"
+    )
+    @DeleteMapping("/{memberId}")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._MEMBERSTAT_NOT_EXISTS
+    })
+    public ResponseEntity<ApiResponse<Boolean>> deleteMemberStatEqualityWithMemberId(
+        @PathVariable Long memberId
+    ) {
+        memberStatEqualityCommandService.deleteMemberStatEqualitiesWithMemberId(memberId);
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(
+                true
+            ));
+    }
+
+    @Operation(
+        summary = "[포비] 일치율 재계산(관리자용)",
+        description = "요청자의 토큰을 넣고, 일치율 정책이 바뀌어 재계산이 필요할 때 사용합니다.\n\n"
+    )
+    @PostMapping("/recalculate")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._MEMBERSTAT_NOT_EXISTS
+    })
+    public ResponseEntity<ApiResponse<Boolean>> deleteMemberStatEqualityWithMemberId(
+    ) {
+        memberStatEqualityCommandService.recalculateAllMemberStatEquality();
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(
+                true
+            ));
+    }
+
+    @Operation(
+        summary = "[포비] 일치율 업데이트(관리자용)",
+        description = "요청자의 토큰을 넣고, 일치율 정책이 바뀌어 재계산이 필요할 때 사용합니다.\n\n"
+    )
+    @PostMapping("/update")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._MEMBERSTAT_NOT_EXISTS
+    })
+    public ResponseEntity<ApiResponse<Boolean>> updateMemberStatEqualityWithMemberId(
+    ) {
+        memberStatEqualityCommandService.recalculateAllMemberStatEquality();
         return ResponseEntity.ok(
             ApiResponse.onSuccess(
                 true

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/controller/MemberStatEqualityController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/controller/MemberStatEqualityController.java
@@ -1,0 +1,42 @@
+package com.cozymate.cozymate_server.domain.memberstatequality.controller;
+
+import com.cozymate.cozymate_server.domain.memberstatequality.service.MemberStatEqualityCommandService;
+import com.cozymate.cozymate_server.global.response.ApiResponse;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequestMapping("/members/stat/equality")
+@RequiredArgsConstructor
+@RestController
+public class MemberStatEqualityController {
+
+    private final MemberStatEqualityCommandService memberStatEqualityCommandService;
+
+    @Operation(
+        summary = "[포비] 일치율 계산(관리자용)",
+        description = "요청자의 토큰을 넣고, 일치율을 생성하고자 하는 멤버의 정보를 넣어 사용합니다.\n\n"
+    )
+    @PostMapping("")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._MEMBERSTAT_NOT_EXISTS
+    })
+    public ResponseEntity<ApiResponse<Boolean>> generateMemberStatEquality(
+    ) {
+        memberStatEqualityCommandService.generateAllMemberStatEquality();
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(
+                true
+            ));
+    }
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityBulkRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityBulkRepository.java
@@ -25,8 +25,8 @@ public class MemberStatEqualityBulkRepository {
             memberStatEqualityList.size(),
             (PreparedStatement ps, MemberStatEquality memberStatEquality) -> {
                 ps.setInt(1, memberStatEquality.getEquality());
-                ps.setLong(2,memberStatEquality.getMemberAId());
-                ps.setLong(3,memberStatEquality.getMemberBId());
+                ps.setLong(2, memberStatEquality.getMemberAId());
+                ps.setLong(3, memberStatEquality.getMemberBId());
             }
         );
     }
@@ -41,8 +41,8 @@ public class MemberStatEqualityBulkRepository {
             memberStatEqualityList.size(),
             (PreparedStatement ps, MemberStatEquality memberStatEquality) -> {
                 ps.setInt(1, memberStatEquality.getEquality());
-                ps.setLong(2,memberStatEquality.getMemberAId());
-                ps.setLong(3,memberStatEquality.getMemberBId());
+                ps.setLong(2, memberStatEquality.getMemberAId());
+                ps.setLong(3, memberStatEquality.getMemberBId());
             }
         );
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityBulkRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityBulkRepository.java
@@ -1,0 +1,34 @@
+package com.cozymate.cozymate_server.domain.memberstatequality.repository;
+
+import com.cozymate.cozymate_server.domain.memberstatequality.MemberStatEquality;
+import java.sql.PreparedStatement;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberStatEqualityBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<MemberStatEquality> memberStatEqualityList) {
+
+        String sql = "INSERT INTO member_stat_equality(equality, memberaid, memberbid) VALUES (?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            memberStatEqualityList,
+            memberStatEqualityList.size(),
+            (PreparedStatement ps, MemberStatEquality memberStatEquality) -> {
+                ps.setInt(1, memberStatEquality.getEquality());
+                ps.setLong(2,memberStatEquality.getMemberAId());
+                ps.setLong(3,memberStatEquality.getMemberBId());
+            }
+        );
+    }
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityBulkRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityBulkRepository.java
@@ -45,6 +45,7 @@ public class MemberStatEqualityBulkRepository {
                 ps.setLong(3,memberStatEquality.getMemberBId());
             }
         );
+
     }
 
     public void deleteAll(List<MemberStatEquality> memberStatEqualityList) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityBulkRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityBulkRepository.java
@@ -10,11 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
+@Transactional
 public class MemberStatEqualityBulkRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
-    @Transactional
     public void saveAll(List<MemberStatEquality> memberStatEqualityList) {
 
         String sql = "INSERT INTO member_stat_equality(equality, memberaid, memberbid) VALUES (?, ?, ?)";
@@ -27,6 +27,37 @@ public class MemberStatEqualityBulkRepository {
                 ps.setInt(1, memberStatEquality.getEquality());
                 ps.setLong(2,memberStatEquality.getMemberAId());
                 ps.setLong(3,memberStatEquality.getMemberBId());
+            }
+        );
+    }
+
+    public void updateAll(List<MemberStatEquality> memberStatEqualityList) {
+
+        String sql = "UPDATE member_stat_equality SET equality = ? where memberaid = ? and memberbid = ?";
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            memberStatEqualityList,
+            memberStatEqualityList.size(),
+            (PreparedStatement ps, MemberStatEquality memberStatEquality) -> {
+                ps.setInt(1, memberStatEquality.getEquality());
+                ps.setLong(2,memberStatEquality.getMemberAId());
+                ps.setLong(3,memberStatEquality.getMemberBId());
+            }
+        );
+    }
+
+    public void deleteAll(List<MemberStatEquality> memberStatEqualityList) {
+
+        String sql = "DELETE FROM member_stat_equality WHERE memberaid = ? AND memberbid = ?";
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            memberStatEqualityList,
+            memberStatEqualityList.size(),
+            (PreparedStatement ps, MemberStatEquality memberStatEquality) -> {
+                ps.setLong(1, memberStatEquality.getMemberAId());
+                ps.setLong(2, memberStatEquality.getMemberBId());
             }
         );
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityRepository.java
@@ -2,7 +2,6 @@ package com.cozymate.cozymate_server.domain.memberstatequality.repository;
 
 import com.cozymate.cozymate_server.domain.memberstatequality.MemberStatEquality;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberStatEqualityRepository extends
@@ -11,6 +10,4 @@ public interface MemberStatEqualityRepository extends
     List<MemberStatEquality> findByMemberAIdAndMemberBIdIn(Long memberAId, List<Long> memberIds);
 
     List<MemberStatEquality> findAllByMemberAIdOrMemberBId(Long memberAId, Long memberBId);
-
-    Boolean existsByMemberAIdAndMemberBId(Long memberAId, Long memberId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityRepository.java
@@ -1,0 +1,16 @@
+package com.cozymate.cozymate_server.domain.memberstatequality.repository;
+
+import com.cozymate.cozymate_server.domain.memberstatequality.MemberStatEquality;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberStatEqualityRepository extends
+    JpaRepository<MemberStatEquality, Long> {
+
+    List<MemberStatEquality> findByMemberAIdAndMemberBIdIn(Long memberAId, List<Long> memberIds);
+
+    List<MemberStatEquality> findAllByMemberAIdOrMemberBId(Long memberAId, Long memberBId);
+
+    Boolean existsByMemberAIdAndMemberBId(Long memberAId, Long memberId);
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
@@ -73,8 +73,8 @@ public class MemberStatEqualityCommandService {
     }
 
     /**
-     * @action : 없는 일치율 재생성
      * @return : void
+     * @action : 없는 일치율 재생성
      */
     public void generateAllMemberStatEquality(
     ) {
@@ -94,7 +94,8 @@ public class MemberStatEqualityCommandService {
         // 성별과 학교를 기준으로 MemberStat을 그룹화
         Map<String, List<MemberStat>> groupedMemberStats = allMemberStats.stream()
             .collect(Collectors.groupingBy(
-                memberStat -> memberStat.getMember().getGender() + "-" + memberStat.getUniversity().getId()
+                memberStat -> memberStat.getMember().getGender() + "-" + memberStat.getUniversity()
+                    .getId()
             ));
 
         // 일치율 리스트 생성
@@ -109,12 +110,15 @@ public class MemberStatEqualityCommandService {
                     MemberStat memberStatB = memberStats.get(j);
 
                     // Set을 이용해 A -> B와 B -> A의 존재 여부를 빠르게 확인
-                    String keyAtoB = memberStatA.getMember().getId() + "-" + memberStatB.getMember().getId();
-                    String keyBtoA = memberStatB.getMember().getId() + "-" + memberStatA.getMember().getId();
+                    String keyAtoB =
+                        memberStatA.getMember().getId() + "-" + memberStatB.getMember().getId();
+                    String keyBtoA =
+                        memberStatB.getMember().getId() + "-" + memberStatA.getMember().getId();
 
                     // A -> B 일치율이 없을 경우
                     if (!existingEqualities.contains(keyAtoB)) {
-                        Integer equality = MemberStatEqualityUtil.calculateEquality(memberStatA, memberStatB);
+                        Integer equality = MemberStatEqualityUtil.calculateEquality(memberStatA,
+                            memberStatB);
 
                         MemberStatEquality equalityAtoB = MemberStatEquality.builder()
                             .memberAId(memberStatA.getMember().getId())
@@ -129,7 +133,8 @@ public class MemberStatEqualityCommandService {
 
                     // B -> A 일치율이 없을 경우
                     if (!existingEqualities.contains(keyBtoA)) {
-                        Integer equality = MemberStatEqualityUtil.calculateEquality(memberStatA, memberStatB);
+                        Integer equality = MemberStatEqualityUtil.calculateEquality(memberStatA,
+                            memberStatB);
 
                         MemberStatEquality equalityBtoA = MemberStatEquality.builder()
                             .memberAId(memberStatB.getMember().getId())
@@ -150,8 +155,8 @@ public class MemberStatEqualityCommandService {
     }
 
     /**
-     * @action : 모든 기존 일치율을 다시 계산하여 업데이트
      * @return : void
+     * @action : 모든 기존 일치율을 다시 계산하여 업데이트
      */
     public void recalculateAllMemberStatEquality() {
 
@@ -169,7 +174,8 @@ public class MemberStatEqualityCommandService {
             MemberStat memberStatB = memberStatMap.get(equality.getMemberBId());
 
             if (memberStatA != null && memberStatB != null) {
-                Integer newEqualityValue = MemberStatEqualityUtil.calculateEquality(memberStatA, memberStatB);
+                Integer newEqualityValue = MemberStatEqualityUtil.calculateEquality(memberStatA,
+                    memberStatB);
 
                 if (!newEqualityValue.equals(equality.getEquality())) {
                     equality.updateEquality(newEqualityValue);

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
@@ -1,0 +1,175 @@
+package com.cozymate.cozymate_server.domain.memberstatequality.service;
+
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
+import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
+import com.cozymate.cozymate_server.domain.memberstat.repository.MemberStatRepository;
+import com.cozymate.cozymate_server.domain.memberstatequality.MemberStatEquality;
+import com.cozymate.cozymate_server.domain.memberstatequality.repository.MemberStatEqualityBulkRepository;
+import com.cozymate.cozymate_server.domain.memberstatequality.repository.MemberStatEqualityRepository;
+import com.cozymate.cozymate_server.domain.memberstatequality.util.MemberStatEqualityUtil;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberStatEqualityCommandService {
+
+    private final MemberStatEqualityRepository memberStatEqualityRepository;
+    private final MemberStatEqualityBulkRepository memberStatEqualityBulkRepository;
+    private final MemberStatRepository memberStatRepository;
+
+    /**
+     * @param newMemberStat : 새롭게 추가된 멤버 상세정보
+     * @return : void
+     */
+    public void createMemberStatEqualities(MemberStat newMemberStat) {
+
+        // 성별이 같고, 같은 학교일 경우에 대해서만 일치율 계산
+        List<MemberStat> memberStatList = memberStatRepository.findByMember_GenderAndUniversity_Id(
+            newMemberStat.getMember().getGender(),
+            newMemberStat.getUniversity().getId()
+        );
+
+        List<MemberStatEquality> memberStatEqualityList = memberStatList.stream()
+            //자기 자신을 제외
+            .filter(memberStat -> !memberStat.getId().equals(newMemberStat.getId()))
+            .flatMap(memberStat -> {
+
+                Integer equality = MemberStatEqualityUtil.calculateEquality(newMemberStat,
+                    memberStat);
+
+                MemberStatEquality equalityA = MemberStatEquality.builder()
+                    .memberAId(newMemberStat.getMember().getId())
+                    .memberBId(memberStat.getMember().getId())
+                    .equality(equality)
+                    .build();
+
+                MemberStatEquality equalityB = MemberStatEquality.builder()
+                    .memberAId(memberStat.getMember().getId())
+                    .memberBId(newMemberStat.getMember().getId())
+                    .equality(equality)
+                    .build();
+
+                return Stream.of(equalityA, equalityB);
+
+            })
+            .collect(Collectors.toList());
+
+        memberStatEqualityBulkRepository.saveAll(memberStatEqualityList);
+
+    }
+
+    public void generateAllMemberStatEquality() {
+
+        long startTime = System.currentTimeMillis();
+
+        // 모든 MemberStat을 성별과 학교 기준으로 필터링하여 가져옴
+        List<MemberStat> allMemberStats = memberStatRepository.findAll();
+
+        // 각 MemberStat에 대해 성별과 학교가 같은 다른 MemberStat 목록 가져오기
+        List<MemberStatEquality> memberStatEqualityList = allMemberStats.stream()
+            .flatMap(memberStatA -> {
+                // 성별과 학교가 같은 다른 MemberStat들을 가져옴
+                List<MemberStat> filteredMemberStats = memberStatRepository.findByMember_GenderAndUniversity_Id(
+                    memberStatA.getMember().getGender(),
+                    memberStatA.getUniversity().getId()
+                );
+
+                return filteredMemberStats.stream()
+                    .filter(memberStatB -> !memberStatA.getId()
+                        .equals(memberStatB.getId())) // 자신과의 비교 제외
+                    // 중복되는 일치율 제외
+                    .filter(
+                        memberStatB -> !memberStatEqualityRepository.existsByMemberAIdAndMemberBId(
+                            memberStatA.getMember().getId(), memberStatB.getMember().getId()))
+                    .flatMap(memberStatB -> {
+                        Integer equality = MemberStatEqualityUtil.calculateEquality(memberStatA,
+                            memberStatB);
+
+                        MemberStatEquality equalityA = MemberStatEquality.builder()
+                            .memberAId(memberStatA.getMember().getId())
+                            .memberBId(memberStatB.getMember().getId())
+                            .equality(equality)
+                            .build();
+
+                        MemberStatEquality equalityB = MemberStatEquality.builder()
+                            .memberAId(memberStatB.getMember().getId())
+                            .memberBId(memberStatA.getMember().getId())
+                            .equality(equality)
+                            .build();
+
+                        return Stream.of(equalityA, equalityB);
+                    });
+            })
+            .collect(Collectors.toList());
+
+        // 일치율 계산 시간 출력
+        System.out.println("Calculation time = " + (System.currentTimeMillis() - startTime) + "ms");
+
+        // 새로운 일치율 데이터를 저장
+        memberStatEqualityBulkRepository.saveAll(memberStatEqualityList);
+
+        // 저장 시간 출력
+        System.out.println("Save time = " + (System.currentTimeMillis() - startTime) + "ms");
+    }
+
+
+    /**
+     * @param changedMemberStat : 변경된 멤버의 상세정보
+     * @return : void
+     */
+
+    public void updateMemberStatEqualities(MemberStat changedMemberStat) {
+
+        List<MemberStatEquality> relatedEqualities = memberStatEqualityRepository.findAllByMemberAIdOrMemberBId(
+            changedMemberStat.getId(), changedMemberStat.getId());
+
+        // 필요 없는 코드 고치기
+        List<MemberStatEquality> updatedEqualities = relatedEqualities.stream()
+            .peek(equality -> {
+
+                MemberStat memberA = memberStatRepository.findByMemberId(equality.getMemberAId())
+                    .orElseThrow(
+                        () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
+                    );
+
+                MemberStat memberB = memberStatRepository.findByMemberId(equality.getMemberBId())
+                    .orElseThrow(
+                        () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
+                    );
+
+                Integer newEqualityScore = MemberStatEqualityUtil.calculateEquality(memberA,
+                    memberB);
+
+                equality.updateEquality(
+                    newEqualityScore
+                );
+
+            })
+            .toList();
+
+    }
+
+    /**
+     * @param deletedMemberStat : 삭제할 멤버의 상세정보
+     * @return : void
+     */
+    public void deleteMemberStatEqualities(MemberStat deletedMemberStat) {
+
+        List<MemberStatEquality> relatedEqualities = memberStatEqualityRepository.findAllByMemberAIdOrMemberBId(
+            deletedMemberStat.getId(), deletedMemberStat.getId());
+
+        memberStatEqualityRepository.deleteAll(relatedEqualities);
+
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
@@ -1,0 +1,38 @@
+package com.cozymate.cozymate_server.domain.memberstatequality.service;
+
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
+import com.cozymate.cozymate_server.domain.memberstat.repository.MemberStatRepository;
+import com.cozymate.cozymate_server.domain.memberstatequality.MemberStatEquality;
+import com.cozymate.cozymate_server.domain.memberstatequality.repository.MemberStatEqualityRepository;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberStatEqualityQueryService {
+
+    private final MemberStatEqualityRepository memberStatEqualityRepository;
+
+    public Map<Long, Integer> getEquality(Long memberAId, List<Long> memberIdList) {
+
+        List<MemberStatEquality> memberStatEqualityList = memberStatEqualityRepository.findByMemberAIdAndMemberBIdIn(
+            memberAId, memberIdList);
+
+        return memberStatEqualityList.stream()
+            .collect(Collectors.toMap(
+                MemberStatEquality::getMemberBId,
+                MemberStatEquality::getEquality
+            ));
+    }
+
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
@@ -1,11 +1,7 @@
 package com.cozymate.cozymate_server.domain.memberstatequality.service;
 
-import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
-import com.cozymate.cozymate_server.domain.memberstat.repository.MemberStatRepository;
 import com.cozymate.cozymate_server.domain.memberstatequality.MemberStatEquality;
 import com.cozymate.cozymate_server.domain.memberstatequality.repository.MemberStatEqualityRepository;
-import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
-import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
@@ -45,7 +45,8 @@ public class MemberStatEqualityUtil {
             ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getCleaningFrequency().equals(memberStat.getCleaningFrequency())
             ? ADDITIONAL_SCORE : NO_SCORE;
-        score += criteriaMemberStat.getAirConditioningIntensity().equals(memberStat.getAirConditioningIntensity())
+        score += criteriaMemberStat.getAirConditioningIntensity()
+            .equals(memberStat.getAirConditioningIntensity())
             ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getHeatingIntensity().equals(memberStat.getHeatingIntensity())
             ? ADDITIONAL_SCORE : NO_SCORE;

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
@@ -4,9 +4,9 @@ import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 
 public class MemberStatEqualityUtil {
 
-    private static final Integer ADDITIONAL_SCORE = 12;
+    private static final Integer ADDITIONAL_SCORE = 36;
     private static final Integer NO_SCORE = 0;
-    private static final Integer ATTRIBUTE_COUNT = 19;
+    private static final Integer ATTRIBUTE_COUNT = 18;
     private static final Integer HALF_DIVISION = 2;
     private static final Integer QUARTER_DIVISION = 4;
     private static final Integer MULTIPLIER_FOR_PERCENTAGE = 100;
@@ -14,10 +14,13 @@ public class MemberStatEqualityUtil {
 
     // 두 사용자간 일치율을 비교해야 할 때, 사용하는 util
     // 성격은 일치율에서 제외, 출생년도는 보류(총 22개 항목)
-    // 완전 라이프스타일에 대한 일치율이라면, 다음의 항목을 제외할 필요성이 있는지 논의가 필요할 듯 함
-    // - 기숙사 합격 여부
-    // - 학번
-    // - 학과
+    // 제외 목록
+//    - 출생년도
+//    - 기숙사 합격 여부
+//    - 학번
+//    - 학과
+//    - 성격
+//    - mbti
     public static int calculateEquality(MemberStat criteriaMemberStat,
         MemberStat memberStat) {
 
@@ -41,8 +44,6 @@ public class MemberStatEqualityUtil {
         score += criteriaMemberStat.getIntake().equals(memberStat.getIntake())
             ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getCleaningFrequency().equals(memberStat.getCleaningFrequency())
-            ? ADDITIONAL_SCORE : NO_SCORE;
-        score += criteriaMemberStat.getMbti().equals(memberStat.getMbti())
             ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getAirConditioningIntensity().equals(memberStat.getAirConditioningIntensity())
             ? ADDITIONAL_SCORE : NO_SCORE;
@@ -81,7 +82,6 @@ public class MemberStatEqualityUtil {
             default -> NO_SCORE;
         };
     }
-
 
     private static int calculateSensitivityScore(Integer sensitivity1, Integer sensitivity2) {
         int sensitivityDifference = Math.abs(sensitivity1 - sensitivity2);

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
@@ -1,10 +1,8 @@
-package com.cozymate.cozymate_server.domain.memberstat.util;
+package com.cozymate.cozymate_server.domain.memberstatequality.util;
 
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
-import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityResponseDTO;
-import com.cozymate.cozymate_server.global.utils.TimeUtil;
 
-public class MemberUtil {
+public class MemberStatEqualityUtil {
 
     private static final Integer ADDITIONAL_SCORE = 12;
     private static final Integer NO_SCORE = 0;
@@ -15,16 +13,15 @@ public class MemberUtil {
     private static final Integer MAX_SCORE = ADDITIONAL_SCORE * ATTRIBUTE_COUNT;
 
     // 두 사용자간 일치율을 비교해야 할 때, 사용하는 util
-    public static int calculateScore(MemberStat criteriaMemberStat,
+    // 성격은 일치율에서 제외, 출생년도는 보류(총 22개 항목)
+    // 완전 라이프스타일에 대한 일치율이라면, 다음의 항목을 제외할 필요성이 있는지 논의가 필요할 듯 함
+    // - 기숙사 합격 여부
+    // - 학번
+    // - 학과
+    public static int calculateEquality(MemberStat criteriaMemberStat,
         MemberStat memberStat) {
 
         int score = NO_SCORE;
-        score += criteriaMemberStat.getAcceptance().equals(memberStat.getAcceptance())
-            ? ADDITIONAL_SCORE : NO_SCORE;
-        score += criteriaMemberStat.getAdmissionYear().equals(memberStat.getAdmissionYear())
-            ? ADDITIONAL_SCORE : NO_SCORE;
-        score += criteriaMemberStat.getMajor().equals(memberStat.getMajor())
-            ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getSmoking().equals(memberStat.getSmoking())
             ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getSleepingHabit().equals(memberStat.getSleepingHabit())
@@ -47,13 +44,17 @@ public class MemberUtil {
             ? ADDITIONAL_SCORE : NO_SCORE;
         score += criteriaMemberStat.getMbti().equals(memberStat.getMbti())
             ? ADDITIONAL_SCORE : NO_SCORE;
-
+        score += criteriaMemberStat.getAirConditioningIntensity().equals(memberStat.getAirConditioningIntensity())
+            ? ADDITIONAL_SCORE : NO_SCORE;
+        score += criteriaMemberStat.getHeatingIntensity().equals(memberStat.getHeatingIntensity())
+            ? ADDITIONAL_SCORE : NO_SCORE;
+        score += criteriaMemberStat.getDrinkingFrequency().equals(memberStat.getDrinkingFrequency())
+            ? ADDITIONAL_SCORE : NO_SCORE;
         score += calculateTimeScore(criteriaMemberStat.getWakeUpTime(), memberStat.getWakeUpTime());
         score += calculateTimeScore(criteriaMemberStat.getSleepingTime(),
             memberStat.getSleepingTime());
         score += calculateTimeScore(criteriaMemberStat.getTurnOffTime(),
             memberStat.getTurnOffTime());
-
         score += calculateSensitivityScore(criteriaMemberStat.getCleanSensitivity(),
             memberStat.getCleanSensitivity());
         score += calculateSensitivityScore(criteriaMemberStat.getNoiseSensitivity(),
@@ -65,9 +66,14 @@ public class MemberUtil {
     }
 
 
-
+    // 24시간 반영해 개선함.
     private static int calculateTimeScore(Integer time1, Integer time2) {
-        int timeDifference = Math.abs(time1 - time2);
+
+        int diff1 = Math.abs(time1 - time2);
+        int diff2 = 24 - diff1;
+
+        int timeDifference = Math.min(diff1, diff2);
+
         return switch (timeDifference) {
             case 0 -> ADDITIONAL_SCORE;
             case 1 -> ADDITIONAL_SCORE / HALF_DIVISION;

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/enums/NotificationType.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/enums/NotificationType.java
@@ -1,6 +1,6 @@
 package com.cozymate.cozymate_server.domain.notificationlog.enums;
 
-import static com.cozymate.cozymate_server.domain.memberstat.util.MemberUtil.getNicknameShowFormat;
+import static com.cozymate.cozymate_server.domain.memberstatequality.util.MemberStatEqualityUtil.getNicknameShowFormat;
 
 import com.cozymate.cozymate_server.domain.fcm.dto.FcmPushContentDto;
 import com.cozymate.cozymate_server.domain.fcm.dto.FcmPushContentResultDto;

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -111,6 +111,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _ALREADY_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK400", "이미 차단된 사용자입니다."),
     _CANNOT_BLOCK_SELF(HttpStatus.BAD_REQUEST, "MEMBERBLOCK401", "자신에 대해 차단 관련 요청을 할 수 없습니다."),
     _ALREADY_NOT_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK402", "이미 차단되지 않은 사용자입니다."),
+
+    // MemberStatEquality 관련
+    _MEMBERSTAT_EQUALITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERSTATEQUALITY400", "일치율이 존재하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -60,6 +60,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBERSTAT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "MEMBERSTAT402", "멤버 상세정보가 존재하지 않습니다."),
     _MEMBERSTAT_FILTER_PARAMETER_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBERSTAT403",
         "멤버 상세정보 filterList이 잘못되었습니다."),
+    _MEMBERSTAT_FILTER_CANNOT_FILTER_ROOMMATE(HttpStatus.BAD_REQUEST, "MEMBERSTAT404", "인실이 정해진 경우 인실 필터링이 불가합니다."),
 
     // ChatRoom 관련 애러
     _CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM400", "쪽지방을 찾을 수 없습니다."),


### PR DESCRIPTION
## #️⃣ 요약 설명

- MemberStat 기획 변경 적용
- 상세 필터링 검색 기능 구현
- 일치율 계산 및 조회 방식 변경

3가지가 모두 묶여 있는 것들이라.. PR을 이렇게 몰아서 하게 된 점 죄송합니다.
테스트라도 보시면서.. 즐겨주세요

## 📝 작업 내용

# 1. 변경된 기획에 따른 상세정보 Data Type 및 저장 방식 변경

**1. Boolean → String**
1. 3가지 멤버변수가 String으로 수정되었습니다.
- canShare, isPlayGame, isPhoneCall

**2. 다중 선택 타입 추가 (잠꼬대, 성격) :star: 중요!**

1. 저장 방식

- 항목들을 저장할 때 구분자로, 를 사용하고 정렬함. EX) '조용해요,활발해요, 말이 많아요,'
            
2. Util을 사용해 배열 → String 저장, String → 배열 읽기
- MemberStatUtil에 구현했습니다.

2. 방식 사용 이유
- 다른 연관관계를 가진 Entity를 만들기에는 가볍고, 항목들이 정해져 있기 때문에 해당 방식이 효율적이라고 생각했음.
3. 검색
- 해당 부분도 고려해 아래 상세 필터링 부분도 제작했습니다. (Filter 중 handleMultiStringContentFilter 제작해 사용)
    
**3. JSON 삭제(추가 입력 정보를 자기소개로 변경)**

- options가 기획에서 사라져 제거하고, self_introduction(String) 을 추가했습니다.

# 2. MemberStat 새로운 상세 필터링 추가

기존 필터링 → 요청자와 완전 일치 여부를 기준으로 검색함.

새로운 필터링 → 요청자가 원하는 항목을 검색할 수 있음.

새로운 필터링은 Post 방식으로 Request Body에 json을 받아 사용할 수 있도록 하였습니다.

Key끼리는 AND 조건으로, Value끼리는 OR 조건으로 검색됩니다.

필터링은 아래 계층으로 구현했습니다.

## createBaseQuery

기본 쿼리를 생성하는 메서드로 MemberStat과 Member를 함께 조회합니다.
Member와 MemberStat을 같이 사용해야하는 코드가 많아, 쿼리를 줄이기 위해 둘다 불러와 Tuple로 리턴했습니다.

```java
private JPAQuery<Tuple> createBaseQuery(MemberStat criteriaMemberStat) {
    return queryFactory
        .select(memberStat, member)
        .from(memberStat)
        .join(memberStat.member, member)
        .where(initDefaultQuery(criteriaMemberStat));
}
```

## initDefaultQuery

기본 필터링 조건을 설정하는 메서드입니다. 요청자의 성별, 학교, 인실 조건을 포함합니다.
조건은 같은 성별, 같은 학교, 같은 인실을 기준으로 하며, 사용자의 인실이 미정일 때는, 인실까지 검색이 가능하도록 했습니다.
만약 인실이 정해져 있는데 인실에 대해 필터링을 하려는 경우, 예외를 리턴하도록 했습니다.
```java
private BooleanBuilder initDefaultQuery(MemberStat criteriaMemberStat) {
    BooleanBuilder builder = new BooleanBuilder()
        .and(memberStat.id.ne(criteriaMemberStat.getId()))  // 본인을 제외
        .and(member.gender.eq(criteriaMemberStat.getMember().getGender()))  // 성별 동일
        .and(memberStat.university.id.eq(criteriaMemberStat.getUniversity().getId()));  // 학교 동일

    // 인실 조건이 "미정"이 아니면 인실 필터링 추가
    if (!criteriaMemberStat.getNumOfRoommate().equals(NUM_OF_ROOMMATE_NOT_DETERMINED)) {
        builder.and(memberStat.numOfRoommate.eq(criteriaMemberStat.getNumOfRoommate()));
    }

    return builder;
}
```

## applyFilters (완전일치 필터링, 상세검색 필터링 두가지 메소드로 분리)

동적으로 입력된 필터링 조건에 따라 작동하는 필터링 메서드입니다.
두가지로 분리했으며, 사용하는 BooleanExpression 메서드들은 동일합니다.
다만 처리 방식에 차이가 있어, applyFilter는 두개의 메서드를 사용합니다.

## applyFilter(applyFilters에서 항목마다 필터를 적용할 수 있게 도와주는 함수)

applyFilter는 applyFilters 메서드에서 호출되어 각 필터 조건에 맞는 Boolean Expression을 생성하고, 해당 조건을 필터링합니다.
사용자가 입력한 필터 조건에 맞춰서 동적으로 BooleanBuilder에 필터 조건을 추가합니다.
필터 키에 맞는 Path를 찾고, 해당 필터 조건에 맞는 값을 처리하여 BooleanBuilder에 추가해줍니다.

## Boolean Expressions
총 4가지 필터가 있으며, String, Number, Boolean, Date를 적절히 처리하도록 했습니다.

## 관련 추가 API
- 필터링된 총 개수 조회하는 API
- 멤버 상세정보의 인실 수가 미정인지 여부를 조회하는 API

# 3. MemberStatEquality 엔티티 추가

기존 일치율 계산은, 일치율이 필요할 때마다 멤버 상세정보를 직접 불러와 계산해 리턴하는 방식이었습니다.
현재 상세정보를 갖고 있는 사용자는 43명으로, 계산 시간이 그리 오래 걸리지 않지만, 추후에 이런 방식을 지속 사용한다면 서버의 부담이 커질 것으로 예상했습니다. 

이런 문제를 해결하기 위해 MemberStat을 저장하거나 수정할 때만 일치율 계산을 해 미리 저장하고, 필요할 때마다 조회를 하는 방식으로 변경하기로 결정했습니다. 특히 일치율은 조회를 많이 하고, 변경이 될 일은 MemberStat이 저장되거나 수정될 때를 제외하고는 없기 때문에, 저장하는 방식은 효율적이라고 생각했습니다.

## Entity 구성

```java
@Getter
@NoArgsConstructor
@AllArgsConstructor(access = AccessLevel.PROTECTED)
@Builder
@Entity
@Table(name = "member_stat_equality",
    indexes = {
        @Index(name = "idx_member_a_id", columnList = "memberAId")
    })
public class MemberStatEquality {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    private Long memberAId;

    private Long memberBId;

    private Integer equality;

    public MemberStatEquality updateEquality(Integer equality) {
        this.equality = equality;
        return this;
    }

}
```

4가지 칼럼으로 나누었고, 빠른 조회를 위해 A에 대해서만 인덱싱을 했습니다.
연관관계는 따로 연결하지 않았습니다.

## 저장 방식

### Save

```java
public void createMemberStatEqualities(MemberStat newMemberStat) {

        // 성별이 같고, 같은 학교일 경우에 대해서만 일치율 계산
        List<MemberStat> memberStatList = memberStatRepository.findByMember_GenderAndUniversity_Id(
            newMemberStat.getMember().getGender(),
            newMemberStat.getUniversity().getId()
        );

        Long newMemberId = newMemberStat.getMember().getId();

        List<MemberStatEquality> memberStatEqualityList = memberStatList.stream()
            //자기 자신을 제외
            .filter(memberStat -> !memberStat.getId().equals(newMemberStat.getId()))
            .flatMap(memberStat -> {

                Integer equality = MemberStatEqualityUtil.calculateEquality(newMemberStat,
                    memberStat);

                Long originalMemberId = memberStat.getMember().getId();

                MemberStatEquality equalityA = MemberStatEquality.builder()
                    .memberAId(newMemberId)
                    .memberBId(originalMemberId)
                    .equality(equality)
                    .build();

                MemberStatEquality equalityB = MemberStatEquality.builder()
                    .memberAId(originalMemberId)
                    .memberBId(newMemberId)
                    .equality(equality)
                    .build();

                return Stream.of(equalityA, equalityB);

            })
            .collect(Collectors.toList());

        memberStatEqualityBulkRepository.saveAll(memberStatEqualityList);

    }
```
같은 학교이고, 같은 성별일 경우 일치율을 저장하도록 했습니다.
JPA에서 제공하는 saveAll 메소드가 Insert문을 하나하나 보내는 방식이라, 네트워크로 인한 오버헤드가 많이 발생했습니다. (2~5초)
이를 해결하기 위해 JPQL을 직접 작성해 Bulk Insert을 사용하는 방식으로 변경해, 한번에 모아서 Query를 전송하도록 했습니다.
이에 API 응답시간은 단순 조회 API와 유사해졌습니다.

추후 확장성을 고려하면, 저장을 늘어난 사용자만큼 해야하는데, JPQL을 직접 사용하고, Bulk Insert까지 하게 되면 JPA와 비교해 매우 빠른 시간에 Insert가 가능하기 때문에 (API 응답시간을 1000ms이내로 예상하고 있습니다.)

### Update

사용자가 상세정보를 업데이트 하면 해당 메서드가 실행되도록 했습니다.

```java
    public void updateMemberStatEqualities(MemberStat changedMemberStat) {

        Long changedMemberId = changedMemberStat.getMember().getId();

        List<MemberStatEquality> relatedEqualities = memberStatEqualityRepository.findAllByMemberAIdOrMemberBId(
            changedMemberId, changedMemberId);

        Set<Long> memberIds = relatedEqualities.stream()
            .flatMap(equality -> Stream.of(equality.getMemberAId(), equality.getMemberBId()))
            .collect(Collectors.toSet());

        Map<Long, MemberStat> memberStatMap = memberStatRepository.findMemberStatsAndMemberIdsByMemberIds(
                memberIds)
            .stream()
            .collect(Collectors.toMap(
                tuple -> tuple.get(1, Long.class),
                tuple -> tuple.get(0, MemberStat.class)
            ));

        List<MemberStatEquality> updatedEqualities = relatedEqualities.stream()
            .map(
                equality -> {
                    boolean isMemberAChanged = equality.getMemberAId().equals(changedMemberId);

                    MemberStat memberStat = isMemberAChanged ?
                        memberStatMap.get(equality.getMemberBId()) :
                        memberStatMap.get(equality.getMemberAId());

                    Integer updatedEquality = MemberStatEqualityUtil.calculateEquality(
                        changedMemberStat, memberStat);

                    return equality.updateEquality(updatedEquality);
                }
            )
            .toList();

        memberStatEqualityBulkRepository.updateAll(updatedEqualities);

    }
```

연관관계를 설정하지 않아, 코드가 조금 복잡해졌는데, LazyLoading으로 인해 쿼리를 계속 하는 것 때문에 지연시간이 늘어지는 단점이 있었습니다. Ex) memberStat.getMember().getId(); <- 이 부분을 사용할 때마다 쿼리함.

이를 해결하기 위해  
```java
Map<Long, MemberStat> memberStatMap = memberStatRepository.findMemberStatsAndMemberIdsByMemberIds(
                memberIds)
            .stream()
            .collect(Collectors.toMap(
                tuple -> tuple.get(1, Long.class),
                tuple -> tuple.get(0, MemberStat.class)
            ));
```
미리 MemberID에 대응되는 MemberStat을 저장하는 쿼리를 만들었고, 메모리의 정보를 활용해 일치율을 계산하고 업데이트를 하도록 했습니다.

Insert문 고유의 Bulk는 Update에 존재하지 않지만, 쿼리를 나눠서 한번에 보내는 Bulk 방식은 가능해 Insert에서 사용한 Bulk와 동일하게 구현했습니다.

### Delete

MemberStat 삭제 API를 실행하면, 자동으로 지워지게 만들었습니다.
```java
    public void deleteMemberStatEqualities(MemberStat deletedMemberStat) {

        Long memberId = deletedMemberStat.getMember().getId();

        List<MemberStatEquality> relatedEqualities = memberStatEqualityRepository.findAllByMemberAIdOrMemberBId(
            memberId, memberId);

        memberStatEqualityBulkRepository.deleteAll(relatedEqualities);

    }
```

 Update와 같은 이유로 Bulk 방식을 사용했습니다.

### 기타 메서드

public void generateAllMemberStatEquality : 현재 존재하는 모든 MemberStat에 대해(같은 성별, 같은 학교 한정) 일치율 생성.
public void recalculateAllMemberStatEquality : 일치율 정책이 변경되면, 모든 Equality에 적용함.

두가지 메서드를 사용하는 API는 모두 최악의 경우 1초 내외의 응답시간을 보였고, 본 서버에 올라가면 쿼리로 인한 Latency가 줄어들기 때문에 1초 이내에 수행할 수 있을 것으로 예상하고 있습니다.

## 동작 확인

1. 상세정보 String 배열 관련 동작 확인(성격, 잠꼬대)

포비 상세정보 Update시 정상 동작

<img width="487" alt="image" src="https://github.com/user-attachments/assets/66b6a99a-9fe1-479d-85fd-a05e718d4003">

조회도 정상 동작 확인

<img width="432" alt="image" src="https://github.com/user-attachments/assets/11f7e28e-cf6c-449c-93a7-b3acdd3bebf7">

2. 상세 정보 필터링 관련 동작 확인

저는 집이 좋고, 부끄러움을 많이 타는 사람이라, 두가지 경우인 사람 모두 검색해봤습니다.

<img width="409" alt="image" src="https://github.com/user-attachments/assets/03b6775a-5c3d-43a2-b205-3419b0c8901d">

<img width="256" alt="image" src="https://github.com/user-attachments/assets/f48e894e-047d-40e3-9a66-f6e871695c8a">

무려 14명이나 되는군요...

이번 룸메이트는 MBTI가 IN*P 인 사람들이었으면 좋겠어서 검색해봤습니다.

<img width="462" alt="image" src="https://github.com/user-attachments/assets/6476909a-bb1d-404d-b833-11824faa5d72">

<img width="410" alt="image" src="https://github.com/user-attachments/assets/4264ff8b-df12-4419-8fc6-6746f1e27a4c">

3명으로 줄었네요. 영광의 주인공들을 살펴보겠습니다.

<img width="271" alt="image" src="https://github.com/user-attachments/assets/0e14c72c-8f7d-4267-ad53-386ff6f1d054">

무려 팀원이 두명이나 있네요..

저에게 족보를 줄 수 있는 동년배나 선배였으면 좋겠어서, 조건을 두개 더 걸어보겠습니다.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/bd99b74b-14a1-4ef9-b8cd-ee4c070afd58">

결국 '반찬'이 제 룸메이트 찜꽁 리스트에 들어갔습니다. 반찬핑..ㅎㅎ
<img width="481" alt="image" src="https://github.com/user-attachments/assets/564e39a3-3680-4c08-8f61-d75de1dc0597">

이렇게 룸메이트를 구하는 과정을 시연해봤고, DataType이나 걸릴 수 있는 부분들을 모두 담아서 테스트 했습니다.

4. 일치율 조회 관련 동작 확인

사실 3번이 일치율 반영된거라서.. 앞서 만든 generate 함수를 사용해서 만들었습니다.
43명이라 총 1806개의 행이 만들어져야하는데,
<img width="483" alt="image" src="https://github.com/user-attachments/assets/553789fc-adfa-44cc-91e9-1e748bec0f61">
잘 만들어졌습니다.

일치율 업데이트 테스트

아까 봤던 반찬 형님이랑 에어컨 과 히터를 맞춰보겠습니다 .. 저는 따라쟁이라서..ㅎㅎ
<img width="461" alt="image" src="https://github.com/user-attachments/assets/3b600bbc-e941-4379-9113-9ad1c604e379">

API를 잘 만들어서 이제 형님과 더 친해졌네요(?) 무려 일치율이 52퍼..
<img width="377" alt="image" src="https://github.com/user-attachments/assets/f5cf2425-abb1-4251-a2ac-9d4299e4a813">


## 💬 리뷰 요구사항(선택)

여기까지 봐주신 여러분이 대한민국의 코지메이트의 미래입니다
고생하셨고 감사합니다
