### PR TITLE
[COZY-368] feat: 방 추천 기능 Type에 따른 정렬 + Pagenation 처리 완료

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/controller/MailController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/controller/MailController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomRecommendController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomRecommendController.java
@@ -4,6 +4,7 @@ import com.cozymate.cozymate_server.domain.auth.userdetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.room.dto.RoomRecommendResponseDto.RoomRecommendationResponseList;
 import com.cozymate.cozymate_server.domain.room.enums.RoomSortType;
 import com.cozymate.cozymate_server.domain.room.service.RoomRecommendService;
+import com.cozymate.cozymate_server.global.common.PageResponseDto;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
@@ -30,13 +31,14 @@ public class RoomRecommendController {
     @SwaggerApiError({
         ErrorStatus._MEMBERSTAT_PREFERENCE_NOT_EXISTS
     })
-    public ResponseEntity<ApiResponse<RoomRecommendationResponseList>> getRoomList(
+    public ResponseEntity<ApiResponse<PageResponseDto<RoomRecommendationResponseList>>> getRoomList(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @RequestParam @Positive @Max(10) int size,
         @RequestParam int page,
         @RequestParam RoomSortType sortType
     ) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
-            roomRecommendService.getRecommendationList(memberDetails.member(), size, page, sortType)));
+            roomRecommendService.getRecommendationList(memberDetails.member(), size, page,
+                sortType)));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomRecommendController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomRecommendController.java
@@ -35,7 +35,7 @@ public class RoomRecommendController {
         @AuthenticationPrincipal MemberDetails memberDetails,
         @RequestParam @Positive @Max(10) int size,
         @RequestParam int page,
-        @RequestParam RoomSortType sortType
+        @RequestParam(defaultValue = "AVERAGE_RATE") RoomSortType sortType
     ) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
             roomRecommendService.getRecommendationList(memberDetails.member(), size, page,

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomRecommendController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomRecommendController.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.room.controller;
 
 import com.cozymate.cozymate_server.domain.auth.userdetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.room.dto.RoomRecommendResponseDto.RoomRecommendationResponseList;
+import com.cozymate.cozymate_server.domain.room.enums.RoomSortType;
 import com.cozymate.cozymate_server.domain.room.service.RoomRecommendService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
@@ -31,9 +32,11 @@ public class RoomRecommendController {
     })
     public ResponseEntity<ApiResponse<RoomRecommendationResponseList>> getRoomList(
         @AuthenticationPrincipal MemberDetails memberDetails,
-        @RequestParam @Positive @Max(10) int size
+        @RequestParam @Positive @Max(10) int size,
+        @RequestParam int page,
+        @RequestParam RoomSortType sortType
     ) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
-            roomRecommendService.getRecommendationList(memberDetails.member(), size)));
+            roomRecommendService.getRecommendationList(memberDetails.member(), size, page, sortType)));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/converter/RoomRecommendConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/converter/RoomRecommendConverter.java
@@ -24,6 +24,20 @@ public class RoomRecommendConverter {
             .build();
     }
 
+    public static RoomRecommendationResponse toRoomRecommendationResponseWhenNoMemberStat(Room room) {
+        return RoomRecommendationResponse.builder()
+            .roomId(room.getId())
+            .name(room.getName())
+            .hashtags(room.getRoomHashtags().stream()
+                .map(roomHashtag -> roomHashtag.getHashtag().getHashtag())
+                .toList())
+            .equality(null)
+            .maxMateNum(room.getMaxMateNum())
+            .numOfArrival(room.getNumOfArrival())
+            .equalMemberStatNum(null)
+            .build();
+    }
+
     public static RoomRecommendationResponseList toRoomRecommendationResponseList(
         List<RoomRecommendationResponse> roomRecommendationResponseList) {
         return RoomRecommendationResponseList.builder()

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/enums/RoomSortType.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/enums/RoomSortType.java
@@ -1,0 +1,7 @@
+package com.cozymate.cozymate_server.domain.room.enums;
+
+public enum RoomSortType {
+    LATEST, // 최신순
+    AVERAGE_RATE, // 평점순
+    CLOSING_SOON // 마감임박순
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
@@ -17,6 +17,6 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     boolean existsByMemberIdAndStatuses(@Param("memberId") Long memberId, @Param("status1") RoomStatus status1, @Param("status2") RoomStatus status2, @Param("status3") EntryStatus status3);
     Optional<Room> findByInviteCode(String inviteCode);
 
-    List<Room> findAllByRoomType(@Param("roomType") RoomType roomType);
+    List<Room> findAllByRoomTypeAndStatusNot(RoomType roomType, RoomStatus status);
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomRecommendService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomRecommendService.java
@@ -14,6 +14,7 @@ import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.domain.room.converter.RoomRecommendConverter;
 import com.cozymate.cozymate_server.domain.room.dto.RoomRecommendResponseDto.RoomRecommendationResponse;
 import com.cozymate.cozymate_server.domain.room.dto.RoomRecommendResponseDto.RoomRecommendationResponseList;
+import com.cozymate.cozymate_server.domain.room.enums.RoomSortType;
 import com.cozymate.cozymate_server.domain.room.enums.RoomType;
 import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
@@ -39,10 +40,13 @@ public class RoomRecommendService {
     private final MemberStatEqualityRepository memberStatEqualityRepository;
     private final MemberStatPreferenceRepository memberStatPreferenceRepository;
 
-    // TODO: 대규모 리팩토링 필요
-    public RoomRecommendationResponseList getRecommendationList(Member member, int size) {
+    // TODO: page, sortType 파라미터 반영해서 로직 수정
+    public RoomRecommendationResponseList getRecommendationList(Member member, int size, int page,
+        RoomSortType sortType) {
 
+        // 공개된 방 찾기 +  TODO: 대학, 성별, 시기 필터링
         List<Room> roomList = roomRepository.findAllByRoomType(RoomType.PUBLIC);
+
         Map<Long, List<Mate>> roomMateMap = groupMatesByRoom(mateRepository.findAll());
         Map<Long, Integer> roomEqualityMap = calculateRoomEqualityMap(roomList, member,
             roomMateMap);

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomRecommendService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomRecommendService.java
@@ -17,8 +17,10 @@ import com.cozymate.cozymate_server.domain.room.dto.RoomRecommendResponseDto.Roo
 import com.cozymate.cozymate_server.domain.room.enums.RoomSortType;
 import com.cozymate.cozymate_server.domain.room.enums.RoomType;
 import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
+import com.cozymate.cozymate_server.global.common.PageResponseDto;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import jakarta.transaction.Transactional;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -32,6 +34,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class RoomRecommendService {
 
     private final RoomRepository roomRepository;
@@ -41,22 +44,24 @@ public class RoomRecommendService {
     private final MemberStatPreferenceRepository memberStatPreferenceRepository;
 
     // TODO: page, sortType 파라미터 반영해서 로직 수정
-    public RoomRecommendationResponseList getRecommendationList(Member member, int size, int page,
+    public PageResponseDto<RoomRecommendationResponseList> getRecommendationList(Member member, int size, int page,
         RoomSortType sortType) {
 
         // 공개된 방 찾기 +  TODO: 대학, 성별, 시기 필터링
         List<Room> roomList = roomRepository.findAllByRoomType(RoomType.PUBLIC);
+
+        Map<Long, Room> roomMap = roomList.stream()
+            .collect(Collectors.toMap(Room::getId, room -> room));
 
         Map<Long, List<Mate>> roomMateMap = groupMatesByRoom(mateRepository.findAll());
         Map<Long, Integer> roomEqualityMap = calculateRoomEqualityMap(roomList, member,
             roomMateMap);
 
         // null을 가장 후순위로 처리
-        List<Pair<Long, Integer>> sortedRoomList = roomEqualityMap.entrySet().stream()
-            .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
-            .sorted(Comparator.comparing(Pair::getRight, Comparator.nullsLast(Comparator.reverseOrder()))) // 직접 람다식으로 비교
-            .limit(size)
-            .toList();
+        List<Pair<Long, Integer>> sortedRoomList = getSortedRoomListBySortType(roomEqualityMap,
+            roomMap,
+            sortType, page, size+1);
+        boolean hasNext = sortedRoomList.size() > size;
 
         MemberStatPreference memberStatPreference = memberStatPreferenceRepository.findByMemberId(
                 member.getId())
@@ -64,11 +69,18 @@ public class RoomRecommendService {
         List<String> preferenceList = Arrays.asList(
             memberStatPreference.getSelectedPreferences().split(","));
 
-        List<RoomRecommendationResponse> roomRecommendationResponseList = buildRoomRecommendationResponses(
+        List<RoomRecommendationResponse> buildRoomRecommendationResponses = buildRoomRecommendationResponses(
             member, sortedRoomList, roomMateMap, roomList, preferenceList);
 
-        return RoomRecommendConverter.toRoomRecommendationResponseList(
-            roomRecommendationResponseList);
+        RoomRecommendationResponseList roomRecommendationResponseList = RoomRecommendConverter.toRoomRecommendationResponseList(
+            buildRoomRecommendationResponses);
+
+        return PageResponseDto.<RoomRecommendationResponseList>builder()
+            .page(page)
+            .hasNext(hasNext)
+            .result(roomRecommendationResponseList)
+            .build();
+
     }
 
 
@@ -80,8 +92,7 @@ public class RoomRecommendService {
         Map<Long, List<Mate>> roomMateMap) {
         Map<Long, Integer> roomEqualityMap = new HashMap<>();
         for (Room room : roomList) {
-            List<Member> memberList = roomMateMap.getOrDefault(room.getId(),
-                    Collections.emptyList()).stream()
+            List<Member> memberList = roomMateMap.get(room.getId()).stream()
                 .map(Mate::getMember)
                 .toList();
             List<Integer> equalityList = memberStatEqualityRepository.findByMemberAIdAndMemberBIdIn(
@@ -137,5 +148,47 @@ public class RoomRecommendService {
         });
 
         return RoomRecommendConverter.toRoomRecommendationResponse(room, pair, preferenceMap);
+    }
+
+    private List<Pair<Long, Integer>> getSortedRoomListBySortType(
+        Map<Long, Integer> roomEqualityMap, Map<Long, Room> roomMap, RoomSortType sortType,
+        int page, int size) {
+        return switch (sortType) {
+            case LATEST -> // 최신순으로 정렬한 후, 동일한 일자면 일치율로 정렬
+                roomEqualityMap.entrySet().stream()
+                    .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
+                    //.filter(pair -> pair.getRight() != null && roomMap.containsKey(pair.getRight()))
+                    .sorted(Comparator.comparing(
+                        pair -> roomMap.get(pair.getLeft()).getCreatedAt(),
+                        Comparator.nullsLast(Comparator.reverseOrder()))) // 직접 람다식으로 비교
+                    .skip((long) page * size)
+                    .limit(size)
+                    .toList();
+            case AVERAGE_RATE -> // 일치율순으로 정렬
+                roomEqualityMap.entrySet().stream()
+                    .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
+                    .sorted(Comparator.comparing(Pair::getRight,
+                        Comparator.nullsLast(Comparator.reverseOrder()))) // 직접 람다식으로 비교
+                    .skip((long) page * size)
+                    .limit(size)
+                    .toList();
+            case CLOSING_SOON -> // 인원이 적게 남은 순으로 정렬한 후, 동일한 값이면 일치율로 정렬
+                roomEqualityMap.entrySet().stream()
+                    .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
+                    .filter(pair -> pair.getRight() != null && roomMap.containsKey(
+                        pair.getLeft())) // 유효한 pair만 포함
+                    .sorted(Comparator.comparing(Pair::getRight,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                    .sorted(Comparator.comparing(
+                        pair -> roomMap.get(pair.getLeft()).getMaxMateNum() - roomMap.get(
+                            pair.getLeft()).getNumOfArrival(),
+                        Comparator.naturalOrder())) // 추가 정렬 기준
+                    .skip((long) page * size)
+                    .limit(size)
+                    .toList();
+            default -> throw new GeneralException(ErrorStatus._INVALID_SORT_TYPE);
+        };
+
+
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomRecommendService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomRecommendService.java
@@ -15,6 +15,7 @@ import com.cozymate.cozymate_server.domain.room.converter.RoomRecommendConverter
 import com.cozymate.cozymate_server.domain.room.dto.RoomRecommendResponseDto.RoomRecommendationResponse;
 import com.cozymate.cozymate_server.domain.room.dto.RoomRecommendResponseDto.RoomRecommendationResponseList;
 import com.cozymate.cozymate_server.domain.room.enums.RoomSortType;
+import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
 import com.cozymate.cozymate_server.domain.room.enums.RoomType;
 import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
 import com.cozymate.cozymate_server.global.common.PageResponseDto;
@@ -48,7 +49,10 @@ public class RoomRecommendService {
         RoomSortType sortType) {
 
         // 공개된 방 찾기 +  TODO: 대학, 성별, 시기 필터링
-        List<Room> roomList = roomRepository.findAllByRoomType(RoomType.PUBLIC);
+        List<Room> roomList = roomRepository.findAllByRoomTypeAndStatusNot(RoomType.PUBLIC, RoomStatus.DISABLE)
+            .stream()
+            .filter(room -> room.getMaxMateNum() - room.getNumOfArrival() > 0)
+            .toList();
 
         Map<Long, Room> roomMap = roomList.stream()
             .collect(Collectors.toMap(Room::getId, room -> room));

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogQueryService.java
@@ -46,9 +46,11 @@ public class RoomLogQueryService {
             .map(RoomLogConverter::toRoomLogDetailResponseDto)
             .toList();
 
-        return new PageResponseDto<>(pageable.getPageNumber(), roomLogSlice.hasNext(),
-            roomLogResponseList);
-
+        return PageResponseDto.<List<RoomLogDetailResponseDto>>builder()
+            .page(pageable.getPageNumber())
+            .hasNext(roomLogSlice.hasNext())
+            .result(roomLogResponseList)
+            .build();
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/global/common/PageResponseDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/common/PageResponseDto.java
@@ -1,14 +1,14 @@
 package com.cozymate.cozymate_server.global.common;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Builder;
 
-@Getter
-@AllArgsConstructor
-public class PageResponseDto<T> {
+@Builder
+public record PageResponseDto<T>(
 
-    private int page;
-    private boolean hasNext;
-    private T result;
+    int page,
+    boolean hasNext,
+    T result
+
+) {
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -57,6 +57,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _REQUEST_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROOM412", "존재하지 않는 참여요청입니다."),
     _PUBLIC_ROOM(HttpStatus.BAD_REQUEST, "ROOM413", "공개방입니다."),
     _PRIVATE_ROOM(HttpStatus.BAD_REQUEST, "ROOM414", "비공개방입니다."),
+    _INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "ROOM415", "유효하지 않은 정렬 타입입니다."),
+
+
     // Hashtag
     _DUPLICATE_HASHTAGS(HttpStatus.BAD_REQUEST, "HASHTAG400", "중복된 해시태그는 입력할 수 없습니다."),
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
넵

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

- 방 추천 기능에 조회 타입이 총 3가지가 있습니다.
<img width="252" alt="image" src="https://github.com/user-attachments/assets/d02991c8-839f-431a-97d2-7b8c1c55aa0b">

- 해당 조회 타입에 맞추어 기능을 추가했습니다.
- 또한 여러개가 필요할 경우 페이징 처리를 통해서 가져올 수 있도록 추가하였습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

### Latest
<img width="389" alt="image" src="https://github.com/user-attachments/assets/13a769da-ff98-412c-ac5a-3bfc1aeb3f54">

최신 방 목록부터 불러오게 됩니다.
현재 반환되는 순서는 초대할 방, 좌심방, 우심방 순입니다.

<img width="339" alt="image" src="https://github.com/user-attachments/assets/3ddb3f39-a475-4a02-b99e-cd75d68a57a3">

아래부터 최근에 생성된 방임을 알 수 있습니다.

### Equality
<img width="256" alt="image" src="https://github.com/user-attachments/assets/7f621d99-1ee3-43aa-9537-d81c781f838c">

일치율 순으로 반환하게 됩니다.
해당 부분은 equality 값으로 높은 값이 먼저 반환됨을 알 수 있씁니다.
좌심방은 42퍼 일치율을 가집니다.

### Closing_soom
<img width="321" alt="image" src="https://github.com/user-attachments/assets/6b906981-be88-450b-912a-aa965548651a">

방이 가득 찰 때까지 인원이 적게 남은 순으로 반환하며, 동일한 반환값을 가질 때에는 equality가 높은 순으로 반환합니다.
우심방, 좌심방 초대할 방 순으로 반환되고 있습니다.

<img width="491" alt="image" src="https://github.com/user-attachments/assets/407aceb8-b4d7-441e-933b-752378130196">

이렇게 인원이 1명, 2명, 3명 순으로 남은 것을 알 수 있습니다.

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
