### PR TITLE
[COZY-328] feat: 방장에게 보이는 방 참여 요청 목록 조회, 방 조회시 기숙사 정보 추가, 사용자가 해당 방에 참여 요청을 했는지 여부 조회

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -36,6 +36,8 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     Optional<Mate> findByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId, EntryStatus status);
 
+    boolean existsByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId, EntryStatus status);
+
     Optional<Mate> findByMemberIdAndEntryStatus(Long memberId, EntryStatus entryStatus);
 
     List<Mate> findAllByMemberIdAndEntryStatus(Long memberId, EntryStatus entryStatus);

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -356,4 +356,16 @@ public class RoomController {
         return ResponseEntity.ok(ApiResponse.onSuccess("공개방 전환 완료"));
     }
 
+    @GetMapping("/{roomId}/pending-status")
+    @Operation(summary = "[바니] 사용자가 해당 방에 참여 요청을 했는지 여부 조회", description = "로그인한 사용자가 roomId에 해당하는 방에 참여 요청을 했는지 여부를 조회합니다.")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._ROOM_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<Boolean>> getPendingStatus(
+        @PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
+        Boolean response = roomQueryService.getPendingStatus(roomId, memberDetails.member().getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -327,7 +327,7 @@ public class RoomController {
         return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.getInvitedRoomList(memberDetails.member().getId())));
     }
 
-    @GetMapping("/pending-mates")
+    @GetMapping("/pending-members")
     @Operation(summary = "[바니] 방장에게 보이는 방 참여 요청 목록 조회", description = "방장에게 도착한 방 참여 요청을 조회합니다.")
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -327,6 +327,15 @@ public class RoomController {
         return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.getInvitedRoomList(memberDetails.member().getId())));
     }
 
+    @GetMapping("/pending-mates")
+    @Operation(summary = "[바니] 방장에게 보이는 방 참여 요청 목록 조회", description = "방장에게 도착한 방 참여 요청을 조회합니다.")
+    @SwaggerApiError({
+
+    })
+    public ResponseEntity<ApiResponse<List<MateDetailResponseDTO>>> getPendingMemberList(
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.getPendingMemberList(memberDetails.member().getId())));
+    }
 
     @PatchMapping("/{roomId}/to-public")
     @Operation(summary = "[바니] 공개방으로 전환", description = "roomId에 해당하는 방을 공개방으로 전환합니다.")

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -330,7 +330,11 @@ public class RoomController {
     @GetMapping("/pending-mates")
     @Operation(summary = "[바니] 방장에게 보이는 방 참여 요청 목록 조회", description = "방장에게 도착한 방 참여 요청을 조회합니다.")
     @SwaggerApiError({
-
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._ROOM_NOT_FOUND,
+        ErrorStatus._NOT_ROOM_MATE,
+        ErrorStatus._ROOM_MANAGER_NOT_FOUND,
+        ErrorStatus._NOT_ROOM_MANAGER
     })
     public ResponseEntity<ApiResponse<List<MateDetailResponseDTO>>> getPendingMemberList(
         @AuthenticationPrincipal MemberDetails memberDetails) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/converter/RoomConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/converter/RoomConverter.java
@@ -63,6 +63,7 @@ public class RoomConverter {
         Boolean isRoomManager,
         Integer maxMateNum,
         Integer arrivalMateNum,
+        String dormitoryName,
         String roomType,
         List<String> hashtagList,
         Integer equality,
@@ -79,20 +80,11 @@ public class RoomConverter {
             isRoomManager,
             maxMateNum,
             arrivalMateNum,
+            dormitoryName,
             roomType,
             hashtagList,
             equality,
             difference
         );
     }
-
-//    public static RoomDetailResponseDTO toRoomListResponse(Room room, Integer roomEquality, List<String> hashtagList) {
-//        return new RoomDetailResponseDTO(
-//            room.getId(),
-//            room.getName(),
-//            roomEquality,
-//            hashtagList,
-//            room.getNumOfArrival()
-//        );
-//    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/response/RoomDetailResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/response/RoomDetailResponseDTO.java
@@ -1,6 +1,5 @@
 package com.cozymate.cozymate_server.domain.room.dto.response;
 
-
 import com.cozymate.cozymate_server.domain.memberstat.dto.response.MemberStatDifferenceListResponseDTO;
 import java.util.List;
 
@@ -15,6 +14,7 @@ public record RoomDetailResponseDTO(
     Boolean isRoomManager,
     Integer maxMateNum,
     Integer arrivalMateNum,
+    String dormitoryName,
     String roomType,
     List<String> hashtagList,
     Integer equality,

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -325,8 +325,7 @@ public class RoomQueryService {
         roomRepository.findById(roomId).orElseThrow(
             () -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
 
-        Optional<Mate> pendingMate = mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.PENDING);
-
-        return pendingMate.isPresent();
+        return mateRepository.existsByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.PENDING);
     }
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -89,11 +89,11 @@ public class RoomQueryService {
             isRoomManager,
             room.getMaxMateNum(),
             room.getNumOfArrival(),
+            getDormitoryName(room),
             room.getRoomType().toString(),
             hashtags,
             roomEquality,
             MemberStatConverter.toMemberStatDifferenceResponseDTO(mateMemberStats)
-            // Todo: 기숙사 정보 추가
         );
     }
 
@@ -241,6 +241,7 @@ public class RoomQueryService {
                     false,
                     room.getMaxMateNum(),
                     room.getNumOfArrival(),
+                    getDormitoryName(room),
                     room.getRoomType().toString(),
                     hashtags,
                     roomEquality,
@@ -248,7 +249,7 @@ public class RoomQueryService {
                         .map(mate -> memberStatRepository.findByMemberId(mate.getMember().getId()))
                         .flatMap(Optional::stream)
                         .toList())
-                    );
+                );
             })
             .toList();
     }
@@ -284,6 +285,7 @@ public class RoomQueryService {
                     false,
                     room.getMaxMateNum(),
                     room.getNumOfArrival(),
+                    getDormitoryName(room),
                     room.getRoomType().toString(),
                     hashtags,
                     roomEquality,
@@ -308,6 +310,12 @@ public class RoomQueryService {
         Mate managerMate = mateRepository.findByRoomIdAndIsRoomManager(room.getId(), true)
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_MANAGER_NOT_FOUND));
         return managerMate.getMember().getNickname();
+    }
+
+    public String getDormitoryName(Room room) {
+        Mate managerMate = mateRepository.findByRoomIdAndIsRoomManager(room.getId(), true)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_MANAGER_NOT_FOUND));
+        return managerMate.getMember().getMemberStat().getDormitoryName();
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -318,4 +318,15 @@ public class RoomQueryService {
         return managerMate.getMember().getMemberStat().getDormitoryName();
     }
 
+    public Boolean getPendingStatus(Long roomId, Long memberId) {
+        memberRepository.findById(memberId).orElseThrow(
+            () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        roomRepository.findById(roomId).orElseThrow(
+            () -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
+
+        Optional<Mate> pendingMate = mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.PENDING);
+
+        return pendingMate.isPresent();
+    }
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네
## #️⃣ 작업 내용
방장에게 보이는 방 참여 요청 목록 조회 추가했습니다
방 조회할때 기숙사 조회하는것도 같이 올릴게요
+사용자가 해당 방에 참여 요청을 했는지 여부 조회도 추가했습니다

## 동작 확인
![image](https://github.com/user-attachments/assets/4a8ebf56-90ac-4d11-b926-2dc787743871)
방 참여 요청 목록 조회

![image](https://github.com/user-attachments/assets/32a9acc3-d782-4690-baf5-d95a573f8941)
방 조회 시 기숙사 정보 추가

![image](https://github.com/user-attachments/assets/6d6ca935-6863-4079-907a-3e77a558a304)
사용자가 해당 방에 참여 요청을 했는지 여부 조회
![image](https://github.com/user-attachments/assets/98488ddf-9e5d-413e-bd95-49fb82107827)
참여요청중일때
![image](https://github.com/user-attachments/assets/aa700d28-44b1-46d0-9aed-525c540deb6a)
참여요청중이 아닐때


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
