### PR TITLE
[COZY-414] fix: 멤버 스탯 조회 시 초대 여부 관련 에러 HOTFIX

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -74,7 +74,7 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     List<Mate> findFetchMemberByRoom(@Param("room") Room room,
         @Param("entryStatus") EntryStatus entryStatus);
 
-    Optional<Mate> findByMember(Member member);
+    Optional<Mate> findByMemberAndEntryStatus(Member member,EntryStatus entryStatus);
 
     @Query("select m from Mate m join fetch m.member")
     List<Mate> findFetchAll();

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -393,7 +393,7 @@ public class RoomQueryService {
     public boolean checkInvitationStatus(Member viewer, List<Mate> mates) {
         return mates.stream()
             .filter(m -> m.getEntryStatus().equals(EntryStatus.PENDING))
-            .anyMatch(m -> mateRepository.findByMember(viewer)
+            .anyMatch(m -> mateRepository.findByMemberAndEntryStatus(viewer, EntryStatus.JOINED)
                 .filter(viewerMate ->
                     viewerMate.isRoomManager() &&
                         viewerMate.getRoom().equals(m.getRoom()))


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

네

## #️⃣ 작업 내용
멤버 스탯 조회 시 초대 여부 조건 중 자신이 방장인 경우 검색할 때 조회 처리 실수가 있었습니다.
관련해서 핫픽스 햇습니다.

## 동작 확인
이제 잘 됩니다.

## 💬 리뷰 요구사항(선택)
감사합니다.
