### PR TITLE
[COZY-258] feat : 신고 API, 쪽지방id 반환 API

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/controller/ChatRoomController.java
@@ -1,15 +1,22 @@
 package com.cozymate.cozymate_server.domain.chatroom.controller;
 
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.converter.ChatRoomConverter;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomIdResponse;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpDto;
 import com.cozymate.cozymate_server.domain.chatroom.service.ChatRoomCommandService;
 import com.cozymate.cozymate_server.domain.chatroom.service.ChatRoomQueryService;
+import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +25,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/chatrooms")
@@ -40,12 +48,29 @@ public class ChatRoomController {
 
     @GetMapping
     @Operation(summary = "[베로] 쪽지방 목록 조회", description = "")
-    @SwaggerApiError(
-        ErrorStatus._CHAT_NOT_FOUND
-    )
     public ResponseEntity<ApiResponse<List<ChatRoomResponseDto>>> getChatRoomList(
         @AuthenticationPrincipal MemberDetails memberDetails) {
         return ResponseEntity.ok(
             ApiResponse.onSuccess(chatRoomQueryService.getChatRoomList(memberDetails.getMember())));
+    }
+
+    @GetMapping("/members/{recipientId}")
+    @Operation(summary = "[베로] 쪽지방 반환", description = "")
+    @SwaggerApiError(
+        ErrorStatus._MEMBER_NOT_FOUND
+    )
+    public ResponseEntity<ApiResponse<ChatRoomIdResponse>> getChatRoom(
+        @AuthenticationPrincipal MemberDetails memberDetails, @PathVariable Long recipientId) {
+        Member member = memberDetails.getMember();
+
+        ChatRoomSimpDto simpDto = chatRoomQueryService.getChatRoom(member, recipientId);
+        Optional<ChatRoom> chatRoom = simpDto.getChatRoom();
+        if (chatRoom.isPresent()) {
+            return ResponseEntity.ok(ApiResponse.onSuccess(
+                ChatRoomConverter.toChatRoomIdResponse(chatRoom.get().getId())));
+        }
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+            chatRoomCommandService.saveChatRoom(member, simpDto.getRecipient())));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/controller/ChatRoomController.java
@@ -5,7 +5,7 @@ import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.chatroom.converter.ChatRoomConverter;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomIdResponse;
-import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpDto;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpleDto;
 import com.cozymate.cozymate_server.domain.chatroom.service.ChatRoomCommandService;
 import com.cozymate.cozymate_server.domain.chatroom.service.ChatRoomQueryService;
 import com.cozymate.cozymate_server.domain.member.Member;
@@ -63,14 +63,14 @@ public class ChatRoomController {
         @AuthenticationPrincipal MemberDetails memberDetails, @PathVariable Long recipientId) {
         Member member = memberDetails.getMember();
 
-        ChatRoomSimpDto simpDto = chatRoomQueryService.getChatRoom(member, recipientId);
-        Optional<ChatRoom> chatRoom = simpDto.getChatRoom();
+        ChatRoomSimpleDto simpleDto = chatRoomQueryService.getChatRoom(member, recipientId);
+        Optional<ChatRoom> chatRoom = simpleDto.getChatRoom();
         if (chatRoom.isPresent()) {
             return ResponseEntity.ok(ApiResponse.onSuccess(
                 ChatRoomConverter.toChatRoomIdResponse(chatRoom.get().getId())));
         }
 
         return ResponseEntity.ok(ApiResponse.onSuccess(
-            chatRoomCommandService.saveChatRoom(member, simpDto.getRecipient())));
+            chatRoomCommandService.saveChatRoom(member, simpleDto.getRecipient())));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
@@ -3,7 +3,7 @@ package com.cozymate.cozymate_server.domain.chatroom.converter;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomIdResponse;
-import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpDto;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpleDto;
 import com.cozymate.cozymate_server.domain.member.Member;
 import java.util.Optional;
 
@@ -33,8 +33,8 @@ public class ChatRoomConverter {
             .build();
     }
 
-    public static ChatRoomSimpDto toChatRoomSimpDto(Optional<ChatRoom> chatRoom, Member recipient) {
-        return ChatRoomSimpDto.builder()
+    public static ChatRoomSimpleDto toChatRoomSimpleDto(Optional<ChatRoom> chatRoom, Member recipient) {
+        return ChatRoomSimpleDto.builder()
             .chatRoom(chatRoom)
             .recipient(recipient)
             .build();

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
@@ -2,7 +2,10 @@ package com.cozymate.cozymate_server.domain.chatroom.converter;
 
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomIdResponse;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpDto;
 import com.cozymate.cozymate_server.domain.member.Member;
+import java.util.Optional;
 
 public class ChatRoomConverter {
 
@@ -21,6 +24,19 @@ public class ChatRoomConverter {
             .chatRoomId(chatRoomId)
             .persona(persona)
             .memberId(memberId)
+            .build();
+    }
+
+    public static ChatRoomIdResponse toChatRoomIdResponse(Long chatRoomId) {
+        return ChatRoomIdResponse.builder()
+            .chatRoomId(chatRoomId)
+            .build();
+    }
+
+    public static ChatRoomSimpDto toChatRoomSimpDto(Optional<ChatRoom> chatRoom, Member recipient) {
+        return ChatRoomSimpDto.builder()
+            .chatRoom(chatRoom)
+            .recipient(recipient)
             .build();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/ChatRoomResponseDto.java
@@ -1,5 +1,8 @@
 package com.cozymate.cozymate_server.domain.chatroom.dto;
 
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.member.Member;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +14,18 @@ public class ChatRoomResponseDto {
     private String lastContent;
     private Long chatRoomId;
     private Long memberId;
+
+    @Getter
+    @Builder
+    public static class ChatRoomIdResponse {
+        private Long chatRoomId;
+    }
+
+    @Getter
+    @Builder
+    public static class ChatRoomSimpDto {
+        private Optional<ChatRoom> chatRoom;
+        private Member recipient;
+
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/ChatRoomResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ChatRoomResponseDto {
+
     private Integer persona;
     private String nickName;
     private String lastContent;
@@ -18,14 +19,15 @@ public class ChatRoomResponseDto {
     @Getter
     @Builder
     public static class ChatRoomIdResponse {
+
         private Long chatRoomId;
     }
 
     @Getter
     @Builder
-    public static class ChatRoomSimpDto {
+    public static class ChatRoomSimpleDto {
+
         private Optional<ChatRoom> chatRoom;
         private Member recipient;
-
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/repository/ChatRoomRepository.java
@@ -4,7 +4,6 @@ import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.member.Member;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
@@ -2,11 +2,15 @@ package com.cozymate.cozymate_server.domain.chatroom.service;
 
 import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.converter.ChatRoomConverter;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomIdResponse;
 import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
 import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +22,7 @@ public class ChatRoomCommandService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
+    private final MemberRepository memberRepository;
 
     public void deleteChatRoom(Member member, Long chatRoomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
@@ -26,6 +31,39 @@ public class ChatRoomCommandService {
         softDeleteChatRoom(chatRoom, member.getId());
 
         tryHardDeleteChatRoom(chatRoom);
+    }
+
+    public ChatRoomIdResponse getChatRoomId(Member member, Long recipientId) {
+        Member recipient = memberRepository.findById(recipientId)
+            .orElseThrow(
+                () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND)
+            );
+
+        Optional<ChatRoom> findChatRoom = chatRoomRepository.findByMemberAAndMemberB(member,
+            recipient);
+
+        if (findChatRoom.isPresent()) {
+            return ChatRoomConverter.toChatRoomIdResponse(findChatRoom.get().getId());
+        }
+
+        ChatRoom chatRoom = ChatRoom.builder()
+            .memberA(member)
+            .memberB(recipient)
+            .build();
+
+        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+        return ChatRoomConverter.toChatRoomIdResponse(savedChatRoom.getId());
+    }
+
+    public ChatRoomIdResponse saveChatRoom(Member member, Member recipient) {
+        ChatRoom chatRoom = ChatRoom.builder()
+            .memberA(member)
+            .memberB(recipient)
+            .build();
+
+        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+
+        return ChatRoomConverter.toChatRoomIdResponse(savedChatRoom.getId());
     }
 
     private void softDeleteChatRoom(ChatRoom chatRoom, Long myId) {
@@ -46,6 +84,8 @@ public class ChatRoomCommandService {
             memberALastDeleteAt, memberBLastDeleteAt)) {
             hardDeleteChatRoom(chatRoom);
         }
+
+
     }
 
     private boolean canHardDelete(ChatRoom chatRoom, LocalDateTime memberALastDeleteAt,
@@ -53,7 +93,7 @@ public class ChatRoomCommandService {
         return chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)
             .map(chat -> chat.getCreatedAt().isBefore(memberALastDeleteAt) && chat.getCreatedAt()
                 .isBefore(memberBLastDeleteAt))
-            .orElse(false);
+            .orElse(true);
     }
 
     private void hardDeleteChatRoom(ChatRoom chatRoom) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryService.java
@@ -3,20 +3,25 @@ package com.cozymate.cozymate_server.domain.chatroom.service;
 import com.cozymate.cozymate_server.domain.chat.Chat;
 import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpDto;
 import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
 import com.cozymate.cozymate_server.domain.chatroom.converter.ChatRoomConverter;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto;
 import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 import com.cozymate.cozymate_server.domain.memberblock.util.MemberBlockUtil;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -24,6 +29,7 @@ public class ChatRoomQueryService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
+    private final MemberRepository memberRepository;
     private final MemberBlockUtil memberBlockUtil;
 
     public List<ChatRoomResponseDto> getChatRoomList(Member member) {
@@ -36,6 +42,9 @@ public class ChatRoomQueryService {
         List<ChatRoom> chatRoomList = findChatRoomList.stream()
             .filter(chatRoom -> {
                 Chat chat = getLatestChatByChatRoom(chatRoom);
+                if (chat == null) {
+                    return false;
+                }
                 LocalDateTime lastDeleteAt = getLastDeleteAtByMember(chatRoom, member);
                 return lastDeleteAt == null || chat.getCreatedAt().isAfter(lastDeleteAt);
             })
@@ -52,9 +61,21 @@ public class ChatRoomQueryService {
             ChatRoomResponseDto::getMemberId);
     }
 
+    public ChatRoomSimpDto getChatRoom(Member member, Long recipientId) {
+        Member recipient = memberRepository.findById(recipientId)
+            .orElseThrow(
+                () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND)
+            );
+
+        Optional<ChatRoom> findChatRoom = chatRoomRepository.findByMemberAAndMemberB(member,
+            recipient);
+
+        return ChatRoomConverter.toChatRoomSimpDto(findChatRoom, recipient);
+    }
+
     private Chat getLatestChatByChatRoom(ChatRoom chatRoom) {
         return chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._CHAT_NOT_FOUND));
+            .orElse(null);
     }
 
     private LocalDateTime getLastDeleteAtByMember(ChatRoom chatRoom, Member member) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryService.java
@@ -3,7 +3,7 @@ package com.cozymate.cozymate_server.domain.chatroom.service;
 import com.cozymate.cozymate_server.domain.chat.Chat;
 import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
-import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpDto;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomSimpleDto;
 import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
 import com.cozymate.cozymate_server.domain.chatroom.converter.ChatRoomConverter;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomResponseDto;
@@ -61,7 +61,7 @@ public class ChatRoomQueryService {
             ChatRoomResponseDto::getMemberId);
     }
 
-    public ChatRoomSimpDto getChatRoom(Member member, Long recipientId) {
+    public ChatRoomSimpleDto getChatRoom(Member member, Long recipientId) {
         Member recipient = memberRepository.findById(recipientId)
             .orElseThrow(
                 () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND)
@@ -70,7 +70,7 @@ public class ChatRoomQueryService {
         Optional<ChatRoom> findChatRoom = chatRoomRepository.findByMemberAAndMemberB(member,
             recipient);
 
-        return ChatRoomConverter.toChatRoomSimpDto(findChatRoom, recipient);
+        return ChatRoomConverter.toChatRoomSimpleDto(findChatRoom, recipient);
     }
 
     private Chat getLatestChatByChatRoom(ChatRoom chatRoom) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/Report.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/Report.java
@@ -1,11 +1,12 @@
 package com.cozymate.cozymate_server.domain.report;
 
-import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
-import com.cozymate.cozymate_server.domain.mate.Mate;
-import com.cozymate.cozymate_server.domain.post.Post;
-import com.cozymate.cozymate_server.domain.postcomment.PostComment;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.report.enums.ReportReason;
+import com.cozymate.cozymate_server.domain.report.enums.ReportSource;
 import com.cozymate.cozymate_server.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -29,16 +30,15 @@ public class Report extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Mate reporter;
+    private Member reporter;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private ChatRoom chatRoom = null;
+    private Long reportedMemberId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Post post = null;
+    @Enumerated(EnumType.STRING)
+    private ReportReason reportReason;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private PostComment comment = null;
+    @Enumerated(EnumType.STRING)
+    private ReportSource reportSource;
 
-    private String reason;
+    private String content;
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/ReportRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/ReportRepository.java
@@ -1,7 +1,0 @@
-package com.cozymate.cozymate_server.domain.report;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ReportRepository extends JpaRepository<Report, Long> {
-
-}

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/controller/ReportController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/controller/ReportController.java
@@ -37,6 +37,7 @@ public class ReportController {
     )
     @SwaggerApiError({
         ErrorStatus._REPORT_MEMBER_NOT_FOUND,
+        ErrorStatus._CANNOT_REPORT_REQUEST_SELF,
         ErrorStatus._REPORT_DUPLICATE
     })
     public ResponseEntity<ApiResponse<String>> saveReport(

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/controller/ReportController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/controller/ReportController.java
@@ -1,0 +1,48 @@
+package com.cozymate.cozymate_server.domain.report.controller;
+
+import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
+import com.cozymate.cozymate_server.domain.report.service.ReportCommandService;
+import com.cozymate.cozymate_server.domain.report.dto.ReportRequestDto;
+import com.cozymate.cozymate_server.global.response.ApiResponse;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/report")
+public class ReportController {
+
+    private final ReportCommandService reportCommandService;
+
+    @PostMapping
+    @Operation(
+        summary = "[베로] 신고하기",
+        description = "reportedMemberId : 신고 대상 사용자 pk\n\n"
+            + "ReportSource :  MEMBER_STAT(사용자 상세에서의 신고) , CHAT(쪽지에서의 신고)\n\n"
+            + "ReportReason : "
+            + "OBSCENITY(음란성/선정성), "
+            + "INSULT(욕설/인신공격), "
+            + "COMMERCIAL(영리목적/홍보성), "
+            + "OTHER(기타)\n\n"
+            + "content(신고 내용) : ReportReason이 OTHER(기타 사유)인 경우만 필요"
+    )
+    @SwaggerApiError({
+        ErrorStatus._REPORT_MEMBER_NOT_FOUND,
+        ErrorStatus._REPORT_DUPLICATE
+    })
+    public ResponseEntity<ApiResponse<String>> saveReport(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @Valid @RequestBody ReportRequestDto reportRequestDto) {
+        reportCommandService.saveReport(memberDetails.getMember(), reportRequestDto);
+        return ResponseEntity.ok(ApiResponse.onSuccess("신고 완료"));
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/converter/ReportConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/converter/ReportConverter.java
@@ -1,0 +1,20 @@
+package com.cozymate.cozymate_server.domain.report.converter;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.report.Report;
+import com.cozymate.cozymate_server.domain.report.dto.ReportRequestDto;
+import com.cozymate.cozymate_server.domain.report.enums.ReportReason;
+import com.cozymate.cozymate_server.domain.report.enums.ReportSource;
+
+public class ReportConverter {
+
+    public static Report toEntity(Member member, ReportRequestDto requestDto) {
+        return Report.builder()
+            .reporter(member)
+            .reportedMemberId(requestDto.getReportedMemberId())
+            .reportReason(ReportReason.valueOf(requestDto.getReportReason()))
+            .reportSource(ReportSource.valueOf(requestDto.getReportSource()))
+            .content(requestDto.getContent())
+            .build();
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/dto/ReportRequestDto.java
@@ -1,0 +1,32 @@
+package com.cozymate.cozymate_server.domain.report.dto;
+
+import com.cozymate.cozymate_server.global.utils.EnumValid;
+import com.cozymate.cozymate_server.domain.report.enums.ReportReason;
+import com.cozymate.cozymate_server.domain.report.enums.ReportSource;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportRequestDto {
+
+    private Long reportedMemberId;
+    @EnumValid(enumClass = ReportSource.class)
+    private String reportSource;
+    @EnumValid(enumClass = ReportReason.class)
+    private String reportReason;
+    private String content;
+
+    @AssertTrue(message = "기타 사유의 경우 신고 내용을 입력해야 합니다.")
+    @JsonIgnore
+    public boolean isContentValid() {
+        if (reportReason != null && reportReason.equals("OTHER")) {
+            return content != null && !content.trim().isEmpty();
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/enums/ReportReason.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/enums/ReportReason.java
@@ -1,0 +1,16 @@
+package com.cozymate.cozymate_server.domain.report.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportReason {
+
+    OBSCENITY("음란성/선정성"),
+    INSULT("욕설/인신공격"),
+    COMMERCIAL("영리목적/홍보성"),
+    OTHER("기타");
+
+    private String name;
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/enums/ReportSource.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/enums/ReportSource.java
@@ -1,0 +1,6 @@
+package com.cozymate.cozymate_server.domain.report.enums;
+
+public enum ReportSource {
+
+    MEMBER_STAT, CHAT
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/repository/ReportRepository.java
@@ -1,0 +1,13 @@
+package com.cozymate.cozymate_server.domain.report.repository;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.report.Report;
+import com.cozymate.cozymate_server.domain.report.enums.ReportReason;
+import com.cozymate.cozymate_server.domain.report.enums.ReportSource;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    boolean existsByReporterAndReportedMemberIdAndReportReasonAndReportSource(Member reporter,
+        Long reportedMemberId, ReportReason reportReason, ReportSource ReportSource);
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/report/service/ReportCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/report/service/ReportCommandService.java
@@ -1,0 +1,58 @@
+package com.cozymate.cozymate_server.domain.report.service;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
+import com.cozymate.cozymate_server.domain.report.Report;
+import com.cozymate.cozymate_server.domain.report.converter.ReportConverter;
+import com.cozymate.cozymate_server.domain.report.enums.ReportReason;
+import com.cozymate.cozymate_server.domain.report.enums.ReportSource;
+import com.cozymate.cozymate_server.domain.report.repository.ReportRepository;
+import com.cozymate.cozymate_server.domain.report.dto.ReportRequestDto;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportCommandService {
+
+    private final ReportRepository reportRepository;
+    private final MemberRepository memberRepository;
+
+    public void saveReport(Member member, ReportRequestDto requestDto) {
+        checkReportSelf(member, requestDto.getReportedMemberId());
+        checkMemberExists(requestDto.getReportedMemberId());
+        checkDuplicateReport(member, requestDto);
+
+        Report report = ReportConverter.toEntity(member, requestDto);
+        reportRepository.save(report);
+    }
+
+    private void checkReportSelf(Member member, Long reportedMemberId) {
+        if (member.getId().equals(reportedMemberId)) {
+            throw new GeneralException(ErrorStatus._CANNOT_REPORT_REQUEST_SELF);
+        }
+    }
+
+    private void checkMemberExists(Long reportedMemberId) {
+        boolean isExists = memberRepository.existsById(reportedMemberId);
+
+        if (!isExists) {
+            throw new GeneralException(ErrorStatus._REPORT_MEMBER_NOT_FOUND);
+        }
+    }
+
+    private void checkDuplicateReport(Member member, ReportRequestDto requestDto) {
+        boolean isAlreadyReported = reportRepository.existsByReporterAndReportedMemberIdAndReportReasonAndReportSource(
+            member, requestDto.getReportedMemberId(),
+            ReportReason.valueOf(requestDto.getReportReason()),
+            ReportSource.valueOf(requestDto.getReportSource()));
+
+        if (isAlreadyReported) {
+            throw new GeneralException(ErrorStatus._REPORT_DUPLICATE);
+        }
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -64,7 +64,6 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBERSTAT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "MEMBERSTAT402", "멤버 상세정보가 존재하지 않습니다."),
     _MEMBERSTAT_FILTER_PARAMETER_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBERSTAT403",
         "멤버 상세정보 filterList이 잘못되었습니다."),
-    _MEMBERSTAT_FILTER_CANNOT_FILTER_ROOMMATE(HttpStatus.BAD_REQUEST, "MEMBERSTAT404", "인실이 정해진 경우 인실 필터링이 불가합니다."),
 
     // ChatRoom 관련 애러
     _CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM400", "쪽지방을 찾을 수 없습니다."),
@@ -119,15 +118,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _MAIL_AUTHENTICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST,"MAIL403","메일 인증코드가 만료되었습니다. 다시 받아주세요"),
   
     // MemberBlock 관련
-    _ALREADY_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK400", "이미 차단된 사용자입니다."),
-    _CANNOT_BLOCK_SELF(HttpStatus.BAD_REQUEST, "MEMBERBLOCK401", "자신에 대해 차단 관련 요청을 할 수 없습니다."),
-    _ALREADY_NOT_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK402", "이미 차단되지 않은 사용자입니다."),
-   _REQUEST_TO_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK403", "차단한 사용자에 대한 요청입니다."),
+    _ALREADY_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK400", "이미 차단한 사용자입니다."),
     _CANNOT_BLOCK_REQUEST_SELF(HttpStatus.BAD_REQUEST, "MEMBERBLOCK401", "자신에 대해 차단 관련 요청을 할 수 없습니다."),
-
-
-    // MemberStatEquality 관련
-    _MEMBERSTAT_EQUALITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERSTATEQUALITY400", "일치율이 존재하지 않습니다.")
+    _ALREADY_NOT_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK402", "이미 차단하지 않은 사용자입니다."),
+    _REQUEST_TO_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK403", "차단한 사용자에 대한 요청입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -64,6 +64,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBERSTAT_NOT_EXISTS(HttpStatus.BAD_REQUEST, "MEMBERSTAT402", "멤버 상세정보가 존재하지 않습니다."),
     _MEMBERSTAT_FILTER_PARAMETER_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBERSTAT403",
         "멤버 상세정보 filterList이 잘못되었습니다."),
+    _MEMBERSTAT_FILTER_CANNOT_FILTER_ROOMMATE(HttpStatus.BAD_REQUEST, "MEMBERSTAT404", "인실이 정해진 경우 인실 필터링이 불가합니다."),
 
     // ChatRoom 관련 애러
     _CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM400", "쪽지방을 찾을 수 없습니다."),
@@ -108,7 +109,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // Post관련
     _POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST400", "게시물이 존재하지 않습니다."),
 
-    // Post Comment 
+    // Post Comment
     _POST_COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT400", "댓글이 존재하지 않습니다."),
 
     // Mail
@@ -116,12 +117,20 @@ public enum ErrorStatus implements BaseErrorCode {
     _MAIL_ADDRESS_DUPLICATED(HttpStatus.BAD_REQUEST,"MAIL401","이미 사용된 메일입니다."),
     _MAIL_AUTHENTICATION_CODE_INCORRECT(HttpStatus.BAD_REQUEST,"MAIL402","인증 코드가 올바르지 않습니다."),
     _MAIL_AUTHENTICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST,"MAIL403","메일 인증코드가 만료되었습니다. 다시 받아주세요"),
-  
+
     // MemberBlock 관련
-    _ALREADY_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK400", "이미 차단한 사용자입니다."),
+    _ALREADY_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK400", "이미 차단된 사용자입니다."),
     _CANNOT_BLOCK_REQUEST_SELF(HttpStatus.BAD_REQUEST, "MEMBERBLOCK401", "자신에 대해 차단 관련 요청을 할 수 없습니다."),
-    _ALREADY_NOT_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK402", "이미 차단하지 않은 사용자입니다."),
+    _ALREADY_NOT_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK402", "이미 차단되지 않은 사용자입니다."),
     _REQUEST_TO_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "MEMBERBLOCK403", "차단한 사용자에 대한 요청입니다."),
+
+    // MemberStatEquality 관련
+    _MEMBERSTAT_EQUALITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERSTATEQUALITY400", "일치율이 존재하지 않습니다."),
+
+    // Report 관련
+    _REPORT_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "REPORT400", "신고 대상 멤버를 찾을 수 없습니다."),
+    _REPORT_DUPLICATE(HttpStatus.BAD_REQUEST, "REPORT401", "중복된 신고 요청입니다."),
+    _CANNOT_REPORT_REQUEST_SELF(HttpStatus.BAD_REQUEST, "REPORT402", "자신에 대한 차단 관련 요청을 할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cozymate/cozymate_server/global/utils/EnumValid.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/utils/EnumValid.java
@@ -1,0 +1,19 @@
+package com.cozymate.cozymate_server.global.utils;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = {EnumValidator.class})
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnumValid {
+
+    String message() default "잘못된 enum 값입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends java.lang.Enum<?>> enumClass();
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/utils/EnumValidator.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/utils/EnumValidator.java
@@ -1,0 +1,47 @@
+package com.cozymate.cozymate_server.global.utils;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<EnumValid, String> {
+
+    private EnumValid annotation;
+
+    @Override
+    public void initialize(EnumValid constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        Class<? extends Enum<?>> enumClass = annotation.enumClass();
+        String className = extractClassName(enumClass);
+
+        if (value == null || value.trim().isEmpty()) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(className + "의 enum 값이 null일 수 없습니다.")
+                .addConstraintViolation();
+            return false;
+        }
+
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value.equals(enumValue.toString())) {
+                    return true;
+                }
+            }
+        }
+
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(className + "의 enum 값이 잘못되었습니다.")
+            .addConstraintViolation();
+        return false;
+    }
+
+    private String extractClassName(Class<? extends Enum<?>> enumClass) {
+        String classPath = enumClass.getName();
+        int index = classPath.lastIndexOf('.') + 1;
+        return (index != -1) ? classPath.substring(index) : classPath;
+    }
+}


### PR DESCRIPTION
## #️⃣ 요약 설명

간단한 신고하기 기능 구현했습니다.

같은 사용자에게 같은 사유와 같은 신고 출처에 대한 신고는 중복 신고 처리했습니다.

RequestBody에서 enum에 대한 검증 어노테이션을 구현했습니다.

쪽지방 id 반환 API를 추가했습니다.

## 📝 작업 내용

> ex) 코드의 흐름이나 중요한 부분을 작성해주세요.
> ex) 기존 calculate 함수의 버그를 수정했습니다.

```java
    public void saveReport(Member member, ReportRequestDto requestDto) {
        checkReportSelf(member, requestDto.getReportedMemberId());
        checkMemberExists(requestDto.getReportedMemberId());
        checkDuplicateReport(member, requestDto);

        Report report = ReportConverter.toEntity(member, requestDto);
        reportRepository.save(report);
    }
```
자신에 대한 신고인지 확인, 신고 대상 사용자가 존재하는지 확인, 중복된 신고 요청인지 확인 이후
신고 데이터 저장이 끝입니다~

```java
public class ReportRequestDto {

    private Long reportedMemberId;
    @EnumValid(enumClass = ReportSource.class)
    private String reportSource;
    @EnumValid(enumClass = ReportReason.class)
    private String reportReason;
    private String content;
```
@EnumValid 
역직렬화된 String값이 enumClass = xx.class로 선언된 enum 값 중 하나인지 검증

---
쪽지방 id 반환 API는 설명 생략하고 동작 확인만 하겠습니다~


## 동작 확인
정상 동작 - 기타를 제외한 신고 사유는 content 필요 x
<img width="272" alt="image" src="https://github.com/user-attachments/assets/701e69ff-4f1c-49c6-b400-ab762dfa8f68">

신고 사유가 OTHER(기타 사유)인 경우 - content 필요 o
<img width="268" alt="image" src="https://github.com/user-attachments/assets/f81c0acd-602b-4d7f-be6b-cf5c88112216">

같은 사용자에게 같은 사유와 같은 신고 출처로 다시 신고할 경우
<img width="300" alt="image" src="https://github.com/user-attachments/assets/cf133ec9-9617-4522-b7fe-e817954ead4e">

신고 사유가 "기타"인데 content가 없는 경우(null이거나 공백)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/06119a9a-e78e-4766-8a31-649c7c661836">

@EnumValid 동작확인
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d9900458-5aff-49dc-a5b4-96d745ccccad">

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f723e599-73a2-4bd4-bb03-7a9dc40c4c78">

<img width="300" alt="image" src="https://github.com/user-attachments/assets/38697bf9-a84d-4aa3-b046-62ef5bd7599c">


---

### 쪽지방 id 반환
베로(memberId = 2)가 속한 쪽지방은 말즈(memberId = 3)와의 쪽지방 1개인 상황
쪽지방 id 2번
<img width="800" alt="image" src="https://github.com/user-attachments/assets/17a2d1af-1160-4406-aa44-7b2b3ea427c6">

말즈(memberId = 3)와의 쪽지방 조회 -> 기존에 존재하는 chatRoomId 2번 반환
<img width="314" alt="image" src="https://github.com/user-attachments/assets/0eab9e7d-a36a-4267-9f3c-b302233cffb2">

포비(memberId = 5)와의 쪽지방id 조회 -> 새로운 쪽지방 생성후 chatRoomId 36번 반환
<img width="313" alt="image" src="https://github.com/user-attachments/assets/77629f7f-45f3-4705-9d57-eb4a53906334">

포비 입장에서 베로와의 쪽지방id 조회 -> chatRoomId 36번 반환
<img width="312" alt="image" src="https://github.com/user-attachments/assets/a692e12d-fca2-4ade-91af-1db333092a0a">

이 상태에서 베로 입장에서 쪽지방 목록을 조회하면
아직은 포비와의 Chat이 없었기 때문에 목록에는 조회 안됌
<img width="316" alt="image" src="https://github.com/user-attachments/assets/ea6c9cf7-bbc5-4e0e-8e0a-b5eb84a6c80d">

포비 입장에서도 마찬가지로 목록에서 조회 안됌
<img width="271" alt="image" src="https://github.com/user-attachments/assets/f0ce71fc-aade-4404-801a-a9bfd603d096">

베로가 포비한테 쪽지를 보내면?
목록에서 조회됌
<img width="434" alt="image" src="https://github.com/user-attachments/assets/edebafa4-6e80-4dc8-96d8-f3ea3adeab68">

포비 입장에서도 목록에서 조회됌
<img width="428" alt="image" src="https://github.com/user-attachments/assets/b763294c-7078-4992-ba94-aa10b15630b1">

예외 처리 동작 (존재하지 않는 recipientId인 경우)
<img width="336" alt="image" src="https://github.com/user-attachments/assets/ddd27b5f-fa86-4c80-8d33-e0c294802e39">

> ex) 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> ex) 테스트 코드 작성도 좋습니다!

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
