### PR TITLE
[COZY-292] feat: 멤버 상세정보 생성 수정 시 대학 정보(학교, 학과) 제외, 기숙사 미정 인원도 받을 수 있게 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/friend/controller/FriendController.java
@@ -130,6 +130,8 @@ public class FriendController {
                 friendQueryService.getFriendList(memberDetails.getMember())
             ));
     }
+
+    @Deprecated
     @Operation(
         summary = "[포비] 친구 여부 가져오기",
         description = "사용자의 토큰을 넣어 사용하고,\n"

--- a/src/main/java/com/cozymate/cozymate_server/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/friend/controller/FriendController.java
@@ -33,6 +33,7 @@ public class FriendController {
     private final FriendCommandService friendCommandService;
     private final FriendQueryService friendQueryService;
 
+    @Deprecated
     @Operation(
         summary = "[포비] 친구 신청 요청",
         description = "보내는 사용자의 토큰을 넣어 사용하고, Body로 친구 요청을 받는 멤버의 ID를 보내주세요."
@@ -52,6 +53,7 @@ public class FriendController {
                 friendCommandService.requestFriend(senderDetails.getMember(), sendFriendRequestDTO)));
     }
 
+    @Deprecated
     @Operation(
         summary = "[포비] 친구 신청 수락",
         description = "수락하는 사용자의 토큰을 넣어 사용하고, Body로 친구 신청을 보냈던 멤버의 ID를 보내주세요."
@@ -71,6 +73,7 @@ public class FriendController {
                 friendCommandService.acceptFriendRequest(receiverDetails.getMember(), sendFriendRequestDTO)));
     }
 
+    @Deprecated
     @Operation(
         summary = "[포비] 친구 신청 거절",
         description = "수락하는 사용자의 토큰을 넣어 사용하고, Body로 친구 신청을 보냈던 멤버의 ID를 보내주세요."
@@ -90,6 +93,7 @@ public class FriendController {
                 friendCommandService.denyFriendRequest(receiverDetails.getMember(), sendFriendRequestDTO)));
     }
 
+    @Deprecated
     @Operation(
         summary = "[포비] 친구 좋아요 토글",
         description = "사용자의 토큰을 넣어 사용하고, Body로 좋아하고자 하는 멤버의 ID를 보내주세요."
@@ -109,6 +113,7 @@ public class FriendController {
                 friendCommandService.toggleLikeFriend(likerDetails.getMember(), sendFriendRequestDTO)));
     }
 
+    @Deprecated
     @Operation(
         summary = "[포비] 친구 목록 가져오기",
         description = "사용자의 토큰을 넣어 사용하고,"

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/Member.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/Member.java
@@ -71,8 +71,6 @@ public class Member extends BaseTimeEntity {
 
     private String majorName;
 
-    // 기존에 member -> memberstat 상속 관계를
-    // member <-> memberstat one to one mapping으로 변경하였습니다.
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "member")
     private MemberStat memberStat;
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
@@ -102,7 +102,7 @@ public class MemberStat extends BaseTimeEntity {
         this.university = university;
         this.acceptance = memberStatCommandRequestDTO.getAcceptance();
         this.admissionYear = Integer.parseInt(memberStatCommandRequestDTO.getAdmissionYear());
-        this.major = memberStatCommandRequestDTO.getMajor();
+        //this.major = memberStatCommandRequestDTO.getMajor();
         this.numOfRoommate = memberStatCommandRequestDTO.getNumOfRoommate();
         this.wakeUpTime = TimeUtil.convertTime(memberStatCommandRequestDTO.getWakeUpMeridian(),
             memberStatCommandRequestDTO.getWakeUpTime());

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/MemberStat.java
@@ -41,10 +41,6 @@ public class MemberStat extends BaseTimeEntity {
     @JoinColumn(name = "member_id", referencedColumnName = "id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "university_id")
-    private University university;
-
     private Integer admissionYear;
 
     private String major;
@@ -95,10 +91,10 @@ public class MemberStat extends BaseTimeEntity {
 
     private String selfIntroduction;
 
-    public void update(Member member, University university,
+    public void update(Member member,
         MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
         this.member = member;
-        this.university = university;
+//        this.university = university;
         this.acceptance = memberStatCommandRequestDTO.getAcceptance();
         this.admissionYear = Integer.parseInt(memberStatCommandRequestDTO.getAdmissionYear());
         //this.major = memberStatCommandRequestDTO.getMajor();

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -21,7 +21,6 @@ public class MemberStatConverter {
 
         MemberStatBuilder builder = MemberStat.builder()
             .member(member)
-            .university(university)
             .admissionYear(Integer.parseInt(memberStatCommandRequestDTO.getAdmissionYear()))
 //            .major(memberStatCommandRequestDTO.getMajor())
             .numOfRoommate(memberStatCommandRequestDTO.getNumOfRoommate())
@@ -63,7 +62,7 @@ public class MemberStatConverter {
 
     public static MemberStatQueryResponseDTO toDto(MemberStat memberStat, Integer birthYear) {
         return MemberStatQueryResponseDTO.builder()
-            .universityId(memberStat.getUniversity().getId())
+            .universityId(memberStat.getMember().getUniversity().getId())
             .admissionYear(memberStat.getAdmissionYear())
             .birthYear(birthYear)
 //            .major(memberStat.getMajor())

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -23,7 +23,7 @@ public class MemberStatConverter {
             .member(member)
             .university(university)
             .admissionYear(Integer.parseInt(memberStatCommandRequestDTO.getAdmissionYear()))
-            .major(memberStatCommandRequestDTO.getMajor())
+//            .major(memberStatCommandRequestDTO.getMajor())
             .numOfRoommate(memberStatCommandRequestDTO.getNumOfRoommate())
             .acceptance(memberStatCommandRequestDTO.getAcceptance())
             .wakeUpTime(TimeUtil.convertTime(memberStatCommandRequestDTO.getWakeUpMeridian(),
@@ -66,7 +66,7 @@ public class MemberStatConverter {
             .universityId(memberStat.getUniversity().getId())
             .admissionYear(memberStat.getAdmissionYear())
             .birthYear(birthYear)
-            .major(memberStat.getMajor())
+//            .major(memberStat.getMajor())
             .numOfRoommate(memberStat.getNumOfRoommate())
             .acceptance(memberStat.getAcceptance())
             .wakeUpMeridian(TimeUtil.convertToMeridian(memberStat.getWakeUpTime()))

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
@@ -3,6 +3,7 @@ package com.cozymate.cozymate_server.domain.memberstat.dto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -20,19 +21,19 @@ public class MemberStatRequestDTO {
     @AllArgsConstructor
     public static class MemberStatCommandRequestDTO {
 
-        @NotNull
-        private Long universityId;
+//        @NotNull
+//        private Long universityId;
         //학번의 경우 처리하기 애매한 부분이 있어, String 2자리로 통일함. EX) 09 학번 -> "09"
         @NotBlank
         @Size(min = 2, max = 2)
         private String admissionYear;
-        @NotBlank
-        private String major;
+//        @NotBlank
+//        private String major;
         @NotNull
-        @Min(2)
+        @Min(0)
         @Max(6)
         private Integer numOfRoommate;
-        @NotBlank
+        @NotEmpty
         private String acceptance;
         @NotBlank
         @Size(min = 2, max = 2)
@@ -55,8 +56,9 @@ public class MemberStatRequestDTO {
         @Min(1)
         @Max(12)
         private Integer turnOffTime;
-        @NotBlank
+        @NotEmpty
         private String smokingState;
+        @NotEmpty
         private List<String> sleepingHabit;
         @NotNull
         @Min(0)
@@ -66,19 +68,19 @@ public class MemberStatRequestDTO {
         @Min(0)
         @Max(3)
         private Integer heatingIntensity;
-        @NotBlank
+        @NotEmpty
         private String lifePattern;
-        @NotBlank
+        @NotEmpty
         private String intimacy;
-        @NotBlank
+        @NotEmpty
         private String canShare;
-        @NotBlank
+        @NotEmpty
         private String isPlayGame;
-        @NotBlank
+        @NotEmpty
         private String isPhoneCall;
-        @NotBlank
+        @NotEmpty
         private String studying;
-        @NotBlank
+        @NotEmpty
         private String intake;
         @NotNull
         @Min(1)
@@ -88,15 +90,16 @@ public class MemberStatRequestDTO {
         @Min(1)
         @Max(5)
         private Integer noiseSensitivity;
-        @NotBlank
+        @NotEmpty
         private String cleaningFrequency;
-        @NotBlank
+        @NotEmpty
         private String drinkingFrequency;
+        @NotEmpty
         private List<String> personality;
         @NotBlank
         @Size(max = 4, min = 4)
         private String mbti;
-        @NotBlank
+        @NotEmpty
         private String selfIntroduction;
     }
 
@@ -105,19 +108,19 @@ public class MemberStatRequestDTO {
     @AllArgsConstructor
     public static class MemberStatSearchRequestDTO {
 
-        @NotNull
-        private Long universityId;
+//        @NotNull
+//        private Long universityId;
         //학번의 경우 처리하기 애매한 부분이 있어, String 2자리로 통일함. EX) 09 학번 -> "09"
-        @NotBlank
+        @NotEmpty
         @Size(min = 2, max = 2)
         private String admissionYear;
-        @NotBlank
-        private String major;
+//        @NotBlank
+//        private String major;
         @NotNull
-        @Min(2)
+        @Min(0)
         @Max(6)
         private Integer numOfRoommate;
-        @NotBlank
+        @NotEmpty
         private String acceptance;
         @NotBlank
         @Size(min = 2, max = 2)
@@ -140,8 +143,9 @@ public class MemberStatRequestDTO {
         @Min(1)
         @Max(12)
         private Integer turnOffTime;
-        @NotBlank
+        @NotEmpty
         private String smokingState;
+        @NotEmpty
         private List<String> sleepingHabit;
         @NotNull
         @Min(1)
@@ -151,19 +155,19 @@ public class MemberStatRequestDTO {
         @Min(1)
         @Max(3)
         private Integer heatingIntensity;
-        @NotBlank
+        @NotEmpty
         private String lifePattern;
-        @NotBlank
+        @NotEmpty
         private String intimacy;
-        @NotBlank
+        @NotEmpty
         private String canShare;
-        @NotBlank
+        @NotEmpty
         private String isPlayGame;
-        @NotBlank
+        @NotEmpty
         private String isPhoneCall;
-        @NotBlank
+        @NotEmpty
         private String studying;
-        @NotBlank
+        @NotEmpty
         private String intake;
         @NotNull
         @Min(1)
@@ -173,15 +177,16 @@ public class MemberStatRequestDTO {
         @Min(1)
         @Max(5)
         private Integer noiseSensitivity;
-        @NotBlank
+        @NotEmpty
         private String cleaningFrequency;
-        @NotBlank
+        @NotEmpty
         private String drinkingFrequency;
+        @NotEmpty
         private List<String> personality;
         @NotBlank
         @Size(max = 4, min = 4)
         private String mbti;
-        @NotBlank
+        @NotEmpty
         private String selfIntroduction;
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/MemberStatRequestDTO.java
@@ -108,8 +108,6 @@ public class MemberStatRequestDTO {
     @AllArgsConstructor
     public static class MemberStatSearchRequestDTO {
 
-//        @NotNull
-//        private Long universityId;
         //학번의 경우 처리하기 애매한 부분이 있어, String 2자리로 통일함. EX) 09 학번 -> "09"
         @NotEmpty
         @Size(min = 2, max = 2)

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
@@ -1,6 +1,5 @@
 package com.cozymate.cozymate_server.domain.memberstat.repository;
 
-import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.enums.Gender;
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
 import com.cozymate.cozymate_server.domain.memberstat.repository.querydsl.MemberStatQueryRepository;
@@ -26,5 +25,5 @@ public interface MemberStatRepository extends
     @Query("SELECT ms FROM MemberStat ms JOIN FETCH ms.member")
     List<MemberStat> findAllWithMember();
 
-    List<MemberStat> findByMember_GenderAndUniversity_Id(Gender gender, Long universityId);
+    List<MemberStat> findByMember_GenderAndMember_University_Id(Gender gender, Long universityId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/querydsl/MemberStatQueryRepositoryImpl.java
@@ -74,10 +74,12 @@ public class MemberStatQueryRepositoryImpl implements MemberStatQueryRepository 
 
     private BooleanBuilder initDefaultQuery(MemberStat criteriaMemberStat) {
 
+        Member criteriaMember = criteriaMemberStat.getMember();
+
         BooleanBuilder builder = new BooleanBuilder()
             .and(memberStat.id.ne(criteriaMemberStat.getId()))
-            .and(member.gender.eq(criteriaMemberStat.getMember().getGender()))
-            .and(memberStat.university.id.eq(criteriaMemberStat.getUniversity().getId()));
+            .and(member.gender.eq(criteriaMember.getGender()))
+            .and(member.university.id.eq(criteriaMember.getUniversity().getId()));
 
         // '미정'인 경우 인실 조건을 무시, 그렇지 않으면 인실 조건 추가
         if (!criteriaMemberStat.getNumOfRoommate().equals(NUM_OF_ROOMMATE_NOT_DETERMINED)) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
@@ -33,13 +33,13 @@ public class MemberStatCommandService {
             throw new GeneralException(ErrorStatus._MEMBERSTAT_EXISTS);
         }
 
-        University university = universityRepository.findById(
-                memberStatCommandRequestDTO.getUniversityId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
+//        University university = universityRepository.findById(
+//                memberStatCommandRequestDTO.getUniversityId())
+//            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
 
         MemberStat saveMemberStat = memberStatRepository.save(
             MemberStatConverter.toEntity(
-                null, member, university, memberStatCommandRequestDTO
+                null, member, null, memberStatCommandRequestDTO
             )
         );
 
@@ -53,16 +53,16 @@ public class MemberStatCommandService {
     public Long modifyMemberStat(
         Member member, MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
 
-        University university = universityRepository.findById(
-                memberStatCommandRequestDTO.getUniversityId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
+//        University university = universityRepository.findById(
+//                memberStatCommandRequestDTO.getUniversityId())
+//            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
 
         MemberStat updatedMemberStat = memberStatRepository.findByMemberId(member.getId())
             .orElseThrow(
                 () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
             );
 
-        updatedMemberStat.update(member, university, memberStatCommandRequestDTO);
+        updatedMemberStat.update(member, null, memberStatCommandRequestDTO);
 
         memberStatEqualityCommandService.updateMemberStatEqualities(
             updatedMemberStat

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatCommandService.java
@@ -33,10 +33,6 @@ public class MemberStatCommandService {
             throw new GeneralException(ErrorStatus._MEMBERSTAT_EXISTS);
         }
 
-//        University university = universityRepository.findById(
-//                memberStatCommandRequestDTO.getUniversityId())
-//            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
-
         MemberStat saveMemberStat = memberStatRepository.save(
             MemberStatConverter.toEntity(
                 null, member, null, memberStatCommandRequestDTO
@@ -53,16 +49,12 @@ public class MemberStatCommandService {
     public Long modifyMemberStat(
         Member member, MemberStatCommandRequestDTO memberStatCommandRequestDTO) {
 
-//        University university = universityRepository.findById(
-//                memberStatCommandRequestDTO.getUniversityId())
-//            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
-
         MemberStat updatedMemberStat = memberStatRepository.findByMemberId(member.getId())
             .orElseThrow(
                 () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
             );
 
-        updatedMemberStat.update(member, null, memberStatCommandRequestDTO);
+        updatedMemberStat.update(member,  memberStatCommandRequestDTO);
 
         memberStatEqualityCommandService.updateMemberStatEqualities(
             updatedMemberStat

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
@@ -34,9 +34,9 @@ public class MemberStatEqualityCommandService {
     public void createMemberStatEqualities(MemberStat newMemberStat) {
 
         // 성별이 같고, 같은 학교일 경우에 대해서만 일치율 계산
-        List<MemberStat> memberStatList = memberStatRepository.findByMember_GenderAndUniversity_Id(
+        List<MemberStat> memberStatList = memberStatRepository.findByMember_GenderAndMember_University_Id(
             newMemberStat.getMember().getGender(),
-            newMemberStat.getUniversity().getId()
+            newMemberStat.getMember().getUniversity().getId()
         );
 
         Long newMemberId = newMemberStat.getMember().getId();
@@ -94,7 +94,7 @@ public class MemberStatEqualityCommandService {
         // 성별과 학교를 기준으로 MemberStat을 그룹화
         Map<String, List<MemberStat>> groupedMemberStats = allMemberStats.stream()
             .collect(Collectors.groupingBy(
-                memberStat -> memberStat.getMember().getGender() + "-" + memberStat.getUniversity()
+                memberStat -> memberStat.getMember().getGender() + "-" + memberStat.getMember().getUniversity()
                     .getId()
             ));
 


### PR DESCRIPTION
## #️⃣ 요약 설명

멤버 상세정보 생성 수정 시 대학 정보(학교, 학과) 제외하고, 기숙사 미정 인원도 받을 수 있게 수정함
대학 연관관계 변경으로 관련 코드 수정
Friend Controller 전체 만료시켰습니다.
MemberStat 일부에서 빈칸이 가능하도록 변경했습니다.

## 📝 작업 내용

..

## 동작 확인

역사 속에 남겨진 Friend...잘가
<img width="429" alt="image" src="https://github.com/user-attachments/assets/71c27992-a562-422c-bfeb-094c4fe54ca7">


생성에서 잘 제외됨
<img width="256" alt="image" src="https://github.com/user-attachments/assets/7c800289-8bb1-4ddc-abd4-a5ee5f9063b4">

수정에서 잘 제외됨
<img width="272" alt="image" src="https://github.com/user-attachments/assets/fcb569e6-938a-4189-93a0-c22000cb94e1">

나머지 조회나 이런 부분은 한번씩 돌려보니 잘 돌아갔습니다.

## 💬 리뷰 요구사항(선택)

감사합니다