### PR TITLE
[COZY-383] feat: MemberStat 조회시 초대 요청을 한 사용자인지, 찜을 했는지 여부 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/favorite/repository/FavoriteRepository.java
@@ -4,6 +4,7 @@ import com.cozymate.cozymate_server.domain.favorite.Favorite;
 import com.cozymate.cozymate_server.domain.favorite.enums.FavoriteType;
 import com.cozymate.cozymate_server.domain.member.Member;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,9 +19,13 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     List<Favorite> findByMemberAndFavoriteType(Member member, FavoriteType favoriteType);
 
+    Optional<Favorite> findByMemberAndTargetIdAndFavoriteType(Member member, Long targetId,
+        FavoriteType favoriteType);
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Modifying(clearAutomatically = true)
     @Query("delete from Favorite f where f.targetId in :targetIds and f.favoriteType = :favoriteType")
     void deleteAllByTargetIdsAndFavoriteType(@Param("targetIds") List<Long> targetIds,
         @Param("favoriteType") FavoriteType favoriteType);
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -34,7 +34,8 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     Optional<Mate> findByMemberIdAndRoomId(Long MemberId, Long RoomId);
 
-    Optional<Mate> findByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId, EntryStatus status);
+    Optional<Mate> findByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId,
+        EntryStatus status);
 
     boolean existsByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId, EntryStatus status);
 
@@ -50,18 +51,23 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     Optional<Mate> findByMemberIdAndEntryStatusAndRoomStatusIn(Long memberId,
         EntryStatus entryStatus, List<RoomStatus> roomStatuses);
 
+    List<Mate> findByMemberIdAndEntryStatusInAndRoomStatusIn(Long memberId,
+        List<EntryStatus> entryStatuses, List<RoomStatus> roomStatuses);
+
     List<Mate> findAllByRoomIdAndEntryStatus(Long roomId, EntryStatus entryStatus);
 
     List<Mate> findAllByMemberBirthDayAndEntryStatus(LocalDate birthday, EntryStatus entryStatus);
 
     // MemberBirthDay의 Localdate 값에서 Month와 Day가 같은 Member들을 찾는다.
     @Query("SELECT m FROM Mate m WHERE MONTH(m.member.birthDay) = :month AND DAY(m.member.birthDay) = :day AND m.entryStatus = :entryStatus")
-    List<Mate> findAllByMemberBirthDayMonthAndDayAndEntryStatus(@Param("month") int month, @Param("day") int day, @Param("entryStatus") EntryStatus entryStatus);
+    List<Mate> findAllByMemberBirthDayMonthAndDayAndEntryStatus(@Param("month") int month,
+        @Param("day") int day, @Param("entryStatus") EntryStatus entryStatus);
 
     List<Mate> findByRoom(Room room);
 
     @Query("select m from Mate m join fetch m.member where m.room = :room and m.entryStatus = :entryStatus")
-    List<Mate> findFetchMemberByRoom(@Param("room") Room room, @Param("entryStatus") EntryStatus entryStatus);
+    List<Mate> findFetchMemberByRoom(@Param("room") Room room,
+        @Param("entryStatus") EntryStatus entryStatus);
 
     Optional<Mate> findByMember(Member member);
 
@@ -78,4 +84,5 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     List<Mate> findByRoomIdAndEntryStatus(Long roomId, EntryStatus entryStatus);
 
     Integer countByMemberIdAndEntryStatus(Long memberId, EntryStatus entryStatus);
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -102,12 +102,16 @@ public class MemberStatConverter {
 
     public static MemberStatDetailAndRoomIdAndEqualityResponseDTO toMemberStatDetailAndRoomIdAndEqualityResponseDTO(MemberStat memberStat,
         Integer equality,
-        Long roomId) {
+        Long roomId,
+        Boolean hasRequestedRoomEntry,
+        Long favoriteId) {
         return MemberStatDetailAndRoomIdAndEqualityResponseDTO.builder()
             .memberDetail(MemberConverter.toMemberDetailResponseDTOFromEntity(memberStat.getMember()))
             .memberStatDetail(MemberStatConverter.toMemberStatDetailDTOFromEntity(memberStat))
             .equality(equality)
             .roomId(roomId)
+            .hasRequestedRoomEntry(hasRequestedRoomEntry)
+            .favoriteId(favoriteId)
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/response/MemberStatDetailAndRoomIdAndEqualityResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/dto/response/MemberStatDetailAndRoomIdAndEqualityResponseDTO.java
@@ -8,7 +8,10 @@ public record MemberStatDetailAndRoomIdAndEqualityResponseDTO(
     MemberDetailResponseDTO memberDetail,
     MemberStatDetailResponseDTO memberStatDetail,
     Integer equality,
-    Long roomId
+    Long roomId,
+    Boolean hasRequestedRoomEntry,
+    Long favoriteId
+
 ) {
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -1,5 +1,8 @@
 package com.cozymate.cozymate_server.domain.memberstat.service;
 
+import com.cozymate.cozymate_server.domain.favorite.Favorite;
+import com.cozymate.cozymate_server.domain.favorite.enums.FavoriteType;
+import com.cozymate.cozymate_server.domain.favorite.repository.FavoriteRepository;
 import com.cozymate.cozymate_server.domain.mate.Mate;
 import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
 import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
@@ -19,6 +22,8 @@ import com.cozymate.cozymate_server.domain.memberstat.util.MemberStatUtil;
 import com.cozymate.cozymate_server.domain.memberstatequality.service.MemberStatEqualityQueryService;
 import com.cozymate.cozymate_server.domain.memberstatpreference.service.MemberStatPreferenceQueryService;
 import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
+import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
+import com.cozymate.cozymate_server.domain.room.service.RoomQueryService;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.util.Collections;
@@ -26,11 +31,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -50,8 +53,13 @@ public class MemberStatQueryService {
     private final MemberStatEqualityQueryService memberStatEqualityQueryService;
     private final MemberStatPreferenceQueryService memberStatPreferenceQueryService;
 
+
     private static final Integer NO_EQUALITY = null;
-    private static final Integer NO_ROOMMATE = 0;
+    private static final Long NO_ROOMMATE = 0L;
+    private static final Long NOT_FAVORITE = 0L;
+
+    private final FavoriteRepository favoriteRepository;
+    private final RoomQueryService roomQueryService;
 
     public MemberStatDetailWithMemberDetailResponseDTO getMemberStat(Member member) {
 
@@ -80,13 +88,30 @@ public class MemberStatQueryService {
                 viewer.getId()
             );
 
-        Optional<Mate> mate = mateRepository.findByMemberIdAndEntryStatusAndRoomStatusIn(
-            memberId, EntryStatus.JOINED, List.of(RoomStatus.ENABLE, RoomStatus.WAITING));
+        List<Mate> mateList = mateRepository.findByMemberIdAndEntryStatusInAndRoomStatusIn(
+            memberId,
+            List.of(EntryStatus.PENDING, EntryStatus.JOINED),
+            List.of(RoomStatus.ENABLE, RoomStatus.WAITING)
+        );
+
+        Long roomId = mateList.stream()
+            .filter(mate -> mate.getEntryStatus().equals(EntryStatus.JOINED))
+            .findFirst()
+            .map(mate -> mate.getRoom().getId())
+            .orElse(NO_ROOMMATE);
+
+        boolean hasRequestedRoomEntry = roomQueryService.checkInvitationStatus(viewer, mateList);
+
+        Long favoriteId = favoriteRepository.findByMemberAndTargetIdAndFavoriteType(viewer, memberId, FavoriteType.MEMBER)
+            .map(Favorite::getId)
+            .orElse(NOT_FAVORITE);
 
         return MemberStatConverter.toMemberStatDetailAndRoomIdAndEqualityResponseDTO(
             memberStat,
             equality,
-            mate.isPresent() ? mate.get().getRoom().getId() : NO_ROOMMATE
+            roomId,
+            hasRequestedRoomEntry,
+            favoriteId
         );
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/service/MemberStatQueryService.java
@@ -22,7 +22,6 @@ import com.cozymate.cozymate_server.domain.memberstat.util.MemberStatUtil;
 import com.cozymate.cozymate_server.domain.memberstatequality.service.MemberStatEqualityQueryService;
 import com.cozymate.cozymate_server.domain.memberstatpreference.service.MemberStatPreferenceQueryService;
 import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
-import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
 import com.cozymate.cozymate_server.domain.room.service.RoomQueryService;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
@@ -100,7 +99,8 @@ public class MemberStatQueryService {
             .map(mate -> mate.getRoom().getId())
             .orElse(NO_ROOMMATE);
 
-        boolean hasRequestedRoomEntry = roomQueryService.checkInvitationStatus(viewer, mateList);
+        boolean hasRequestedRoomEntry = roomId.equals(NO_ROOMMATE)
+            && roomQueryService.checkInvitationStatus(viewer, mateList);
 
         Long favoriteId = favoriteRepository.findByMemberAndTargetIdAndFavoriteType(viewer, memberId, FavoriteType.MEMBER)
             .map(Favorite::getId)

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -393,4 +393,18 @@ public class RoomQueryService {
             .toList();
     }
 
+    public boolean checkInvitationStatus(Member viewer, List<Mate> mates) {
+        return mates.stream()
+            .filter(m -> {
+                if (m.getEntryStatus().equals(EntryStatus.JOINED)) {
+                    return false;
+                }
+                return m.getEntryStatus().equals(EntryStatus.PENDING);
+            })
+            .anyMatch(m -> mateRepository.findByMember(viewer)
+                .filter(viewerMate ->
+                    viewerMate.isRoomManager() &&
+                        viewerMate.getRoom().equals(m.getRoom()))
+                .isPresent());
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -395,12 +395,7 @@ public class RoomQueryService {
 
     public boolean checkInvitationStatus(Member viewer, List<Mate> mates) {
         return mates.stream()
-            .filter(m -> {
-                if (m.getEntryStatus().equals(EntryStatus.JOINED)) {
-                    return false;
-                }
-                return m.getEntryStatus().equals(EntryStatus.PENDING);
-            })
+            .filter(m -> m.getEntryStatus().equals(EntryStatus.PENDING))
             .anyMatch(m -> mateRepository.findByMember(viewer)
                 .filter(viewerMate ->
                     viewerMate.isRoomManager() &&


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
NE

## #️⃣ 작업 내용

MemberStat 조회시 초대 요청을 한 사용자인지, 찜을 했는지 여부 추가

## 동작 확인
눈꽃에 저희 방에 초대 요청을 보내고, 저를 찜하기도 했습니다.
<img width="450" alt="image" src="https://github.com/user-attachments/assets/1665f5b3-9558-4c0a-94c3-886a65e22961">

말즈는 찜도 없고, 초대 요청도 하지 않았습니다.
<img width="469" alt="image" src="https://github.com/user-attachments/assets/efb5455e-21a7-4833-8d32-acc3f0701df2">

테슽트 계정이 저희 방에 초대 요청을 보냈습니다
테슽트 계정이 포비를 조회하는 화면 : 정상
<img width="483" alt="image" src="https://github.com/user-attachments/assets/de398d34-e224-48e1-8c11-de3f85d29fd6">
포비 입장에서 봤을 때 수락 거절을 선택할 수 있습니다.
<img width="414" alt="image" src="https://github.com/user-attachments/assets/8e9d8599-1281-44ec-be2b-6f6f725a6f61">


## 💬 리뷰 요구사항(선택)
음...멤버 상세정보 Service에서 room이나 mate에 접근하다보니까 지연시간이 좀 늘어나긴 하는데, 고민이네여