### PR TITLE
[COZY-370] feat: 사용자 검색 시 멤버 상세정보 없는 사람 제외

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/repository/MemberRepository.java
@@ -30,6 +30,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         "WHERE m.university.id = :universityId " +
         "AND m.gender = :gender " +
         "AND m.id <> :searchingMemberId " +
+        "AND ms IS NOT NULL " +
         "AND (:numOfRoomMateOfSearchingMember = 0 OR ms.numOfRoommate = :numOfRoomMateOfSearchingMember) " +
         "AND ms.dormitoryName = :dormitoryName "+
         "AND m.nickname LIKE %:subString%")
@@ -41,10 +42,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         @Param("dormitoryName") String dormitoryName,
         @Param("searchingMemberId") Long searchingMemberId
     );
-    @Query("SELECT m FROM Member m " +
+
+    @Query("SELECT m FROM Member m JOIN m.memberStat ms " +
         "WHERE m.university.id = :universityId " +
         "AND m.gender = :gender " +
         "AND m.id <> :searchingMemberId " +
+        "AND ms IS NOT NULL " +
         "AND m.nickname LIKE %:subString%")
     List<Member> findMembersWithMatchingCriteria(
         @Param("subString") String subString,


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용

사용자 검색 시 멤버 상세정보 없는 사람 제외
두줄 추가했습니다

## 동작 확인
<img width="586" alt="image" src="https://github.com/user-attachments/assets/1acfdc91-31df-40cb-be66-9b0bd643add4">
수많은 테스트 계정중 있는거만 뜹니다

## 💬 리뷰 요구사항(선택)
감사합니다
