### PR TITLE
[COZY-395] feat: 방장 로직 수정, 비공개방 전환 API

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/Mate.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/Mate.java
@@ -59,6 +59,14 @@ public class Mate extends BaseTimeEntity {
         setEntryStatus(EntryStatus.EXITED);
     }
 
+    public void setRoomManager() {
+        this.isRoomManager = true;
+    }
+
+    public void setNotRoomManager() {
+        this.isRoomManager = false;
+    }
+
     public void setNotExit() {
         this.isExit = false;
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/postcomment/PostCommentRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/postcomment/PostCommentRepository.java
@@ -4,8 +4,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
-    void deleteByPostId(Long postId);
-
     Integer countByPostId(Long postId);
 
     List<PostComment> findByPostIdOrderByCreatedAt(Long postId);

--- a/src/main/java/com/cozymate/cozymate_server/domain/postimage/PostImageRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/postimage/PostImageRepository.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
-    void deleteByPostId(Long PostId);
-
     List<PostImage> findByPostId(Long PostId);
+
+    void deleteAllByPostId(Long postId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
@@ -83,8 +83,12 @@ public class Room extends BaseTimeEntity {
         this.profileImage = newProfileImage;
     }
 
-    public void convertToPublicRoom() {
+    public void changeToPublicRoom() {
         this.roomType = RoomType.PUBLIC;
     }
 
+    public void changeToPrivateRoom() {
+        this.roomType = RoomType.PRIVATE;
+        this.status = RoomStatus.ENABLE;
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
@@ -60,8 +60,6 @@ public class Room extends BaseTimeEntity {
 
     private int numOfArrival = 1;
 
-
-
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "room")
     private Feed feed;
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
@@ -73,8 +73,7 @@ public class Room extends BaseTimeEntity {
 
     public void isRoomFull() {
         if (numOfArrival == maxMateNum) {
-            this.status = RoomStatus.ENABLE;
-            this.enabledAt = LocalDate.now();
+            enableRoom();
         }
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
@@ -89,6 +89,13 @@ public class Room extends BaseTimeEntity {
 
     public void changeToPrivateRoom() {
         this.roomType = RoomType.PRIVATE;
+        if (this.getStatus() != RoomStatus.ENABLE) {
+            enableRoom();
+        }
+    }
+
+    public void enableRoom() {
         this.status = RoomStatus.ENABLE;
+        this.enabledAt = LocalDate.now();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -349,8 +349,20 @@ public class RoomController {
     })
     public ResponseEntity<ApiResponse<String>> convertToPublicRoom(
         @PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
-        roomCommandService.convertToPublicRoom(roomId, memberDetails.member().getId());
+        roomCommandService.changeToPublicRoom(roomId, memberDetails.member().getId());
         return ResponseEntity.ok(ApiResponse.onSuccess("공개방 전환 완료"));
+    }
+
+    @PatchMapping("/{roomId}/to-private")
+    @Operation(summary = "[바니] 비공개방으로 전환", description = "roomId에 해당하는 방을 비공개방으로 전환합니다.")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._ROOM_NOT_FOUND,
+    })
+    public ResponseEntity<ApiResponse<String>> convertToPrivateRoom(
+        @PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
+        roomCommandService.changeToPrivateRoom(roomId, memberDetails.member().getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess("비공개방 전환 완료"));
     }
 
     @GetMapping("/{roomId}/pending-status")

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -358,6 +358,9 @@ public class RoomController {
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._ROOM_NOT_FOUND,
+        ErrorStatus._NOT_ROOM_MATE,
+        ErrorStatus._NOT_ROOM_MANAGER,
+        ErrorStatus._PRIVATE_ROOM,
     })
     public ResponseEntity<ApiResponse<String>> convertToPrivateRoom(
         @PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/PrivateRoomCreateRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/PrivateRoomCreateRequestDTO.java
@@ -12,7 +12,7 @@ public record PrivateRoomCreateRequestDTO(
     @Pattern(regexp = "^(?!\\s)[가-힣a-zA-Z0-9\\s]+(?<!\\s)$", message = "한글, 영어, 숫자 및 공백만 입력해주세요. 단, 공백은 처음이나 끝에 올 수 없습니다.")
     String name,
     @NotNull(message = "프로필 이미지 선택은 필수입니다.")
-    @Range(min=0, max=15)
+    @Range(min=1, max=16)
     Integer persona,
     @NotNull(message = "방 인원수 선택은 필수입니다.")
     @Range(min=2, max=6, message = "방 인원은 2~6명 사이여야 합니다.")

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/PublicRoomCreateRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/PublicRoomCreateRequestDTO.java
@@ -13,7 +13,7 @@ public record PublicRoomCreateRequestDTO (
     @Pattern(regexp = "^(?!\\s)[가-힣a-zA-Z0-9\\s]+(?<!\\s)$", message = "한글, 영어, 숫자 및 공백만 입력해주세요. 단, 공백은 처음이나 끝에 올 수 없습니다.")
     String name,
     @NotNull(message = "프로필 이미지 선택은 필수입니다.")
-    @Range(min=0, max=15)
+    @Range(min=1, max=16)
     Integer persona,
     @NotNull(message = "방 인원수 선택은 필수입니다.")
     @Range(min=2, max=6, message = "방 인원은 2~6명 사이여야 합니다.")

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/RoomUpdateRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/RoomUpdateRequestDTO.java
@@ -13,7 +13,7 @@ public record RoomUpdateRequestDTO(
     @Pattern(regexp = "^(?!\\s)[가-힣a-zA-Z0-9\\s]+(?<!\\s)$", message = "한글, 영어, 숫자 및 공백만 입력해주세요. 단, 공백은 처음이나 끝에 올 수 없습니다.")
     String name,
     @NotNull(message = "프로필 이미지 선택은 필수입니다.")
-    @Range(min=0, max=15)
+    @Range(min=1, max=16)
     Integer persona,
     @Size(min = 1, max = 3, message = "해시태그는 1개에서 3개까지 입력할 수 있습니다.")
     List<@NotBlank @Pattern(regexp = "^(?!_)[가-힣a-zA-Z0-9]+(_[가-힣a-zA-Z0-9]+)*(?<!_)$",

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -80,6 +80,7 @@ public class RoomCommandService {
 
         String inviteCode = generateUniqueUppercaseKey();
         Room room = RoomConverter.toPrivateRoom(request, inviteCode);
+        room.enableRoom();
         room = roomRepository.save(room);
         roomLogCommandService.addRoomLogCreationRoom(room);
 
@@ -249,7 +250,6 @@ public class RoomCommandService {
             .min(Comparator.comparing(Mate::getCreatedAt))
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_MANAGER_NOT_FOUND)); // 방장 없음 예외 처리
         newManager.setRoomManager();
-        mateRepository.save(newManager);
     }
 
     private void deleteRoomDatas(Long roomId) {
@@ -267,8 +267,8 @@ public class RoomCommandService {
             Feed feed = feedRepository.findByRoomId(roomId);
             List<Post> posts = postRepository.findByFeedId(feed.getId());
             for (Post post : posts) {
-                postCommentRepository.deleteByPostId(post.getId());
-                postImageRepository.deleteByPostId(post.getId());
+                postCommentRepository.deleteAllByPostId(post.getId());
+                postImageRepository.deleteAllByPostId(post.getId());
             }
             postRepository.deleteByFeedId(feed.getId());
             feedRepository.deleteByRoomId(roomId);
@@ -601,7 +601,6 @@ public class RoomCommandService {
         }
 
         room.changeToPublicRoom();
-        roomRepository.save(room);
     }
 
     public void changeToPrivateRoom(Long roomId, Long memberId) {
@@ -624,7 +623,6 @@ public class RoomCommandService {
         }
 
         room.changeToPrivateRoom();
-        roomRepository.save(room);
     }
 
     // 초대코드 생성 부분

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -175,12 +175,10 @@ public class RoomCommandService {
         Room room = roomRepository.findById(roomId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
 
-        mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.JOINED)
+        Mate member = mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.JOINED)
             .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_ROOM_MATE));
 
-        Mate manager = mateRepository.findByRoomIdAndIsRoomManager(roomId, true)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_MANAGER_NOT_FOUND));
-        if (!manager.getMember().getId().equals(memberId)) {
+        if (!member.isRoomManager()) {
             throw new GeneralException(ErrorStatus._NOT_ROOM_MANAGER);
         }
 
@@ -286,12 +284,10 @@ public class RoomCommandService {
         Room room = roomRepository.findById(roomId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
 
-        mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.JOINED)
+        Mate member = mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.JOINED)
             .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_ROOM_MATE));
 
-        Mate manager = mateRepository.findByRoomIdAndIsRoomManager(roomId, true)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_MANAGER_NOT_FOUND));
-        if (!manager.getMember().getId().equals(memberId)) {
+        if (!member.isRoomManager()) {
             throw new GeneralException(ErrorStatus._NOT_ROOM_MANAGER);
         }
 
@@ -585,15 +581,14 @@ public class RoomCommandService {
         }
     }
 
-    public void convertToPublicRoom(Long roomId, Long memberId) {
+    public void changeToPublicRoom(Long roomId, Long memberId) {
         memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
         Room room = roomRepository.findById(roomId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
 
-        Mate member = mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId,
-                EntryStatus.JOINED)
+        Mate member = mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.JOINED)
             .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_ROOM_MATE));
 
         // 방장이 아니면 예외 발생
@@ -605,7 +600,30 @@ public class RoomCommandService {
             throw new GeneralException(ErrorStatus._PUBLIC_ROOM);
         }
 
-        room.convertToPublicRoom();
+        room.changeToPublicRoom();
+        roomRepository.save(room);
+    }
+
+    public void changeToPrivateRoom(Long roomId, Long memberId) {
+        memberRepository.findById(memberId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        Room room = roomRepository.findById(roomId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
+
+        Mate member = mateRepository.findByRoomIdAndMemberIdAndEntryStatus(roomId, memberId,
+                EntryStatus.JOINED)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_ROOM_MATE));
+
+        if (!member.isRoomManager()) {
+            throw new GeneralException(ErrorStatus._NOT_ROOM_MANAGER);
+        }
+
+        if (room.getRoomType() != RoomType.PUBLIC) {
+            throw new GeneralException(ErrorStatus._PRIVATE_ROOM);
+        }
+
+        room.changeToPrivateRoom();
         roomRepository.save(room);
     }
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네 
## #️⃣ 작업 내용
방장이 나가는 경우 그 다음으로 가장 먼저 들어온 mate가 방장이 되도록 변경
비공개방 전환 API 구현
persona range 1-16으로 수정했습니다

## 동작 확인
![image](https://github.com/user-attachments/assets/a1f0dc19-7adc-417c-8e7f-56994bcb55a0)
방장이 나갔을 때
![image](https://github.com/user-attachments/assets/dc956aeb-6b62-4b6a-8361-1ba0f60e2414)
그 다음으로 들어온 mate가 방장이 됨
최후의 방장이 나갔을때 방 삭제되는 것 확인했습니다

**비공개방 전환**
![image](https://github.com/user-attachments/assets/d1bec897-4484-43d9-b343-031b1c246481)
이미 비공개방일때
![image](https://github.com/user-attachments/assets/d7a2fb93-4f36-4190-a7c0-f3932ac52d1c)
비공개방 전환 성공

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
