### PR TITLE
[COZY-400] feat: 쪽지방 목록 정렬 및 새로운 쪽지 유무 반환 추가, 새로운 쪽지 온 쪽지방 갯수 조회 API, 회원탈퇴 쪽지 null 처리

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/repository/ChatRepository.java
@@ -2,6 +2,8 @@ package com.cozymate.cozymate_server.domain.chat.repository;
 
 import com.cozymate.cozymate_server.domain.chat.Chat;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.member.Member;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +18,12 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     @Query("select c from Chat c where c.chatRoom = :chatRoom")
     List<Chat> findAllByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
+
+    @Query("select case when count(c) > 0 then true else false end " +
+        "from Chat c " +
+        "where c.sender = :member and c.chatRoom = :chatRoom " +
+        "and (c.createdAt > :lastSeenAt or :lastSeenAt is null)")
+    boolean existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+        @Param("member") Member member, @Param("chatRoom") ChatRoom chatRoom,
+        @Param("lastSeenAt") LocalDateTime lastSeenAt);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/ChatRoom.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/ChatRoom.java
@@ -36,11 +36,23 @@ public class ChatRoom extends BaseTimeEntity {
 
     private LocalDateTime memberBLastDeleteAt;
 
+    private LocalDateTime memberALastSeenAt;
+
+    private LocalDateTime memberBLastSeenAt;
+
     public void updateMemberALastDeleteAt() {
         this.memberALastDeleteAt = LocalDateTime.now();
     }
 
     public void updateMemberBLastDeleteAt() {
         this.memberBLastDeleteAt = LocalDateTime.now();
+    }
+
+    public void updateMemberALastSeenAt() {
+        this.memberALastSeenAt = LocalDateTime.now();
+    }
+
+    public void updateMemberBLastSeenAt() {
+        this.memberBLastSeenAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/controller/ChatRoomController.java
@@ -4,6 +4,7 @@ import com.cozymate.cozymate_server.domain.auth.userdetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.chatroom.converter.ChatRoomConverter;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomSimpleDTO;
+import com.cozymate.cozymate_server.domain.chatroom.dto.response.CountChatRoomsWithNewChatDTO;
 import com.cozymate.cozymate_server.domain.chatroom.dto.response.ChatRoomIdResponseDTO;
 import com.cozymate.cozymate_server.domain.chatroom.dto.response.ChatRoomDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.chatroom.service.ChatRoomCommandService;
@@ -72,5 +73,16 @@ public class ChatRoomController {
 
         return ResponseEntity.ok(ApiResponse.onSuccess(
             chatRoomCommandService.saveChatRoom(member, simpleDTO.recipient())));
+    }
+
+    @GetMapping("/count/new-chat")
+    @Operation(summary = "[베로] 새로운 쪽지가 온 쪽지방의 갯수 반환", description = "")
+    @SwaggerApiError(
+        ErrorStatus._MEMBER_NOT_FOUND
+    )
+    public ResponseEntity<ApiResponse<CountChatRoomsWithNewChatDTO>> getCountChatRoomsWithNewChat(
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+            chatRoomQueryService.countChatRoomsWithNewChat(memberDetails.member())));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
@@ -42,9 +42,9 @@ public class ChatRoomConverter {
             .build();
     }
 
-    public static CountChatRoomsWithNewChatDTO toCountChatRoomsWithNewChatDTO(Integer hasNewChatCount) {
+    public static CountChatRoomsWithNewChatDTO toCountChatRoomsWithNewChatDTO(Integer chatRoomsWithNewChatCount) {
         return CountChatRoomsWithNewChatDTO.builder()
-            .hasNewChatCount(hasNewChatCount)
+            .chatRoomsWithNewChatCount(chatRoomsWithNewChatCount)
             .build();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.chatroom.converter;
 
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomSimpleDTO;
+import com.cozymate.cozymate_server.domain.chatroom.dto.response.CountChatRoomsWithNewChatDTO;
 import com.cozymate.cozymate_server.domain.chatroom.dto.response.ChatRoomIdResponseDTO;
 import com.cozymate.cozymate_server.domain.chatroom.dto.response.ChatRoomDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.member.Member;
@@ -17,13 +18,14 @@ public class ChatRoomConverter {
     }
 
     public static ChatRoomDetailResponseDTO toChatRoomDetailResponseDTO(String nickname, String content,
-        Long chatRoomId, Integer persona, Long memberId) {
+        Long chatRoomId, Integer persona, Long memberId, boolean hasNewChat) {
         return ChatRoomDetailResponseDTO.builder()
             .nickname(nickname)
             .lastContent(content)
             .chatRoomId(chatRoomId)
             .persona(persona)
             .memberId(memberId)
+            .hasNewChat(hasNewChat)
             .build();
     }
 
@@ -37,6 +39,12 @@ public class ChatRoomConverter {
         return ChatRoomSimpleDTO.builder()
             .chatRoom(chatRoom)
             .recipient(recipient)
+            .build();
+    }
+
+    public static CountChatRoomsWithNewChatDTO toCountChatRoomsWithNewChatDTO(Integer hasNewChatCount) {
+        return CountChatRoomsWithNewChatDTO.builder()
+            .hasNewChatCount(hasNewChatCount)
             .build();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/response/ChatRoomDetailResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/response/ChatRoomDetailResponseDTO.java
@@ -8,7 +8,8 @@ public record ChatRoomDetailResponseDTO(
     String nickname,
     String lastContent,
     Long chatRoomId,
-    Long memberId
+    Long memberId,
+    boolean hasNewChat
 ) {
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/response/CountChatRoomsWithNewChatDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/response/CountChatRoomsWithNewChatDTO.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record CountChatRoomsWithNewChatDTO(
-    Integer hasNewChatCount
+    Integer chatRoomsWithNewChatCount
 ) {
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/response/CountChatRoomsWithNewChatDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/dto/response/CountChatRoomsWithNewChatDTO.java
@@ -1,0 +1,10 @@
+package com.cozymate.cozymate_server.domain.chatroom.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CountChatRoomsWithNewChatDTO(
+    Integer hasNewChatCount
+) {
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
@@ -57,28 +57,37 @@ public class ChatRoomCommandService {
         LocalDateTime memberALastDeleteAt = chatRoom.getMemberALastDeleteAt();
         LocalDateTime memberBLastDeleteAt = chatRoom.getMemberBLastDeleteAt();
 
-        if (Objects.nonNull(memberALastDeleteAt) && Objects.nonNull(memberBLastDeleteAt)
-            && canHardDelete(chatRoom, memberALastDeleteAt, memberBLastDeleteAt)) {
+        // 멤버 둘다 해당 방을 나간 적이 있는 경우
+        if (canHardDeleteWhenBothLeft(memberALastDeleteAt, memberBLastDeleteAt, chatRoom)) {
             hardDeleteChatRoom(chatRoom);
             return;
         }
 
-        if (Objects.nonNull(memberALastDeleteAt) && Objects.isNull(memberBLastDeleteAt)
-            && Objects.isNull(chatRoom.getMemberB())) {
-
-            if (canHardDeleteWithNullMember(chatRoom, memberALastDeleteAt)) {
-                hardDeleteChatRoom(chatRoom);
-                return;
-            }
+        // A는 해당 방을 나간적이 있고, B는 나간적은 없지만 null(탈퇴)인 경우
+        if (canHardDeleteWhenOneLeftAndOtherIsNull(memberALastDeleteAt, memberBLastDeleteAt,
+            chatRoom.getMemberB(), chatRoom)) {
+            hardDeleteChatRoom(chatRoom);
+            return;
         }
 
-        if (Objects.nonNull(memberBLastDeleteAt) && Objects.isNull(memberALastDeleteAt)
-            && Objects.isNull(chatRoom.getMemberA())) {
-
-            if (canHardDeleteWithNullMember(chatRoom, memberBLastDeleteAt)) {
-                hardDeleteChatRoom(chatRoom);
-            }
+        // B는 해당 방을 나간적이 있고, A는 나간적이 없지만 (null)탈퇴인 경우
+        if (canHardDeleteWhenOneLeftAndOtherIsNull(memberBLastDeleteAt, memberALastDeleteAt,
+            chatRoom.getMemberA(), chatRoom)) {
+            hardDeleteChatRoom(chatRoom);
         }
+    }
+
+    private boolean canHardDeleteWhenBothLeft(LocalDateTime memberALastDeleteAt,
+        LocalDateTime memberBLastDeleteAt, ChatRoom chatRoom) {
+        return Objects.nonNull(memberALastDeleteAt) && Objects.nonNull(memberBLastDeleteAt)
+            && canHardDelete(chatRoom, memberALastDeleteAt, memberBLastDeleteAt);
+    }
+
+    private boolean canHardDeleteWhenOneLeftAndOtherIsNull(LocalDateTime nonNullMemberLastDeleteAt,
+        LocalDateTime nullMemberLastDeleteAt, Member nullMember, ChatRoom chatRoom) {
+        return Objects.nonNull(nonNullMemberLastDeleteAt) && Objects.isNull(nullMemberLastDeleteAt)
+            && Objects.isNull(nullMember)
+            && canHardDeleteWithNullMember(chatRoom, nonNullMemberLastDeleteAt);
     }
 
     private boolean canHardDelete(ChatRoom chatRoom, LocalDateTime memberALastDeleteAt,

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
@@ -9,6 +9,7 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,9 +43,10 @@ public class ChatRoomCommandService {
     }
 
     private void softDeleteChatRoom(ChatRoom chatRoom, Long myId) {
-        if (chatRoom.getMemberA().getId().equals(myId)) {
+        if (Objects.nonNull(chatRoom.getMemberA()) && chatRoom.getMemberA().getId().equals(myId)) {
             chatRoom.updateMemberALastDeleteAt();
-        } else if (chatRoom.getMemberB().getId().equals(myId)) {
+        } else if (Objects.nonNull(chatRoom.getMemberB()) && chatRoom.getMemberB().getId()
+            .equals(myId)) {
             chatRoom.updateMemberBLastDeleteAt();
         } else {
             throw new GeneralException(ErrorStatus._CHATROOM_FORBIDDEN);
@@ -55,9 +57,27 @@ public class ChatRoomCommandService {
         LocalDateTime memberALastDeleteAt = chatRoom.getMemberALastDeleteAt();
         LocalDateTime memberBLastDeleteAt = chatRoom.getMemberBLastDeleteAt();
 
-        if (memberALastDeleteAt != null && memberBLastDeleteAt != null && canHardDelete(chatRoom,
-            memberALastDeleteAt, memberBLastDeleteAt)) {
+        if (Objects.nonNull(memberALastDeleteAt) && Objects.nonNull(memberBLastDeleteAt)
+            && canHardDelete(chatRoom, memberALastDeleteAt, memberBLastDeleteAt)) {
             hardDeleteChatRoom(chatRoom);
+            return;
+        }
+
+        if (Objects.nonNull(memberALastDeleteAt) && Objects.isNull(memberBLastDeleteAt)
+            && Objects.isNull(chatRoom.getMemberB())) {
+
+            if (canHardDeleteWithNullMember(chatRoom, memberALastDeleteAt)) {
+                hardDeleteChatRoom(chatRoom);
+                return;
+            }
+        }
+
+        if (Objects.nonNull(memberBLastDeleteAt) && Objects.isNull(memberALastDeleteAt)
+            && Objects.isNull(chatRoom.getMemberA())) {
+
+            if (canHardDeleteWithNullMember(chatRoom, memberBLastDeleteAt)) {
+                hardDeleteChatRoom(chatRoom);
+            }
         }
     }
 
@@ -66,6 +86,13 @@ public class ChatRoomCommandService {
         return chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)
             .map(chat -> chat.getCreatedAt().isBefore(memberALastDeleteAt) && chat.getCreatedAt()
                 .isBefore(memberBLastDeleteAt))
+            .orElse(true);
+    }
+
+    private boolean canHardDeleteWithNullMember(ChatRoom chatRoom,
+        LocalDateTime lastDeleteAt) {
+        return chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)
+            .map(chat -> chat.getCreatedAt().isBefore(lastDeleteAt))
             .orElse(true);
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryService.java
@@ -5,16 +5,19 @@ import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomSimpleDTO;
 import com.cozymate.cozymate_server.domain.chatroom.dto.response.ChatRoomDetailResponseDTO;
+import com.cozymate.cozymate_server.domain.chatroom.dto.response.CountChatRoomsWithNewChatDTO;
 import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
 import com.cozymate.cozymate_server.domain.chatroom.converter.ChatRoomConverter;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
-import com.cozymate.cozymate_server.domain.memberblock.util.MemberBlockUtil;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +33,9 @@ public class ChatRoomQueryService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
     private final MemberRepository memberRepository;
-    private final MemberBlockUtil memberBlockUtil;
+
+    private static final Integer NO_NEW_CHAT_ROOMS = 0;
+    private static final String UNKNOWN_SENDER_NICKNAME = "(알수없음)";
 
     public List<ChatRoomDetailResponseDTO> getChatRoomList(Member member) {
         List<ChatRoom> findChatRoomList = chatRoomRepository.findAllByMember(member);
@@ -39,26 +44,85 @@ public class ChatRoomQueryService {
             return new ArrayList<>();
         }
 
+        Map<ChatRoom, Chat> chatRoomLastChatMap = new HashMap<>();
+
         List<ChatRoom> chatRoomList = findChatRoomList.stream()
             .filter(chatRoom -> {
                 Chat chat = getLatestChatByChatRoom(chatRoom);
+                chatRoomLastChatMap.put(chatRoom, chat);
                 if (chat == null) {
                     return false;
                 }
                 LocalDateTime lastDeleteAt = getLastDeleteAtByMember(chatRoom, member);
                 return lastDeleteAt == null || chat.getCreatedAt().isAfter(lastDeleteAt);
             })
-            .toList();
+            .sorted((chatRoomA, chatRoomB) -> {
+                Chat chatA = chatRoomLastChatMap.get(chatRoomA);
+                Chat chatB = chatRoomLastChatMap.get(chatRoomB);
 
-        List<ChatRoomDetailResponseDTO> chatRoomDetailResponseDTOList = chatRoomList.stream()
-            .map(chatRoom -> {
-                Chat chat = getLatestChatByChatRoom(chatRoom);
-                return toChatRoomDetailResponseDTO(chatRoom, member, chat);
+                return chatB.getCreatedAt().compareTo(chatA.getCreatedAt());
             })
             .toList();
 
-        return memberBlockUtil.filterBlockedMember(chatRoomDetailResponseDTOList, member,
-            ChatRoomDetailResponseDTO::memberId);
+        return chatRoomList.stream()
+            .map(chatRoom -> {
+                Chat chat = chatRoomLastChatMap.get(chatRoom);
+                // 한명이라도 null(탈퇴)인 쪽지방은 새로운 쪽지 유무 확인 x, 전부 false 처리
+                if (Objects.isNull(chatRoom.getMemberA()) ||
+                    Objects.isNull(chatRoom.getMemberB())) {
+                    return toChatRoomDetailResponseDTO(chatRoom, member, chat, false);
+                }
+
+                Member recipient = chatRoom.getMemberA().getId().equals(member.getId()) ?
+                    chatRoom.getMemberB() : chatRoom.getMemberA();
+
+                LocalDateTime lastSeenAt = chatRoom.getMemberA().getId().equals(member.getId()) ?
+                    chatRoom.getMemberALastSeenAt() : chatRoom.getMemberBLastSeenAt();
+
+                boolean hasNewChat = existNewChat(recipient, chatRoom, lastSeenAt);
+
+                return toChatRoomDetailResponseDTO(chatRoom, member, chat, hasNewChat);
+            })
+            .toList();
+    }
+
+    public CountChatRoomsWithNewChatDTO countChatRoomsWithNewChat(Member member) {
+        List<ChatRoom> findChatRoomList = chatRoomRepository.findAllByMember(member);
+
+        if (findChatRoomList.isEmpty()) {
+            return ChatRoomConverter.toCountChatRoomsWithNewChatDTO(NO_NEW_CHAT_ROOMS);
+        }
+
+        List<ChatRoom> chatRoomList = findChatRoomList.stream()
+            .filter(chatRoom -> {
+                Chat chat = getLatestChatByChatRoom(chatRoom);
+
+                if (chat == null) {
+                    return false;
+                }
+
+                LocalDateTime lastDeleteAt = getLastDeleteAtByMember(chatRoom, member);
+                return lastDeleteAt == null || chat.getCreatedAt().isAfter(lastDeleteAt);
+            }).toList();
+
+        long newChatRoomCount = chatRoomList.stream()
+            .filter(chatRoom -> {
+                // 탈퇴 사용자가 있는 경우, 새로운 쪽지가 없음 처리
+                if (Objects.isNull(chatRoom.getMemberA()) ||
+                    Objects.isNull(chatRoom.getMemberB())) {
+                    return false;
+                }
+
+                Member recipient = chatRoom.getMemberA().getId().equals(member.getId()) ?
+                    chatRoom.getMemberB() : chatRoom.getMemberA();
+
+                LocalDateTime lastSeenAt = chatRoom.getMemberA().getId().equals(member.getId()) ?
+                    chatRoom.getMemberALastSeenAt() : chatRoom.getMemberBLastSeenAt();
+
+                return existNewChat(recipient, chatRoom, lastSeenAt);
+            }).count();
+
+        return ChatRoomConverter.toCountChatRoomsWithNewChatDTO((int) newChatRoomCount);
     }
 
     public ChatRoomSimpleDTO getChatRoom(Member member, Long recipientId) {
@@ -79,12 +143,35 @@ public class ChatRoomQueryService {
     }
 
     private LocalDateTime getLastDeleteAtByMember(ChatRoom chatRoom, Member member) {
+        // memberA가 null이면 memberB가 로그인 사용자임이 보장됌
+        if (Objects.isNull(chatRoom.getMemberA())) {
+            return chatRoom.getMemberBLastDeleteAt();
+        }
+
+        // memberB가 null이면 memberA가 로그인 사용자임이 보장됌
+        if (Objects.isNull(chatRoom.getMemberB())) {
+            return chatRoom.getMemberALastDeleteAt();
+        }
+
+        // 둘다 null이 아니면(탈퇴자가 없으면) 기존 로직 수행
         return chatRoom.getMemberA().getNickname().equals(member.getNickname()) ?
             chatRoom.getMemberALastDeleteAt() : chatRoom.getMemberBLastDeleteAt();
     }
 
+    private boolean existNewChat(Member recipient, ChatRoom chatRoom, LocalDateTime lastSeenAt) {
+        return chatRepository.existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+            recipient, chatRoom, lastSeenAt);
+    }
+
     private ChatRoomDetailResponseDTO toChatRoomDetailResponseDTO(ChatRoom chatRoom, Member member,
-        Chat chat) {
+        Chat chat, boolean hasNewChat) {
+
+        // 상대가 탈퇴한 경우
+        if (Objects.isNull(chatRoom.getMemberA()) || Objects.isNull(chatRoom.getMemberB())) {
+            return ChatRoomConverter.toChatRoomDetailResponseDTO(UNKNOWN_SENDER_NICKNAME, chat.getContent(),
+                chatRoom.getId(), null, null, false);
+        }
+
         return ChatRoomConverter.toChatRoomDetailResponseDTO(
             member.getNickname().equals(chatRoom.getMemberA().getNickname()) ?
                 chatRoom.getMemberB().getNickname() : chatRoom.getMemberA().getNickname(),
@@ -93,7 +180,8 @@ public class ChatRoomQueryService {
             member.getNickname().equals(chatRoom.getMemberA().getNickname()) ?
                 chatRoom.getMemberB().getPersona() : chatRoom.getMemberA().getPersona(),
             member.getNickname().equals(chatRoom.getMemberA().getNickname()) ?
-                chatRoom.getMemberB().getId() : chatRoom.getMemberA().getId()
+                chatRoom.getMemberB().getId() : chatRoom.getMemberA().getId(),
+            hasNewChat
         );
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryService.java
@@ -105,7 +105,7 @@ public class ChatRoomQueryService {
                 return lastDeleteAt == null || chat.getCreatedAt().isAfter(lastDeleteAt);
             }).toList();
 
-        long newChatRoomCount = chatRoomList.stream()
+        long chatRoomsWithNewChatCount = chatRoomList.stream()
             .filter(chatRoom -> {
                 // 탈퇴 사용자가 있는 경우, 새로운 쪽지가 없음 처리
                 if (Objects.isNull(chatRoom.getMemberA()) ||
@@ -122,7 +122,7 @@ public class ChatRoomQueryService {
                 return existNewChat(recipient, chatRoom, lastSeenAt);
             }).count();
 
-        return ChatRoomConverter.toCountChatRoomsWithNewChatDTO((int) newChatRoomCount);
+        return ChatRoomConverter.toCountChatRoomsWithNewChatDTO((int) chatRoomsWithNewChatCount);
     }
 
     public ChatRoomSimpleDTO getChatRoom(Member member, Long recipientId) {


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

- 쪽지방 목록 정렬
- 새로운 쪽지 유무 반환 추가
- 새로운 쪽지가 온 쪽지방 갯수 조회 API
- 회원탈퇴 쪽지 null 처리

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

마지막 쪽지방 읽은 시간 기준 이후에 쪽지가 온 경우 true를 반환
<img width="401" alt="image" src="https://github.com/user-attachments/assets/1ced83c3-e110-45a6-8198-6d05277d2154">

새 쪽지가 눈꽃에서만 왔기 때문에 새로운 쪽지방 갯수 조회 = 1
<img width="356" alt="image" src="https://github.com/user-attachments/assets/e8e4b824-c1a5-4159-8ee7-be143b74cc7e">

포비 계정으로 베로에게 쪽지 하나를 보낸 경우 - true반환, 최근 쪽지가 오고 간 순서대로 정렬됌
<img width="360" alt="image" src="https://github.com/user-attachments/assets/269e5cf9-608a-497f-bea3-960992f68beb">

새로운 쪽지방 갯수 조회 = 2
<img width="349" alt="image" src="https://github.com/user-attachments/assets/7d3d8f20-ffc1-4518-9a7d-2bc419909c33">

쪽지방 목록 조회 시 탈퇴한 멤버 (알수없음)으로 처리 
<img width="365" alt="image" src="https://github.com/user-attachments/assets/fe9e7a79-c981-4e08-99d8-1f139683aec9">

탈퇴한 멤버와의 쪽지 상세 조회
<img width="371" alt="image" src="https://github.com/user-attachments/assets/ebfe6568-879c-493d-96ba-6adc79066be3">



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

null 처리 최대한 한다고 했는데 오류 생기면 수정할게요

아직 쪽지방 삭제는 null 처리하고 테스트를 못해봤어요