### PR TITLE
[COZY-360] feat: 멤버 일치율 조회시, 예외처리 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/controller/MemberStatController.java
@@ -113,7 +113,7 @@ public class MemberStatController {
             + "성격, 잠버릇은 다중 선택으로, 문자열 배열을 리턴합니다.\n\n"
             + "멤버 정보는 memberDetail, 멤버 스탯 정보는 memberStatDetail 객체로 리턴합니다."
             + "일치율과 roomId를 추가로 리턴합니다."
-            + "일치율은 본인을 호출할 경우, 0을 리턴합니다."
+            + "일치율은 본인을 호출할 경우, 또는 없는 사람을 호출할 경우 null을 리턴합니다."
     )
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -73,15 +73,10 @@ public class MemberStatQueryService {
             () -> new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS)
         );
 
-        // 본인은 일치율 0으로 처리
-        Integer equality = EQUALITY_ZERO;
-
-        if(!viewer.getId().equals(memberId)){
-            equality = memberStatEqualityQueryService.getSingleEquality(
+        Integer equality = memberStatEqualityQueryService.getSingleEquality(
                 memberId,
                 viewer.getId()
             );
-        }
 
         Optional<Mate> mate = mateRepository.findByMemberIdAndEntryStatusAndRoomStatusIn(
             memberId, EntryStatus.JOINED, List.of(RoomStatus.ENABLE, RoomStatus.WAITING));

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -49,8 +49,6 @@ public class MemberStatQueryService {
     private final MemberStatEqualityQueryService memberStatEqualityQueryService;
     private final MemberStatPreferenceQueryService memberStatPreferenceQueryService;
 
-    private static final Integer EQUALITY_ZERO = 0;
-
     public MemberStatDetailWithMemberDetailResponseDTO getMemberStat(Member member) {
 
         MemberStat memberStat = memberStatRepository.findByMemberId(member.getId())

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -208,16 +208,14 @@ public class MemberStatQueryService {
     public List<MemberStatSearchResponseDTO> getMemberSearchResponse(String subString, Member searchingMember) {
 
         // 가독성을 위해 분리해 봄
-        Integer numOfRoomMateOfSearchingMember = searchingMember.getMemberStat().getNumOfRoommate();
         Long universityId = searchingMember.getUniversity().getId();
         Gender gender = searchingMember.getGender();
-        String dormitoryName = searchingMember.getMemberStat().getDormitoryName();
         Long searchingMemberId = searchingMember.getId();
 
         //memberStat이 존재할 때
         if(memberStatRepository.existsByMemberId(searchingMemberId)){
             List<Member> memberList = memberRepository.findMembersWithMatchingCriteria(
-                subString, universityId, gender, numOfRoomMateOfSearchingMember, dormitoryName, searchingMemberId
+                subString, universityId, gender, searchingMember.getMemberStat().getNumOfRoommate(), searchingMember.getMemberStat().getDormitoryName(), searchingMemberId
             );
             return memberList.stream()
                 .map(member -> {
@@ -233,7 +231,7 @@ public class MemberStatQueryService {
             subString, universityId, gender,searchingMemberId
         );
         return memberList.stream()
-            .map(member-> MemberStatConverter.toMemberStatSearchResponseDTO(member, 0))
+            .map(member-> MemberStatConverter.toMemberStatSearchResponseDTO(member, null))
             .toList();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
@@ -33,13 +33,10 @@ public class MemberStatEqualityQueryService {
     }
 
     public Integer getSingleEquality(Long memberAId, Long memberBId) {
-        MemberStatEquality memberStatEquality = memberStatEqualityRepository.findMemberStatEqualitiesByMemberAIdAndMemberBId(
-            memberAId, memberBId
-        ).orElseThrow(
-            () ->  new GeneralException(ErrorStatus._MEMBERSTAT_EQUALITY_NOT_FOUND)
-        );
 
-        return memberStatEquality.getEquality();
+        return memberStatEqualityRepository.findMemberStatEqualitiesByMemberAIdAndMemberBId(
+            memberAId, memberBId
+        ).map(MemberStatEquality::getEquality).orElse(null);
     }
 
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
넵
## #️⃣ 작업 내용

멤버 일치율 조회시, 예외처리 수정 (exeception->null)
멤버 상세정보가 없는 사람이 멤버 상세정보가 있는 화면을 봤을 때, exception이 발생했었고, 이제 발생하지 않고 null을 리턴하도록 했습니다.

## 동작 확인
저걸 사용하는 API 2개 시험해봤습니다.
<img width="518" alt="image" src="https://github.com/user-attachments/assets/969a86d3-7d62-4a8f-badd-5ba8b539eb9e">
<img width="595" alt="image" src="https://github.com/user-attachments/assets/747ed63b-a412-4409-ab04-53bb8e5886a8">


## 💬 리뷰 요구사항(선택)
감사합니다.
