### PR TITLE
[COZY-315] feat: 멤버 상세정보 조회 시 방에 참여했는지 여부와 일치율 조회 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
@@ -3,6 +3,8 @@ package com.cozymate.cozymate_server.domain.memberstat.controller;
 import com.cozymate.cozymate_server.domain.auth.userDetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.memberstat.converter.MemberStatConverter;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatRequestDTO;
+import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO;
+import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.service.MemberStatCommandService;
 import com.cozymate.cozymate_server.domain.memberstat.service.MemberStatQueryService;
@@ -113,7 +115,7 @@ public class MemberStatController {
         ErrorStatus._MEMBERSTAT_NOT_EXISTS
     })
     @GetMapping("/{memberId}")
-    public ResponseEntity<ApiResponse<MemberStatQueryResponseDTO>> getMemberStat(
+    public ResponseEntity<ApiResponse<MemberStatDetailResponseDTO>> getMemberStat(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @PathVariable Long memberId
     ) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
@@ -114,11 +114,12 @@ public class MemberStatController {
     })
     @GetMapping("/{memberId}")
     public ResponseEntity<ApiResponse<MemberStatQueryResponseDTO>> getMemberStat(
+        @AuthenticationPrincipal MemberDetails memberDetails,
         @PathVariable Long memberId
     ) {
         return ResponseEntity.ok(
             ApiResponse.onSuccess(
-                memberStatQueryService.getMemberStatWithId(memberId)
+                memberStatQueryService.getMemberStatWithId(memberDetails.getMember(),memberId)
             ));
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -4,6 +4,7 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat.MemberStatBuilder;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatRequestDTO.MemberStatCommandRequestDTO;
+import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatEqualityResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.dto.MemberStatResponseDTO.MemberStatQueryResponseDTO;
 import com.cozymate.cozymate_server.domain.memberstat.util.MemberStatUtil;
@@ -93,6 +94,46 @@ public class MemberStatConverter {
             .personality(MemberStatUtil.fromStringToList(memberStat.getPersonality()))
             .mbti(memberStat.getMbti())
             .selfIntroduction(memberStat.getSelfIntroduction())
+            .build();
+    }
+
+    public static MemberStatDetailResponseDTO toDetailDto(MemberStat memberStat,
+        Integer birthYear,
+        Integer equality,
+        Long roomId) {
+        return MemberStatDetailResponseDTO.builder()
+            .universityId(memberStat.getUniversity().getId())
+            .admissionYear(memberStat.getAdmissionYear())
+            .birthYear(birthYear)
+            .major(memberStat.getMajor())
+            .numOfRoommate(memberStat.getNumOfRoommate())
+            .acceptance(memberStat.getAcceptance())
+            .wakeUpMeridian(TimeUtil.convertToMeridian(memberStat.getWakeUpTime()))
+            .wakeUpTime(TimeUtil.convertToTime(memberStat.getWakeUpTime()))
+            .sleepingMeridian(TimeUtil.convertToMeridian(memberStat.getSleepingTime()))
+            .sleepingTime(TimeUtil.convertToTime(memberStat.getSleepingTime()))
+            .turnOffMeridian(TimeUtil.convertToMeridian(memberStat.getTurnOffTime()))
+            .turnOffTime(TimeUtil.convertToTime(memberStat.getTurnOffTime()))
+            .smokingState(memberStat.getSmoking())
+            .sleepingHabit(MemberStatUtil.fromStringToList(memberStat.getSleepingHabit()))
+            .airConditioningIntensity(memberStat.getAirConditioningIntensity())
+            .heatingIntensity(memberStat.getHeatingIntensity())
+            .lifePattern(memberStat.getLifePattern())
+            .intimacy(memberStat.getIntimacy())
+            .canShare(memberStat.getCanShare())
+            .isPlayGame(memberStat.getIsPlayGame())
+            .isPhoneCall(memberStat.getIsPhoneCall())
+            .studying(memberStat.getStudying())
+            .intake(memberStat.getIntake())
+            .cleanSensitivity(memberStat.getCleanSensitivity())
+            .noiseSensitivity(memberStat.getNoiseSensitivity())
+            .cleaningFrequency(memberStat.getCleaningFrequency())
+            .drinkingFrequency(memberStat.getDrinkingFrequency())
+            .personality(MemberStatUtil.fromStringToList(memberStat.getPersonality()))
+            .mbti(memberStat.getMbti())
+            .selfIntroduction(memberStat.getSelfIntroduction())
+            .equality(equality)
+            .roomId(roomId)
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatResponseDTO.java
@@ -49,6 +49,47 @@ public class MemberStatResponseDTO {
         private String selfIntroduction;
     }
 
+    // 일치율, 방 존재 여부까지 들어있는 DTO
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberStatDetailResponseDTO {
+
+        private Long universityId;
+        private Integer admissionYear;
+        private Integer birthYear;
+        private String major;
+        private Integer numOfRoommate;
+        private String acceptance;
+        private String wakeUpMeridian;
+        private Integer wakeUpTime;
+        private String sleepingMeridian;
+        private Integer sleepingTime;
+        private String turnOffMeridian;
+        private Integer turnOffTime;
+        private String smokingState;
+        private List<String> sleepingHabit;
+        private Integer airConditioningIntensity;
+        private Integer heatingIntensity;
+        private String lifePattern;
+        private String intimacy;
+        private String canShare;
+        private String isPlayGame;
+        private String isPhoneCall;
+        private String studying;
+        private String intake;
+        private Integer cleanSensitivity;
+        private Integer noiseSensitivity;
+        private String cleaningFrequency;
+        private String drinkingFrequency;
+        private List<String> personality;
+        private String mbti;
+        private String selfIntroduction;
+        private Integer equality;
+        private Long roomId;
+    }
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityRepository.java
@@ -10,4 +10,6 @@ public interface MemberStatEqualityRepository extends
     List<MemberStatEquality> findByMemberAIdAndMemberBIdIn(Long memberAId, List<Long> memberIds);
 
     List<MemberStatEquality> findAllByMemberAIdOrMemberBId(Long memberAId, Long memberBId);
+
+    Integer findMemberStatEqualitiesByMemberAIdAndMemberBId(Long memberAId, Long memberBId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/repository/MemberStatEqualityRepository.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.memberstatequality.repository;
 
 import com.cozymate.cozymate_server.domain.memberstatequality.MemberStatEquality;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberStatEqualityRepository extends
@@ -11,5 +12,5 @@ public interface MemberStatEqualityRepository extends
 
     List<MemberStatEquality> findAllByMemberAIdOrMemberBId(Long memberAId, Long memberBId);
 
-    Integer findMemberStatEqualitiesByMemberAIdAndMemberBId(Long memberAId, Long memberBId);
+    Optional<MemberStatEquality> findMemberStatEqualitiesByMemberAIdAndMemberBId(Long memberAId, Long memberBId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
@@ -30,5 +30,11 @@ public class MemberStatEqualityQueryService {
             ));
     }
 
+    public Integer getSingleEquality(Long memberAId, Long memberBId) {
+        return memberStatEqualityRepository.findMemberStatEqualitiesByMemberAIdAndMemberBId(
+            memberAId, memberBId
+        );
+    }
+
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
@@ -2,6 +2,8 @@ package com.cozymate.cozymate_server.domain.memberstatequality.service;
 
 import com.cozymate.cozymate_server.domain.memberstatequality.MemberStatEquality;
 import com.cozymate.cozymate_server.domain.memberstatequality.repository.MemberStatEqualityRepository;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,9 +33,13 @@ public class MemberStatEqualityQueryService {
     }
 
     public Integer getSingleEquality(Long memberAId, Long memberBId) {
-        return memberStatEqualityRepository.findMemberStatEqualitiesByMemberAIdAndMemberBId(
+        MemberStatEquality memberStatEquality = memberStatEqualityRepository.findMemberStatEqualitiesByMemberAIdAndMemberBId(
             memberAId, memberBId
+        ).orElseThrow(
+            () ->  new GeneralException(ErrorStatus._MEMBERSTAT_EQUALITY_NOT_FOUND)
         );
+
+        return memberStatEquality.getEquality();
     }
 
 


### PR DESCRIPTION
## #️⃣ 요약 설명

멤버 상세정보 조회 시 방에 참여했는지 여부와 일치율을 추가했습니다.

## 📝 작업 내용

한번 달아보겠습니다

## 동작 확인

잘 동작합니다.
<img width="361" alt="image" src="https://github.com/user-attachments/assets/8e94c135-9f65-4aae-90f2-1836447d1ea0">

방에 속해있지 않을 때 0을 리턴합니다.
<img width="368" alt="image" src="https://github.com/user-attachments/assets/bf4a7c8d-91bb-4e98-ba90-fbc2c3aaff4a">


## 💬 리뷰 요구사항(선택)

감사합니다.
