### PR TITLE
[COZY-417] 멤버 스탯이 없는 경우 자동 삭제하는 로직을 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
@@ -9,6 +9,7 @@ import com.cozymate.cozymate_server.domain.memberstatequality.util.MemberStatEqu
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -205,6 +206,8 @@ public class MemberStatEqualityCommandService {
             .flatMap(equality -> Stream.of(equality.getMemberAId(), equality.getMemberBId()))
             .collect(Collectors.toSet());
 
+        log.info(memberIds.toString());
+
         Map<Long, MemberStat> memberStatMap = memberStatRepository.findMemberStatsAndMemberIdsByMemberIds(
                 memberIds)
             .stream()
@@ -213,21 +216,32 @@ public class MemberStatEqualityCommandService {
                 tuple -> tuple.get(0, MemberStat.class)
             ));
 
+        log.info(memberStatMap.toString());
+
         List<MemberStatEquality> updatedEqualities = relatedEqualities.stream()
             .map(
                 equality -> {
+
                     boolean isMemberAChanged = equality.getMemberAId().equals(changedMemberId);
 
                     MemberStat memberStat = isMemberAChanged ?
                         memberStatMap.get(equality.getMemberBId()) :
                         memberStatMap.get(equality.getMemberAId());
 
-                    Integer updatedEquality = MemberStatEqualityUtil.calculateEquality(
-                        changedMemberStat, memberStat);
+                    if (memberStat != null) {
+                        Integer updatedEquality = MemberStatEqualityUtil.calculateEquality(
+                            changedMemberStat, memberStat);
 
-                    return equality.updateEquality(updatedEquality);
+                        return equality.updateEquality(updatedEquality);
+                    }
+
+                    deleteMemberStatEqualitiesWithMemberId(
+                        isMemberAChanged ? equality.getMemberBId() : equality.getMemberAId());
+
+                    return null;
                 }
             )
+            .filter(Objects::nonNull)
             .toList();
 
         memberStatEqualityBulkRepository.updateAll(updatedEqualities);

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/service/MemberStatEqualityCommandService.java
@@ -206,8 +206,6 @@ public class MemberStatEqualityCommandService {
             .flatMap(equality -> Stream.of(equality.getMemberAId(), equality.getMemberBId()))
             .collect(Collectors.toSet());
 
-        log.info(memberIds.toString());
-
         Map<Long, MemberStat> memberStatMap = memberStatRepository.findMemberStatsAndMemberIdsByMemberIds(
                 memberIds)
             .stream()
@@ -215,8 +213,6 @@ public class MemberStatEqualityCommandService {
                 tuple -> tuple.get(1, Long.class),
                 tuple -> tuple.get(0, MemberStat.class)
             ));
-
-        log.info(memberStatMap.toString());
 
         List<MemberStatEquality> updatedEqualities = relatedEqualities.stream()
             .map(

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
@@ -1,7 +1,9 @@
 package com.cozymate.cozymate_server.domain.memberstatequality.util;
 
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class MemberStatEqualityUtil {
 
     private static final Integer ADDITIONAL_SCORE = 36;

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstatequality/util/MemberStatEqualityUtil.java
@@ -1,9 +1,7 @@
 package com.cozymate.cozymate_server.domain.memberstatequality.util;
 
 import com.cozymate.cozymate_server.domain.memberstat.MemberStat;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 public class MemberStatEqualityUtil {
 
     private static final Integer ADDITIONAL_SCORE = 36;


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

네

## #️⃣ 작업 내용

멤버 스탯 업데이트 중 일치율 업데이트 관련해 NPE 가 발생했는데, 사실 비즈니스 로직 상 있을 수 없는 경우이지만 이럴 경우를 대비해 로직을 하나 만들어놨습니다.

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

- 

## 💬 리뷰 요구사항(선택)
감사합니다.
