### PR TITLE
[COZY-382] feat: 방 초대 요청, 참여 요청, 수락/거절에 푸시 알림 로직 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/controller/FcmController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/controller/FcmController.java
@@ -35,17 +35,4 @@ public class FcmController {
         fcmCommandService.createFcm(memberDetails.member(), fcmRequestDTO);
         return ResponseEntity.ok(ApiResponse.onSuccess("fcm토큰 및 기기 고유 값 저장 완료"));
     }
-
-
-    private final MemberRepository memberRepository;
-    private final FcmPushService fcmPushService;
-
-    @GetMapping("/test/send")
-    public ResponseEntity<ApiResponse<String>> sendTest() {
-        Member member = memberRepository.findById(7L).get();
-
-        fcmPushService.sendNotification(OneTargetDto.create(member, NotificationType.SELECT_COZY_MATE));
-
-        return ResponseEntity.ok(ApiResponse.onSuccess(member.getNickname() + "에게 알림 전송"));
-    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -23,6 +23,11 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     Optional<Mate> findByRoomIdAndMemberId(Long roomId, Long memberId);
 
+    @Query("select m from Mate m where m.room.id = :roomId and m.member.id = :memberId and m.entryStatus <> :entryStatus")
+    Optional<Mate> findByRoomIdAndMemberIdAndNotEntryStatus(@Param("roomId") Long roomId,
+        @Param("memberId") Long memberId, @Param("entryStatus") EntryStatus entryStatus);
+
+
     @Query("SELECT COUNT(m) FROM Mate m WHERE m.room.id = :roomId AND m.entryStatus = 'JOINED'")
     long countActiveMatesByRoomId(@Param("roomId") Long roomId);
 
@@ -34,7 +39,8 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     Optional<Mate> findByMemberIdAndRoomId(Long MemberId, Long RoomId);
 
-    Optional<Mate> findByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId, EntryStatus status);
+    Optional<Mate> findByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId,
+        EntryStatus status);
 
     boolean existsByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId, EntryStatus status);
 
@@ -56,12 +62,14 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     // MemberBirthDay의 Localdate 값에서 Month와 Day가 같은 Member들을 찾는다.
     @Query("SELECT m FROM Mate m WHERE MONTH(m.member.birthDay) = :month AND DAY(m.member.birthDay) = :day AND m.entryStatus = :entryStatus")
-    List<Mate> findAllByMemberBirthDayMonthAndDayAndEntryStatus(@Param("month") int month, @Param("day") int day, @Param("entryStatus") EntryStatus entryStatus);
+    List<Mate> findAllByMemberBirthDayMonthAndDayAndEntryStatus(@Param("month") int month,
+        @Param("day") int day, @Param("entryStatus") EntryStatus entryStatus);
 
     List<Mate> findByRoom(Room room);
 
     @Query("select m from Mate m join fetch m.member where m.room = :room and m.entryStatus = :entryStatus")
-    List<Mate> findFetchMemberByRoom(@Param("room") Room room, @Param("entryStatus") EntryStatus entryStatus);
+    List<Mate> findFetchMemberByRoom(@Param("room") Room room,
+        @Param("entryStatus") EntryStatus entryStatus);
 
     Optional<Mate> findByMember(Member member);
 
@@ -78,4 +86,8 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     List<Mate> findByRoomIdAndEntryStatus(Long roomId, EntryStatus entryStatus);
 
     Integer countByMemberIdAndEntryStatus(Long memberId, EntryStatus entryStatus);
+
+    @Query("select m from Mate m join fetch m.member where m.room = :room and m.isRoomManager = :isRoomManager")
+    Optional<Mate> findFetchByRoomAndIsRoomManager(@Param("room") Room room,
+        @Param("isRoomManager") boolean isRoomManager);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/enums/NotificationType.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/enums/NotificationType.java
@@ -203,6 +203,19 @@ public enum NotificationType {
                 + "님이 방 참여 요청을 수락했어요";
         }
     },
+
+    /**
+     * ex) xx님이 방 참여 요청을 보냈어요
+     * xx가 방장에게 방 참여 요청을 보낸 경우 방장이 받는 알림
+     * OneTargetReverse
+     */
+    ARRIVE_ROOM_JOIN_REQUEST(NotificationCategory.ROOM_JOIN_REQUEST) {
+        @Override
+        public String generateContent(FcmPushContentDto fcmPushContentDto) {
+            return fcmPushContentDto.getMember().getNickname()
+                + "님이 방 참여 요청을 보냈어요";
+        }
+    }
     ;
 
     private NotificationCategory category;

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -460,9 +460,6 @@ public class RoomCommandService {
             throw new GeneralException(ErrorStatus._ROOM_ALREADY_EXISTS);
         }
 
-        // 여기서 mate 두개 조회되서 에러 발생
-//        Optional<Mate> existingMate = mateRepository.findByRoomIdAndMemberId(roomId, memberId);
-
         Optional<Mate> existingMate = mateRepository.findByRoomIdAndMemberIdAndNotEntryStatus(
             roomId, memberId, EntryStatus.EXITED);
         checkEntryStatus(existingMate);
@@ -471,7 +468,6 @@ public class RoomCommandService {
             throw new GeneralException(ErrorStatus._ROOM_FULL);
         }
 
-        // 여기서 기존 mate exit가 있는 상태에서 mate가 한개 더 만들어짐
         Mate mate = MateConverter.toPending(room, member, false);
         mateRepository.save(mate);
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

- 방 초대 요청, 방 초대 수락/거절, 방 참여 요청, 방 참여 수락/거절 API에 푸시 알림 로직을 추가했습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/59628ab8-4e35-4017-86e4-649d5adbd925">
db에 저장 되면 푸시 알림 간게 보장된거라 이걸로 대체할게요

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

테스트 한다고 알림 많이 가서 죄송합니다 ㅜ
