### PR TITLE
[COZY-340] feat: 투두에 룸 로그 활성화 및 기타 리팩터링

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/dto/FcmPushTargetDto.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/dto/FcmPushTargetDto.java
@@ -109,8 +109,8 @@ public class FcmPushTargetDto {
 
     /**
      * 특정 사용자의 행위를 본인을 제외한 다른 사용자들에게 알림을 전송하는 경우 사용
-     * me.getNickname()님이 오늘 해야 할 일을 전부 완료했어요!
-     * 매치되는 NotificationType -> 현재 해당 dto와 매칭되는 NotificationType은 없습니다
+     * me.getNickname()님이 오늘 해야 할 일을 전부 완료했어요! -> 사용중
+     * 매치되는 NotificationType : COMPLETE_ALL_TODAY_TODO
      */
     @Getter
     public static class GroupWithOutMeTargetDto {

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -97,4 +97,6 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     List<Mate> findAllByMemberId(Long memberId);
 
     void deleteAllByMemberId(Long memberId);
+
+    List<Mate> findAllByIdIn(List<Long> mateIds);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/RoomLog.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/RoomLog.java
@@ -33,4 +33,6 @@ public class RoomLog extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Todo todo;
+
+    private Long mateId;
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/converter/RoomLogConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/converter/RoomLogConverter.java
@@ -1,5 +1,6 @@
 package com.cozymate.cozymate_server.domain.roomlog.converter;
 
+import com.cozymate.cozymate_server.domain.mate.Mate;
 import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.domain.roomlog.RoomLog;
 import com.cozymate.cozymate_server.domain.roomlog.dto.RoomLogResponseDto.RoomLogDetailResponseDto;
@@ -7,11 +8,12 @@ import com.cozymate.cozymate_server.domain.todo.Todo;
 
 public class RoomLogConverter {
 
-    public static RoomLog toEntity(String content, Room room, Todo todo) {
+    public static RoomLog toEntity(String content, Room room, Todo todo, Mate mate) {
         return RoomLog.builder()
             .content(content)
             .room(room)
             .todo(todo)
+            .mateId(mate.getId())
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
@@ -14,7 +14,7 @@ public interface RoomLogRepository extends JpaRepository<RoomLog, Long> {
 
     Slice<RoomLog> findAllByRoomIdOrderByCreatedAtDesc(Long roomId, Pageable pageable);
 
-    Optional<RoomLog> findByTodoId(Long todoId);
+    Optional<RoomLog> findByTodoIdAndMateId(Long todoId, Long mateId);
 
     void deleteByRoomId(Long roomId);
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogCommandService.java
@@ -1,6 +1,7 @@
 package com.cozymate.cozymate_server.domain.roomlog.service;
 
 import com.cozymate.cozymate_server.domain.mate.Mate;
+import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
 import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.domain.roomlog.RoomLog;
 import com.cozymate.cozymate_server.domain.roomlog.converter.RoomLogConverter;
@@ -9,9 +10,11 @@ import com.cozymate.cozymate_server.domain.todo.Todo;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,8 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class RoomLogCommandService {
 
-    private final RoomLogRepository roomLogRepository;
-
+    // 방이 생성되었을 때 메시지
+    public static final String DEFAULT_CREATION_MESSAGE = "의 역사적인 하루가 시작됐어요!";
+    public static final String DEFAULT_REMINDING_ROLE_MESSAGE = "까먹은 거 같아요 ㅠㅠ";
+    public static final String DEFAULT_CHOICE_COZY_MATE_MESSAGE = "의 Best, Worst 코지메이트를 선정해주세요!";
     // 투두 완료했을 때 메시지
     private static final String DEFAULT_FINAL_MESSAGE = "완료했어요!";
     private static final List<String> FINISH_MESSAGE_LIST = Arrays.asList(
@@ -30,65 +35,72 @@ public class RoomLogCommandService {
         "완료했어요! 얼른 칭찬해주세요!",
         "완료하여, 최고의 cozy mate가 되었어요!"
     );
-
-    // 방이 생성되었을 때 메시지
-    public static final String DEFAULT_CREATION_MESSAGE = "의 역사적인 하루가 시작됐어요!";
-
-    public static final String DEFAULT_REMINDING_ROLE_MESSAGE = "까먹은 거 같아요 ㅠㅠ";
-
-    public static final String DEFAULT_CHOICE_COZY_MATE_MESSAGE = "의 Best, Worst 코지메이트를 선정해주세요!";
+    private final RoomLogRepository roomLogRepository;
+    private final MateRepository mateRepository;
 
     // TODO: 수정해야함
-//    // 투두 추가되었을 때
-//    public void addRoomLogFromTodo(Todo todo) {
-//        Optional<RoomLog> existingLog = roomLogRepository.findByTodoId(todo.getId());
-//        // False일 때 기존 로그 삭제, True일 때 새로운 로그 생성
-//        if (Boolean.FALSE.equals(todo.isCompleted()) && existingLog.isPresent()) {
-//            roomLogRepository.delete(existingLog.get());
-//        }
-//        if (Boolean.TRUE.equals(todo.isCompleted()) && existingLog.isEmpty()) {
-//            String who = "{" + todo.getMate().getMember().getNickname() + "}님이 ";
-//            String what = "[" + todo.getContent() + "]을/를 ";
-//            String finish = DEFAULT_FINAL_MESSAGE;
-//
-//            if (Objects.nonNull(todo.getRole())) {
-//                finish = FINISH_MESSAGE_LIST.get(
-//                    ThreadLocalRandom.current().nextInt(FINISH_MESSAGE_LIST.size()));
-//
-//            }
-//
-//            String content = who + what + finish;
-//            roomLogRepository.save(RoomLogConverter.toEntity(content, todo.getRoom(), todo));
-//        }
-//
-//    }
+    // 투두 완료버튼 눌렀을 때
+    public void addRoomLogFromTodo(Mate mate, Todo todo) {
+        String who = "{" + mate.getMember().getNickname() + "}님이 ";
+        String what = "[" + todo.getContent() + "]을/를 ";
+        String finish = DEFAULT_FINAL_MESSAGE;
+
+        if (Objects.nonNull(todo.getRole())) {
+            finish = FINISH_MESSAGE_LIST.get(
+                ThreadLocalRandom.current().nextInt(FINISH_MESSAGE_LIST.size()));
+
+        }
+
+        String content = who + what + finish;
+        roomLogRepository.save(RoomLogConverter.toEntity(content, todo.getRoom(), todo, mate));
+    }
+
+    public void deleteRoomLogFromTodo(Mate mate, Todo todo) {
+        Optional<RoomLog> existingLog = roomLogRepository.findByTodoIdAndMateId(todo.getId(),
+            mate.getId());
+        existingLog.ifPresent(roomLogRepository::delete);
+    }
 
     // 방 생성이 완료되었을 때 실행
     public void addRoomLogCreationRoom(Room room) {
         String content = "{" + room.getName() + "}" + DEFAULT_CREATION_MESSAGE;
-        roomLogRepository.save(RoomLogConverter.toEntity(content, room, null));
+        roomLogRepository.save(RoomLogConverter.toEntity(content, room, null, null));
     }
 
-    // 역할을 특정 시간에 수행하지 않았을 때 룸 로그 추가
-    public void addRoomLogRemindingRole(Todo todo) {
-        String who = "{" + todo.getMate().getMember().getNickname() + "}님이 ";
-        String what = "[" + todo.getContent() + "]을/를 " + DEFAULT_REMINDING_ROLE_MESSAGE;
-        String content = who + what;
-        roomLogRepository.save(RoomLogConverter.toEntity(content, todo.getRoom(), null));
+    /**
+     * 각 메이트들에게 역할 알림 로그 추가
+     *
+     * @param mateTodoMap 메이트별 할당된 투두 리스트
+     */
+    public void addRoomLogRemindingRole(Map<Long, List<Todo>> mateTodoMap) {
+        Map<Long, Mate> mateIdMap = mateRepository.findAllByIdIn(
+                mateTodoMap.keySet().stream().toList())
+            .stream().collect(Collectors.toMap(Mate::getId, mate -> mate));
+
+        mateTodoMap.forEach((mateId, todoList) -> {
+            Mate mate = mateIdMap.get(mateId);
+            todoList.forEach(todo -> {
+                String who = "{" + mate.getMember().getNickname() + "}님이 ";
+                String what = "[" + todo.getContent() + "]을/를 " + DEFAULT_REMINDING_ROLE_MESSAGE;
+                String content = who + what;
+                roomLogRepository.save(
+                    RoomLogConverter.toEntity(content, todo.getRoom(), null, mate));
+            });
+        });
     }
 
     // 이달의 베스트 코지메이트, 워스크 코지메이트 선정 알림 로그 추가
     public void addRoomLogChoiceCozyMate(Room room, String month) {
         // [해당 월]의 Best, Worst 코지메이트를 선정해주세요!
         String content = month + DEFAULT_CHOICE_COZY_MATE_MESSAGE;
-        roomLogRepository.save(RoomLogConverter.toEntity(content, room, null));
+        roomLogRepository.save(RoomLogConverter.toEntity(content, room, null, null));
     }
 
     public void addRoomLogBirthday(Mate mate, LocalDate today) {
         // ”0월 0일은 [닉네임]님의 생일이에요! 모두 축하해주세요!”
         String content = today.getMonthValue() + "월 " + today.getDayOfMonth() + "일은 "
             + mate.getMember().getNickname() + "님의 생일이에요! 모두 축하해주세요!";
-        roomLogRepository.save(RoomLogConverter.toEntity(content, mate.getRoom(), null));
+        roomLogRepository.save(RoomLogConverter.toEntity(content, mate.getRoom(), null, mate));
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/Todo.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/Todo.java
@@ -115,6 +115,10 @@ public class Todo extends BaseTimeEntity {
                 != 0;
     }
 
+    public boolean isAssigneeIn(Long assigneeId) {
+        return this.assignedMateIdList.contains(assigneeId);
+    }
+
     // TodoType 변경
     public void updateTodoType(TodoType todoType) {
         this.todoType = todoType;

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/Todo.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/Todo.java
@@ -16,6 +16,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -60,11 +61,13 @@ public class Todo extends BaseTimeEntity {
     @Column(length = 20)
     private TodoType todoType;
 
+    // 투두 업데이트
     public void updateContent(String content, LocalDate timePoint) {
         this.content = content;
         this.timePoint = timePoint;
     }
 
+    // 할당자 여러명 추가
     public void addAssignees(List<Long> assigneeIds) {
         for (Long assigneeId : assigneeIds) {
             addAssignee(assigneeId);
@@ -77,20 +80,24 @@ public class Todo extends BaseTimeEntity {
         this.completeBitmask &= ~(1 << (this.assignedMateIdList.size() - 1));
     }
 
+    // Todo를 Complete로 변경
     public void markTodoComplete(Long assigneeId) {
         this.completeBitmask |= (1 << findAssigneeIndex(this.assignedMateIdList, assigneeId));
     }
 
+    // Todo를 Incomplete로 변경
     public void unmarkTodoComplete(Long assigneeId) {
         this.completeBitmask &= ~(1 << findAssigneeIndex(this.assignedMateIdList, assigneeId));
     }
 
+    // 할당자 여러명 삭제
     public void removeAssignees(List<Long> assigneeIds) {
         for (Long assigneeId : assigneeIds) {
             removeAssignee(assigneeId);
         }
     }
 
+    // 할당자 삭제
     public void removeAssignee(Long assigneeId) {
         int index = this.assignedMateIdList.indexOf(assigneeId);
         if (index != -1) { // 해당 할당자가 있는지 확인
@@ -101,17 +108,30 @@ public class Todo extends BaseTimeEntity {
         }
     }
 
-
+    // 해당 Asstignee가 Todo를 완료했는지 확인
     public boolean isAssigneeCompleted(Long assigneeId) {
         return
             (this.completeBitmask & (1 << findAssigneeIndex(this.assignedMateIdList, assigneeId)))
                 != 0;
     }
 
+    // TodoType 변경
     public void updateTodoType(TodoType todoType) {
         this.todoType = todoType;
     }
 
+    // 완료하지 않은 할당자 ID 리스트 반환
+    public List<Long> getIncompleteAssigneeIdList() {
+        List<Long> incompleteAssigneeIdList = new ArrayList<>();
+        for (int i = 0; i < this.assignedMateIdList.size(); i++) {
+            if ((this.completeBitmask & (1 << i)) == 0) {
+                incompleteAssigneeIdList.add(this.assignedMateIdList.get(i));
+            }
+        }
+        return incompleteAssigneeIdList;
+    }
+
+    // 할당자가 모두 같은 방에 있는지 확인
     private int findAssigneeIndex(List<Long> assigneeIdList, Long assigneeId) {
         return assigneeIdList.indexOf(assigneeId);
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/Todo.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/Todo.java
@@ -54,7 +54,7 @@ public class Todo extends BaseTimeEntity {
 
     private LocalDate timePoint;
 
-    // Bitmasking 방식으로 사용 예정
+    // Bitmasking 방식으로 사용자별 완료 여부를 저장
     private Integer completeBitmask;
 
     @Convert(converter = TodoTypeConverter.class)
@@ -115,6 +115,7 @@ public class Todo extends BaseTimeEntity {
                 != 0;
     }
 
+    // 해당 메이트가 할당자인지 확인
     public boolean isAssigneeIn(Long assigneeId) {
         return this.assignedMateIdList.contains(assigneeId);
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
@@ -19,16 +19,10 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     @Query("select t from Todo t join fetch t.mate m join fetch m.member where t.timePoint = :today")
     List<Todo> findByTimePoint(@Param("today") LocalDate today);
+    
+    List<Todo> findByTimePointAndRoleIsNotNull(LocalDate today);
 
-//    @Query("select t from Todo t join fetch t.mate m join fetch m.member where t.timePoint = :today and t.role is not null and t.completed is false")
-//    List<Todo> findByTimePointAndRoleIsNotNullCompletedFalse(@Param("today") LocalDate today);
-
-    List<Todo>findByTimePointAndRoleIsNotNull(LocalDate today);
-
-//    boolean existsByMateAndTimePointAndCompletedFalse(Mate mate, LocalDate timePoint);
-
-
-    List<Todo>findAllByMateId(Long mateId);
+    List<Todo> findAllByMateId(Long mateId);
 
     @Modifying
     @Query("UPDATE Todo t SET t.mate = null WHERE t.mate = :mate")

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
@@ -3,6 +3,9 @@ package com.cozymate.cozymate_server.domain.todo.service;
 import com.cozymate.cozymate_server.domain.mate.Mate;
 import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
 import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.roomlog.RoomLog;
+import com.cozymate.cozymate_server.domain.roomlog.repository.RoomLogRepository;
+import com.cozymate.cozymate_server.domain.roomlog.service.RoomLogCommandService;
 import com.cozymate.cozymate_server.domain.todo.Todo;
 import com.cozymate.cozymate_server.domain.todo.converter.TodoConverter;
 import com.cozymate.cozymate_server.domain.todo.dto.request.CreateTodoRequestDTO;
@@ -29,7 +32,7 @@ public class TodoCommandService {
 
     private final MateRepository mateRepository;
     private final TodoRepository todoRepository;
-    //    private final RoomLogCommandService roomLogCommandService;
+    private final RoomLogCommandService roomLogCommandService;
     private final ApplicationEventPublisher eventPublisher;
 
 
@@ -86,6 +89,7 @@ public class TodoCommandService {
 
         if (completed) { // 완료 상태로 바꾸는 경우
             todo.markTodoComplete(mate.getId());
+            roomLogCommandService.addRoomLogFromTodo(mate, todo);
 //            //모든 투두가 완료되었을 때 알림을 보냄
 //            // TODO: 바뀐 기획에 따라 로직 변경이 필요함, 추후 수정 예정
 //            allTodoCompleteNotification(todo, member);
@@ -93,6 +97,7 @@ public class TodoCommandService {
         }
         // 미완료 상태로 바꾸는 경우
         todo.unmarkTodoComplete(mate.getId());
+        roomLogCommandService.deleteRoomLogFromTodo(mate, todo);
     }
 
     /**

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
@@ -95,6 +95,7 @@ public class TodoCommandService {
             allTodoCompleteNotification(mate);
             return;
         }
+
         // 미완료 상태로 바꾸는 경우
         todo.unmarkTodoComplete(mate.getId());
         roomLogCommandService.deleteRoomLogFromTodo(mate, todo);
@@ -232,6 +233,11 @@ public class TodoCommandService {
         }
     }
 
+    /**
+     * 투두 타입 분류, GROUP, SINGLE을 분류함
+     * @param todoIdList 투두 ID 리스트
+     * @return TodoType
+     */
     private TodoType classifyTodoType(List<Long> todoIdList) {
         // size가 1보다 크면 그룹투두
         if (todoIdList.size() > SINGLE_NUM) {
@@ -241,6 +247,11 @@ public class TodoCommandService {
         return TodoType.SINGLE_TODO;
     }
 
+    /**
+     * 할당자 리스트가 모두 호출한 사람과 같은 방에 있는지 확인
+     * @param mate 호출한 사람
+     * @param mateIdList 할당자 리스트
+     */
     private void checkMateIdListIsSameRoomWithMate(Mate mate, List<Long> mateIdList) {
         List<Mate> mateList = mateRepository.findByRoomId(mate.getRoom().getId());
         if (mateIdList.stream().anyMatch(
@@ -249,6 +260,10 @@ public class TodoCommandService {
         }
     }
 
+    /**
+     * 최대 할당자 수 체크
+     * @param mateIdList 할당자 리스트
+     */
     private void checkMaxAssignee(List<Long> mateIdList) {
         if (mateIdList.size() > MAX_ASSIGNEE) {
             throw new GeneralException(ErrorStatus._TODO_OVER_MAX);

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
@@ -1,6 +1,6 @@
 package com.cozymate.cozymate_server.domain.todo.service;
 
-import com.cozymate.cozymate_server.domain.fcm.dto.FcmPushTargetDto.OneTargetDto;
+import com.cozymate.cozymate_server.domain.fcm.dto.FcmPushTargetDto.GroupWithOutMeTargetDto;
 import com.cozymate.cozymate_server.domain.fcm.service.FcmPushService;
 import com.cozymate.cozymate_server.domain.mate.Mate;
 import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
@@ -215,13 +215,16 @@ public class TodoCommandService {
         List<Todo> todoList = todoRepository.findAllByRoomIdAndTimePoint(mate.getRoom().getId(),
             now);
 
+        List<Mate> mateList = mateRepository.findByRoomId(mate.getRoom().getId());
+
         // 모든 투두중 내가 할당되었는데, 완료되지 않은 투두가 있는지 확인
         if (todoList.stream().filter(
                 todo -> todo.isAssigneeIn(mate.getId()) && !todo.isAssigneeCompleted(mate.getId()))
             .findFirst().isEmpty()) {
 
             // 없으면 FCM 발행 (모든 투두를 완료했음)
-            fcmPushService.sendNotification(OneTargetDto.create(mate.getMember(),
+            fcmPushService.sendNotification(GroupWithOutMeTargetDto.create(mate.getMember(),
+                mateList.stream().map(Mate::getMember).toList(),
                 NotificationType.COMPLETE_ALL_TODAY_TODO));
         }
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoQueryService.java
@@ -19,6 +19,7 @@ import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +62,10 @@ public class TodoQueryService {
                     mateTodoList.get(mateId).add(todoDto);
                 });
         });
+
+        // todoType를 self, other, group, role 순으로 정렬
+        mateTodoList.forEach((mateId, todoListDto) ->
+            mateTodoList.put(mateId, sortTodoDetailResponseDTOByTodoType(todoListDto)));
 
         TodoMateListResponseDTO myTodoListResponseDto = TodoConverter.toTodoMateListResponseDTO(
             currentMate.getMember(), mateTodoList.get(currentMate.getId()));
@@ -130,8 +135,8 @@ public class TodoQueryService {
     /**
      * 여러명이 할당 - 그룹 투두 / 생성자, 할당자가 동일 - 내 투두 / 생성자, 할당자가 다름 - 남 투두 / 롤 투두 - 롤 투두
      *
-     * @param todo
-     * @return
+     * @param todo 투두
+     * @return 투두 타입
      */
     private String getTodoType(Todo todo) {
         if (todo.getTodoType() != TodoType.SINGLE_TODO) {
@@ -141,6 +146,24 @@ public class TodoQueryService {
             return "self";
         }
         return "other";
+    }
+
+    // todoType이 self, other, group, role 순으로 정렬
+    private List<TodoDetailResponseDTO> sortTodoDetailResponseDTOByTodoType(
+        List<TodoDetailResponseDTO> list) {
+        // Define the sorting priority for each todoType
+        Map<String, Integer> priorityMap = Map.of(
+            "self", 1,
+            "other", 2,
+            "group", 3,
+            "role", 4
+        );
+
+        // Sort based on the priority defined in the map
+        return list.stream()
+            .sorted(Comparator.comparingInt(
+                o -> priorityMap.getOrDefault(o.todoType(), Integer.MAX_VALUE)))
+            .toList();
     }
 
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoQueryService.java
@@ -111,6 +111,7 @@ public class TodoQueryService {
                 mateTodoMap.keySet().stream().toList())
             .stream().collect(Collectors.toMap(Mate::getId, Mate::getMember));
 
+        // TODO: remide할 size가 여러개면 ~~ 외 몇개로 수정
         mateTodoMap.forEach((mateId, todos) ->
             todos.forEach(todo ->
                 fcmPushService.sendNotification(

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoQueryService.java
@@ -127,10 +127,16 @@ public class TodoQueryService {
         );
     }
 
+    /**
+     * 두 mate가 다른지 확인
+     *
+     * @param mate1 메이트 1
+     * @param mate2 메이트 2
+     * @return 다르면 true
+     */
     private boolean isNotSameMate(Mate mate1, Mate mate2) {
         return !mate1.getId().equals(mate2.getId());
     }
-
 
     /**
      * 여러명이 할당 - 그룹 투두 / 생성자, 할당자가 동일 - 내 투두 / 생성자, 할당자가 다름 - 남 투두 / 롤 투두 - 롤 투두
@@ -148,7 +154,9 @@ public class TodoQueryService {
         return "other";
     }
 
-    // todoType이 self, other, group, role 순으로 정렬
+    /**
+     * todoType에 따라 self, other, group, role 순으로 정렬
+     */
     private List<TodoDetailResponseDTO> sortTodoDetailResponseDTOByTodoType(
         List<TodoDetailResponseDTO> list) {
         // Define the sorting priority for each todoType

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoQueryService.java
@@ -155,15 +155,15 @@ public class TodoQueryService {
     }
 
     /**
-     * todoType에 따라 self, other, group, role 순으로 정렬
+     * todoType에 따라 self, group, other, role 순으로 정렬
      */
     private List<TodoDetailResponseDTO> sortTodoDetailResponseDTOByTodoType(
         List<TodoDetailResponseDTO> list) {
         // Define the sorting priority for each todoType
         Map<String, Integer> priorityMap = Map.of(
             "self", 1,
-            "other", 2,
             "group", 3,
+            "other", 2,
             "role", 4
         );
 

--- a/src/main/java/com/cozymate/cozymate_server/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/scheduler/NotificationScheduler.java
@@ -7,17 +7,13 @@ import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
 import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
-import com.cozymate.cozymate_server.domain.role.Role;
-import com.cozymate.cozymate_server.domain.role.enums.DayListBitmask;
-import com.cozymate.cozymate_server.domain.role.repository.RoleRepository;
+import com.cozymate.cozymate_server.domain.role.service.RoleCommandService;
 import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
 import com.cozymate.cozymate_server.domain.roomlog.service.RoomLogCommandService;
 import com.cozymate.cozymate_server.domain.todo.Todo;
-import com.cozymate.cozymate_server.domain.todo.converter.TodoConverter;
-import com.cozymate.cozymate_server.domain.todo.enums.TodoType;
 import com.cozymate.cozymate_server.domain.todo.repository.TodoRepository;
-import java.time.DayOfWeek;
+import com.cozymate.cozymate_server.domain.todo.service.TodoQueryService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -42,7 +38,8 @@ public class NotificationScheduler {
 
     private final RoomLogCommandService roomLogCommandService;
     private final RoomRepository roomRepository;
-    private final RoleRepository roleRepository;
+    private final TodoQueryService todoQueryService;
+    private final RoleCommandService roleCommandService;
 
     // 매일 자정 반복 (해당하는 날 역할을 Todo에 추가) 작업 자정에 먼저하고 나서 시작하도록 30초로 설정
     @Scheduled(cron = "30 0 0 * * *")
@@ -63,55 +60,6 @@ public class NotificationScheduler {
             fcmPushService.sendNotification(
                 OneTargetDto.create(member, NotificationType.TODO_LIST, todoContents));
         });
-    }
-
-    /**
-     * Role 투두 잊지 않았는지 FCM 알림
-     */
-    @Scheduled(cron = "00 00 21 * * *")
-    public void sendReminderRoleNotification() {
-        LocalDate today = LocalDate.now();
-        List<Todo> todoList = todoRepository.findByTimePointAndRoleIsNotNull(today);
-
-        Map<Long, List<Todo>> mateTodoMap = todoList.stream()
-            .flatMap(todo -> todo.getIncompleteAssigneeIdList().stream()
-                .map(mateId -> Map.entry(mateId, todo)))
-            .collect(Collectors.groupingBy(
-                Map.Entry::getKey,
-                Collectors.mapping(Map.Entry::getValue, Collectors.toList())
-            ));
-
-        Map<Long, Member> mateIdMemberMap = mateRepository.findAllByIdIn(
-                mateTodoMap.keySet().stream().toList())
-            .stream().collect(Collectors.toMap(Mate::getId, Mate::getMember));
-
-        mateTodoMap.forEach((mateId, todos) ->
-            todos.forEach(todo ->
-                fcmPushService.sendNotification(
-                    OneTargetDto.create(mateIdMemberMap.get(mateId),
-                        NotificationType.REMINDER_ROLE,
-                        todo.getContent())
-                ))
-                );
-
-    }
-
-    /**
-     * 매일 자정에 완료하지 않은 RoomLog에 대해서 알림 추가
-     */
-    @Scheduled(cron = "0 0 0 * * *") // 매일 22시에 실행
-    public void addReminderRoleRoomLog() {
-        LocalDate today = LocalDate.now();
-        List<Todo> todoList = todoRepository.findByTimePointAndRoleIsNotNull(today);
-        Map<Long, List<Todo>> mateTodoMap = todoList.stream()
-            .flatMap(todo -> todo.getIncompleteAssigneeIdList().stream()
-                .map(mateId -> Map.entry(mateId, todo)))
-            .collect(Collectors.groupingBy(
-                Map.Entry::getKey,
-                Collectors.mapping(Map.Entry::getValue, Collectors.toList())
-            ));
-
-        roomLogCommandService.addRoomLogRemindingRole(mateTodoMap);
     }
 
     @Scheduled(cron = "0 0 12 L * ?")
@@ -147,19 +95,27 @@ public class NotificationScheduler {
         );
     }
 
-    // 매일 자정 반복 (해당하는 날 역할을 Todo에 추가)
+    /**
+     * Role 투두 잊지 않았는지 FCM 알림
+     */
+    @Scheduled(cron = "00 00 21 * * *")
+    public void sendReminderRoleNotification() {
+        todoQueryService.sendReminderRoleNotification();
+    }
+
+    /**
+     * 매일 자정에 완료하지 않은 RoomLog에 대해서 알림 추가
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 22시에 실행
+    public void addReminderRoleRoomLog() {
+        todoQueryService.addReminderRoleRoomLog();
+    }
+
+    /**
+     * 매일 자정 반복 (해당하는 날 역할을 Todo에 추가)
+     */
     @Scheduled(cron = "0 0 0 * * *")
     public void addRoleToTodo() {
-        DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
-        int dayBitmask = DayListBitmask.getBitmaskByDayOfWeek(dayOfWeek);
-        List<Role> roleList = roleRepository.findAll(); // TODO 페이징 반복 처리?
-        roleList.stream().filter(role -> (role.getRepeatDays() & dayBitmask) != 0).toList()
-            .forEach(role ->
-                todoRepository.save(
-                    TodoConverter.toEntity(role.getMate().getRoom(), role.getMate(),
-                        role.getAssignedMateIdList(), role.getContent(),
-                        LocalDate.now(), role, TodoType.ROLE_TODO)
-                )
-            );
+        roleCommandService.addRoleToTodo();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/scheduler/NotificationScheduler.java
@@ -106,7 +106,7 @@ public class NotificationScheduler {
     /**
      * 매일 자정에 완료하지 않은 RoomLog에 대해서 알림 추가
      */
-    @Scheduled(cron = "0 0 0 * * *") // 매일 22시에 실행
+    @Scheduled(cron = "0 0 0 * * *")
     public void addReminderRoleRoomLog() {
         todoQueryService.addReminderRoleRoomLog();
     }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
넵

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

- 기존에 Todo 변경으로 비활성화해둔 룸 로그를 활성화시켰습니다.
- 이를 위해서 룸로그에 mateId Long 값을 외래키 연관을 시키지 않고 추가했습니다 (mate와 연관해서 사용하지 않는 도메인이기 때문입니다.)
- Todo랑 RoomLog 연관도 그냥 없애버릴까 고민중입니다. 이것도 mate와 연관될 구석이 없고, 그냥 값을 찾기 위해서만 사용되기 때문입니다.
- 룸 로그와 함께 연관된 FCM도 다시 활성화시켰습니다.
- 코드 형태를 좀 리팩토링 했고, 기능이 크게 바뀐건 없지만 validation 체크가 좀 추가되었습니다.
- iOS에서 요청한 Todo 정렬 후 반환 기능을 또 추가하였습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

<img width="746" alt="image" src="https://github.com/user-attachments/assets/25490c9e-07c7-42d4-b10d-ffad7f637391">

위의 데이터에서 조회한 결과입니다. 저는 mateId가 5번입니다.
``` json
"todoList": [
        {
          "todoId": 1245,
          "content": "내 투두 테스트",
          "completed": false,
          "todoType": "self",

        },
        {
          "todoId": 1250,
          "content": "내꺼+1",
          "completed": false,
          "todoType": "self",

        },
        {
          "todoId": 1247,
          "content": "남 투두두두두",
          "completed": false,
          "todoType": "other",

        },
        {
          "todoId": 1251,
          "content": "남꺼+1",
          "completed": false,
          "todoType": "other",

        },
        {
          "todoId": 1252,
          "content": "남꺼+1",
          "completed": false,
          "todoType": "other",

        },
        {
          "todoId": 1248,
          "content": "그뤁투두ㅜ두",
          "completed": false,
          "todoType": "group",

        },
        {
          "todoId": 1249,
          "content": "그룹투두루ㅜㄹ뒤루",
          "completed": false,
          "todoType": "group",
 
        },
        {
          "todoId": 1235,
          "content": "피드 완벽하게 구현하기",
          "completed": true,
          "todoType": "role",

        },
        {
          "todoId": 1236,
          "content": "팀원들을 칭찬해주기",
          "completed": true,
          "todoType": "role",

        },
        {
          "todoId": 1237,
          "content": "새롭게 롤을 생성해보았습니다, 매일",
          "completed": true,
          "todoType": "role",

        }
      ]
```
제가 이것저것 추가한 뒤 조회한 결과입니다. 코드가 길어져서 mateIdList는 지웠고, todoType이 self, group, other, role 순으로 정렬되어 조회됩니다.
FCM은 직접 보내서 좌심방친구들은 모두 봤을거고요.

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

위에 적은것을 복사해서 가져왔습니다.
- Todo랑 RoomLog 연관도 그냥 없애버릴까 고민중입니다. 이것도 mate와 연관될 구석이 없고, 그냥 값을 찾기 위해서만 사용되기 때문입니다.