### PR TITLE
[COZY-408] fix: 롤 삭제시 투두 삭제되도록 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/repository/MemberStatRepository.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Tuple;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/cozymate/cozymate_server/domain/role/service/RoleCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/role/service/RoleCommandService.java
@@ -13,6 +13,7 @@ import com.cozymate.cozymate_server.domain.role.repository.RoleRepository;
 import com.cozymate.cozymate_server.domain.todo.converter.TodoConverter;
 import com.cozymate.cozymate_server.domain.todo.enums.TodoType;
 import com.cozymate.cozymate_server.domain.todo.repository.TodoRepository;
+import com.cozymate.cozymate_server.domain.todo.service.TodoCommandService;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.time.DayOfWeek;
@@ -32,6 +33,7 @@ public class RoleCommandService {
     private final RoleRepository roleRepository;
     private final MateRepository mateRepository;
     private final TodoRepository todoRepository;
+    private final TodoCommandService todoCommandService;
 
     /**
      * Role 생성
@@ -68,6 +70,7 @@ public class RoleCommandService {
 
         checkUpdatePermission(role, mate);
 
+        todoCommandService.deleteTodoByRoleId(roleId);
         roleRepository.delete(role);
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/RoomLog.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/RoomLog.java
@@ -35,4 +35,8 @@ public class RoomLog extends BaseTimeEntity {
     private Todo todo;
 
     private Long mateId;
+
+    public void changeTodoToNull() {
+        this.todo = null;
+    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/RoomLog.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/RoomLog.java
@@ -31,6 +31,7 @@ public class RoomLog extends BaseTimeEntity {
 
     private String content;
 
+    // TODO: 연관 없애기
     @ManyToOne(fetch = FetchType.LAZY)
     private Todo todo;
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/converter/RoomLogConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/converter/RoomLogConverter.java
@@ -5,6 +5,7 @@ import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.domain.roomlog.RoomLog;
 import com.cozymate.cozymate_server.domain.roomlog.dto.RoomLogResponseDto.RoomLogDetailResponseDto;
 import com.cozymate.cozymate_server.domain.todo.Todo;
+import java.util.Objects;
 
 public class RoomLogConverter {
 
@@ -13,7 +14,7 @@ public class RoomLogConverter {
             .content(content)
             .room(room)
             .todo(todo)
-            .mateId(mate.getId())
+            .mateId(Objects.isNull(mate) ? null : mate.getId())
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.roomlog.repository;
 
 import com.cozymate.cozymate_server.domain.roomlog.RoomLog;
 import com.cozymate.cozymate_server.domain.todo.Todo;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -15,6 +16,8 @@ public interface RoomLogRepository extends JpaRepository<RoomLog, Long> {
     Slice<RoomLog> findAllByRoomIdOrderByCreatedAtDesc(Long roomId, Pageable pageable);
 
     Optional<RoomLog> findByTodoIdAndMateId(Long todoId, Long mateId);
+
+    List<RoomLog> findAllByTodoId(Long todoId);
 
     void deleteByRoomId(Long roomId);
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogCommandService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -101,6 +102,11 @@ public class RoomLogCommandService {
         String content = today.getMonthValue() + "월 " + today.getDayOfMonth() + "일은 "
             + mate.getMember().getNickname() + "님의 생일이에요! 모두 축하해주세요!";
         roomLogRepository.save(RoomLogConverter.toEntity(content, mate.getRoom(), null, mate));
+    }
+
+    public void changeRoomLogTodoToNull(Long todoId) {
+        List<RoomLog> roomLog = roomLogRepository.findAllByTodoId(todoId);
+        roomLog.forEach(RoomLog::changeTodoToNull);
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/service/RoomLogCommandService.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/Rule.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/Rule.java
@@ -32,7 +32,7 @@ public class Rule extends BaseTimeEntity {
     @Column(nullable = false, length = 50)
     private String content;
 
-    @Column(nullable = false, length = 40)
+    @Column(nullable = false, length = 50)
     private String memo;
 
     // 메모가 nullable이라, 수정할 때 그냥 값을 덮어씌우도록 구성

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/request/CreateRuleRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/dto/request/CreateRuleRequestDTO.java
@@ -9,7 +9,7 @@ public record CreateRuleRequestDTO(
     String content,
 
     @NotNull(message = "메모는 필수로 입력해주세요. 아니면 빈 문자열로 보내주세요.")
-    @Size(max = 40, message = "메모는 40자 이하로 입력해주세요.")
+    @Size(max = 50, message = "메모는 50자 이하로 입력해주세요.")
     String memo
 ) {
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
@@ -27,4 +27,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Modifying
     @Query("UPDATE Todo t SET t.mate = null WHERE t.mate = :mate")
     void bulkDeleteMate(@Param("mate") Mate mate);
+
+    void deleteAllByRoleId(Long roleId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
@@ -128,6 +128,9 @@ public class TodoCommandService {
             throw new GeneralException(ErrorStatus._TODO_NOT_DELETE);
         }
 
+        // 투두를 삭제하기 전 Todo를 NULL로 변경
+        roomLogCommandService.changeRoomLogTodoToNull(todo.getId());
+
         // 내 투두면 투두 자체를 삭제
         if (todo.getTodoType() == TodoType.SINGLE_TODO) {
             todoRepository.delete(todo);
@@ -268,6 +271,10 @@ public class TodoCommandService {
         if (mateIdList.size() > MAX_ASSIGNEE) {
             throw new GeneralException(ErrorStatus._TODO_OVER_MAX);
         }
+    }
+
+    public void deleteTodoByRoleId(Long roleId) {
+        todoRepository.deleteAllByRoleId(roleId);
     }
 
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
넵

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

- 롤 삭제시 투두가 삭제됩니다.
- 투두가 삭제될 시 룸 로그의 할당된 값이 사라집니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

- 패스패스패스


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
