### PR TITLE
[COZY-366] feat: 일치율 존재하지 않을 시 null 처리, MemberStat, Room, Favorite 3개 사용 도메인 모두 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteQueryService.java
@@ -165,9 +165,7 @@ public class FavoriteQueryService {
         List<Integer> roomEquality = equalityMap.values().stream()
             .toList();
 
-        return (int) Math.round(roomEquality.stream()
-            .mapToInt(Integer::intValue)
-            .average()
-            .orElse((Integer)null));
+        int sum = roomEquality.stream().mapToInt(Integer::intValue).sum();
+        return roomEquality.isEmpty() ? null : (int) Math.round((double) sum / roomEquality.size());
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteQueryService.java
@@ -100,7 +100,7 @@ public class FavoriteQueryService {
         List<Room> notEnableFavoriteRoomList = partitionedRoomsMap.get(false);
 
         Map<Long, List<Mate>> roomIdMatesMap = notEnableFavoriteRoomList.stream().collect(
-            Collectors.toMap(Room::getId, room -> mateRepository.findFetchMemberByRoom(room)));
+            Collectors.toMap(Room::getId, mateRepository::findFetchMemberByRoom));
 
         List<String> criteriaPreferenceList = memberStatPreferenceQueryService.getPreferencesToList(
             member.getId());
@@ -162,17 +162,12 @@ public class FavoriteQueryService {
     }
 
     private Integer getCalculateRoomEquality(Long memberId, Map<Long, Integer> equalityMap) {
-        List<Integer> roomEquality = equalityMap.entrySet().stream()
-            .map(Map.Entry::getValue)
-            .collect(Collectors.toList());
-
-        if (roomEquality.isEmpty()) {
-            return 0;
-        }
+        List<Integer> roomEquality = equalityMap.values().stream()
+            .toList();
 
         return (int) Math.round(roomEquality.stream()
             .mapToInt(Integer::intValue)
             .average()
-            .orElse(0));
+            .orElse((Integer)null));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/response/MemberStatPreferenceResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/response/MemberStatPreferenceResponseDTO.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 @Builder
 public record MemberStatPreferenceResponseDTO(
     MemberDetailResponseDTO memberDetail,
-    int equality,
+    Integer equality,
     Map<String,Object> preferenceStats
 ) {
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -49,6 +49,9 @@ public class MemberStatQueryService {
     private final MemberStatEqualityQueryService memberStatEqualityQueryService;
     private final MemberStatPreferenceQueryService memberStatPreferenceQueryService;
 
+    private static final Integer NO_EQUALITY = null;
+    private static final Integer NO_ROOMMATE = 0;
+
     public MemberStatDetailWithMemberDetailResponseDTO getMemberStat(Member member) {
 
         MemberStat memberStat = memberStatRepository.findByMemberId(member.getId())
@@ -82,7 +85,7 @@ public class MemberStatQueryService {
         return MemberStatConverter.toMemberStatDetailAndRoomIdAndEqualityResponseDTO(
             memberStat,
             equality,
-            mate.isPresent() ? mate.get().getRoom().getId() : 0
+            mate.isPresent() ? mate.get().getRoom().getId() : NO_ROOMMATE
         );
     }
 
@@ -173,7 +176,7 @@ public class MemberStatQueryService {
                 return MemberStatConverter.toPreferenceResponseDTO(
                     stat,
                     preferences,
-                    0
+                    NO_EQUALITY
                 );
             })
             .toList();
@@ -215,7 +218,12 @@ public class MemberStatQueryService {
         //memberStat이 존재할 때
         if(memberStatRepository.existsByMemberId(searchingMemberId)){
             List<Member> memberList = memberRepository.findMembersWithMatchingCriteria(
-                subString, universityId, gender, searchingMember.getMemberStat().getNumOfRoommate(), searchingMember.getMemberStat().getDormitoryName(), searchingMemberId
+                subString,
+                universityId,
+                gender,
+                searchingMember.getMemberStat().getNumOfRoommate(),
+                searchingMember.getMemberStat().getDormitoryName(),
+                searchingMemberId
             );
             return memberList.stream()
                 .map(member -> {
@@ -231,7 +239,7 @@ public class MemberStatQueryService {
             subString, universityId, gender,searchingMemberId
         );
         return memberList.stream()
-            .map(member-> MemberStatConverter.toMemberStatSearchResponseDTO(member, null))
+            .map(member-> MemberStatConverter.toMemberStatSearchResponseDTO(member, NO_EQUALITY))
             .toList();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityQueryService.java
@@ -20,6 +20,8 @@ public class MemberStatEqualityQueryService {
 
     private final MemberStatEqualityRepository memberStatEqualityRepository;
 
+    private static final Integer NO_EQUALITY = null;
+
     public Map<Long, Integer> getEquality(Long memberAId, List<Long> memberIdList) {
 
         List<MemberStatEquality> memberStatEqualityList = memberStatEqualityRepository.findByMemberAIdAndMemberBIdIn(
@@ -36,7 +38,7 @@ public class MemberStatEqualityQueryService {
 
         return memberStatEqualityRepository.findMemberStatEqualitiesByMemberAIdAndMemberBId(
             memberAId, memberBId
-        ).map(MemberStatEquality::getEquality).orElse(null);
+        ).map(MemberStatEquality::getEquality).orElse(NO_EQUALITY);
     }
 
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -147,12 +147,8 @@ public class RoomQueryService {
     public Integer getCalculateRoomEquality(Map<Long, Integer> equalityMap){
         List<Integer> roomEquality = equalityMap.values().stream()
             .toList();
-
-        return (int) Math.round(roomEquality.stream()
-            .mapToInt(Integer::intValue)
-            .average()
-            // primitive double이라 casting 해줘야 함
-            .orElse((Integer)null));
+        int sum = roomEquality.stream().mapToInt(Integer::intValue).sum();
+        return roomEquality.isEmpty() ? null : (int) Math.round((double) sum / roomEquality.size());
 
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -148,14 +148,11 @@ public class RoomQueryService {
         List<Integer> roomEquality = equalityMap.values().stream()
             .toList();
 
-        if (roomEquality.isEmpty()) {
-            return 0;
-        }
-
         return (int) Math.round(roomEquality.stream()
             .mapToInt(Integer::intValue)
             .average()
-            .orElse(0));
+            // primitive double이라 casting 해줘야 함
+            .orElse((Integer)null));
 
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomRecommendService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomRecommendService.java
@@ -20,6 +20,7 @@ import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,9 +47,10 @@ public class RoomRecommendService {
         Map<Long, Integer> roomEqualityMap = calculateRoomEqualityMap(roomList, member,
             roomMateMap);
 
+        // null을 가장 후순위로 처리
         List<Pair<Long, Integer>> sortedRoomList = roomEqualityMap.entrySet().stream()
             .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
-            .sorted((pair1, pair2) -> pair2.getRight().compareTo(pair1.getRight())) // 직접 람다식으로 비교
+            .sorted(Comparator.comparing(Pair::getRight, Comparator.nullsLast(Comparator.reverseOrder()))) // 직접 람다식으로 비교
             .limit(size)
             .toList();
 
@@ -82,8 +84,8 @@ public class RoomRecommendService {
                     member.getId(), memberList.stream().map(Member::getId).toList()).stream()
                 .map(MemberStatEquality::getEquality)
                 .toList();
-            int averageEquality = equalityList.isEmpty() ? 0
-                : equalityList.stream().reduce(Integer::sum).orElse(0) / equalityList.size();
+            Integer averageEquality = equalityList.isEmpty() ? null
+                : equalityList.stream().reduce(Integer::sum).orElse(null) / equalityList.size();
             roomEqualityMap.put(room.getId(), averageEquality);
         }
         return roomEqualityMap;


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
YES
## #️⃣ 작업 내용

일치율 없을 시 null을 리턴하도록 적용했습니다.

## 동작 확인

Room 도메인
<img width="434" alt="image" src="https://github.com/user-attachments/assets/9d8d8aa2-d73b-4c2f-aab5-b5cb474d7379">

Member 도메인
<img width="445" alt="image" src="https://github.com/user-attachments/assets/1974edc1-2e99-4127-a9db-aef5477fc883">

방 추천
<img width="511" alt="image" src="https://github.com/user-attachments/assets/8bbd7154-f8bd-4e35-9d3b-734ea76f36bf">

Favorite 도메인
<img width="534" alt="image" src="https://github.com/user-attachments/assets/55404aa3-7202-4ec1-bc79-5afe01265d1d">

상세정보 없는 멤버 처리 해주세용 @veronees 
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/740e160f-c054-4b02-9f42-a0232e110c08">


## 💬 리뷰 요구사항(선택)
NPE 한번 겪고 나니까 좀 후회되긴 합니다ㅜㅜ
그런데 없을 경우 처리가 애매하고, 프런트와 협의한 부분이라 우선 책임지고 문제생기면 제가 유지보수 할게요..