### PR TITLE
[COZY-79] fix: 방 정보 조회 수정 및 방 수정사항에 프로필 사진 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
@@ -77,8 +77,9 @@ public class Room extends BaseTimeEntity {
         }
     }
 
-    public void updateRoomName(String newRoomName) {
+    public void updateRoom(String newRoomName, Integer newProfileImage) {
         this.name = newRoomName;
+        this.profileImage = newProfileImage;
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/RoomRequestDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/RoomRequestDto.java
@@ -14,17 +14,17 @@ public class RoomRequestDto {
 
     @Getter
     public static class PrivateRoomCreateRequest{
-        @NotBlank
-        @Size(max=12)
+        @NotBlank(message = "방 이름은 필수입니다.")
+        @Size(max=12, message = "방 이름은 최대 12글자입니다.")
         @Pattern(regexp = "^(?!\\s)[가-힣a-zA-Z0-9\\s]+(?<!\\s)$", message = "한글, 영어, 숫자 및 공백만 입력해주세요. 단, 공백은 처음이나 끝에 올 수 없습니다.")
         private String name;
-        @NotNull
+        @NotNull(message = "프로필 이미지 선택은 필수입니다.")
         @Min(0)
         @Max(15)
         private Integer profileImage;
-        @NotNull
-        @Min(2)
-        @Max(6)
+        @NotNull(message = "방 인원수 선택은 필수입니다.")
+        @Min(value = 2, message = "방 인원은 2~6명 사이여야 합니다.")
+        @Max(value = 6, message = "방 인원은 2~6명 사이여야 합니다.")
         private Integer maxMateNum;
     }
 
@@ -53,6 +53,10 @@ public class RoomRequestDto {
         @Size(max=12, message = "방 이름은 최대 12글자입니다.")
         @Pattern(regexp = "^(?!\\s)[가-힣a-zA-Z0-9\\s]+(?<!\\s)$", message = "한글, 영어, 숫자 및 공백만 입력해주세요. 단, 공백은 처음이나 끝에 올 수 없습니다.")
         private String name;
+        @NotNull(message = "프로필 이미지 선택은 필수입니다.")
+        @Min(0)
+        @Max(15)
+        private Integer profileImage;
         @Size(min = 1, max = 3, message = "해시태그는 1개에서 3개까지 입력할 수 있습니다.")
         private List<@NotBlank @Pattern(regexp = "^(?!_)[가-힣a-zA-Z0-9]+(_[가-힣a-zA-Z0-9]+)*(?<!_)$",
             message = "해시태그는 한글, 영어, 숫자 및 '_'만 사용할 수 있으며, '_'는 앞이나 뒤에 올 수 없습니다.") String> hashtags;

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/RoomResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/RoomResponseDto.java
@@ -18,12 +18,13 @@ public class RoomResponseDto {
         private String inviteCode;
         private Integer profileImage;
         List<CozymateInfoResponse> mateList;
-        private boolean isRoomManager;
+        private Long managerId;
+        private Boolean isRoomManager;
         private Integer maxMateNum;
         private Integer numOfArrival;
         private RoomType roomType;
         private List<String> hashtags;
-        private Integer equaility;
+        private Integer equality;
         private MemberStatDifferenceResponseDTO difference;
         // TODO: 기숙사 정보 추가
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -271,7 +271,7 @@ public class RoomCommandService {
             roomHashtagCommandService.deleteRoomHashtags(room);
             roomHashtagCommandService.updateRoomHashtags(room, request.getHashtags());
         }
-        room.updateRoomName(request.getName());
+        room.updateRoom(request.getName(), request.getProfileImage());
         roomRepository.save(room);
 
         return roomQueryService.getRoomById(roomId, memberId);


### PR DESCRIPTION
## #️⃣ 요약 설명
공개방은 다른 사용자도 방 정보 조회 가능하게 수정
오타 및 필드 이름 수정
방정보 수정시 프로필 사진도 수정 가능하도록 변경했습니다

## 📝 작업 내용


## 동작 확인
![image](https://github.com/user-attachments/assets/63e92eb6-cb95-495c-8af4-29e26dc4b758)
비공개방 조회시 해당방의 룸메이트인지 검사
![image](https://github.com/user-attachments/assets/b412ddd4-a475-40ab-a37e-66f6530f3def)
공개방은 룸메이트 아니어도 방 정보 조회 가능
![image](https://github.com/user-attachments/assets/b9821832-fa2b-40da-8c71-8073178b4f61)
![image](https://github.com/user-attachments/assets/6e5c7aa2-3f6e-4667-857f-5bc1144699ad)
방 수정시 프로필 이미지도 수정되도록 변경

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
