### PR TITLE
[COZY-421] fix : mate 삭제전 방나가기 EntryStatus.equals(JOINED)인 경우에만 나가는걸로 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
@@ -6,6 +6,7 @@ import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepositor
 import com.cozymate.cozymate_server.domain.fcm.repository.FcmRepository;
 import com.cozymate.cozymate_server.domain.mail.repository.MailRepository;
 import com.cozymate.cozymate_server.domain.mate.Mate;
+import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
 import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
@@ -101,7 +102,9 @@ public class MemberWithdrawService {
         mateRepository.findAllByMemberId(member.getId())
             .forEach(mate -> {
                 deleteRelatedWithMate(mate);
-                roomCommandService.quitRoom(mate.getRoom().getId(), mate.getMember().getId());
+                if (mate.getEntryStatus().equals(EntryStatus.JOINED)) {
+                    roomCommandService.quitRoom(mate.getRoom().getId(), mate.getMember().getId());
+                }
             });
 
         mateRepository.deleteAllByMemberId(member.getId());


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
Mate의 Status가 JOINED가 아닌대도 RoomCommandService.quitRoom()을 호출하는 경우에 문제가 생긴거 같습니다.
그래서 Mate의 Status가 JOINED인 경우에만 RoomCommandService.quitRoom()을 호출하도록 수정했습니다.

## 동작 확인

테스트 하기엔 품이 많이드는데 급한 부분이라.. 사고실험 해봤는데 이거 맞는거 같아요
코드도 딸랑 한줄 추가 했어여
## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
