### PR TITLE
[COZY-427] feat: 사용자가 초대받은 방인지 조회, 방장이 방에 참여 요청한 사용자인지 조회하는 API 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.room.controller;
 
 
 import com.cozymate.cozymate_server.domain.auth.userdetails.MemberDetails;
+import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
 import com.cozymate.cozymate_server.domain.room.dto.request.PrivateRoomCreateRequestDTO;
 import com.cozymate.cozymate_server.domain.room.dto.request.PublicRoomCreateRequestDTO;
 import com.cozymate.cozymate_server.domain.room.dto.request.RoomUpdateRequestDTO;
@@ -368,18 +369,6 @@ public class RoomController {
         return ResponseEntity.ok(ApiResponse.onSuccess("비공개방 전환 완료"));
     }
 
-    @GetMapping("/{roomId}/pending-status")
-    @Operation(summary = "[바니] 사용자가 해당 방에 참여 요청을 했는지 여부 조회", description = "로그인한 사용자가 roomId에 해당하는 방에 참여 요청을 했는지 여부를 조회합니다.")
-    @SwaggerApiError({
-        ErrorStatus._MEMBER_NOT_FOUND,
-        ErrorStatus._ROOM_NOT_FOUND
-    })
-    public ResponseEntity<ApiResponse<Boolean>> getPendingStatus(
-        @PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
-        Boolean response = roomQueryService.getPendingStatus(roomId, memberDetails.member().getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(response));
-    }
-
     @GetMapping("/search")
     @Operation(summary = "[바니] 방 검색", description = "공개방을 검색합니다. 라이프 스타일 없는 경우 가나다순, 있는 경우 평균 일치율 순으로 정렬됩니다.")
     @SwaggerApiError({
@@ -391,16 +380,52 @@ public class RoomController {
     }
 
     @GetMapping("/invited-status/{memberId}")
-    @Operation(summary = "[바니] 방장이 사용자한테 방 참여 요청을 보냈는지 여부 조회", description = "방장이 memberId에게 방 참여 요청을 보냈는지 여부를 조회합니다.")
+    @Operation(summary = "[바니] 방장 -> 방장이 사용자를 초대 했는지 여부 조회", description = "방장이 memberId에 해당하는 사용자에게 방 참여 요청을 보냈는지 여부를 조회합니다.")
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._ROOM_NOT_FOUND,
         ErrorStatus._ROOM_MANAGER_NOT_FOUND,
         ErrorStatus._NOT_ROOM_MANAGER
     })
-    public ResponseEntity<ApiResponse<Boolean>> getInvitedStatus(
+    public ResponseEntity<ApiResponse<Boolean>> isInvitedMember(
         @PathVariable Long memberId, @AuthenticationPrincipal MemberDetails memberDetails) {
-        return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.getInvitedStatus(memberId, memberDetails.member().getId())));
+        return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.isMemberInEntryStatus(memberId, memberDetails.member().getId(), EntryStatus.INVITED)));
+    }
+
+    @GetMapping("pending-status/{memberId}")
+    @Operation(summary = "[바니] 방장 -> 사용자가 방에 참여 요청을 했는지 여부 조회", description = "memberId에 해당하는 사용자가 방장의 방에 참여 요청을 보냈는지 여부를 조회합니다.")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._ROOM_NOT_FOUND,
+        ErrorStatus._ROOM_MANAGER_NOT_FOUND,
+        ErrorStatus._NOT_ROOM_MANAGER
+    })
+    public ResponseEntity<ApiResponse<Boolean>> isPendingMember(
+        @PathVariable Long memberId, @AuthenticationPrincipal MemberDetails memberDetails) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.isMemberInEntryStatus(memberId, memberDetails.member().getId(), EntryStatus.PENDING)));
+    }
+
+    @GetMapping("/{roomId}/invited-status")
+    @Operation(summary = "[바니] 사용자가 해당 방에 초대 받았는지 여부 조회", description = "로그인한 사용자가 해당 roomId의 방에 초대받았는지 여부를 조회합니다.")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._ROOM_NOT_FOUND,
+    })
+    public ResponseEntity<ApiResponse<Boolean>> isInvitedToRoom(
+        @PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.isEntryStatusToRoom(roomId, memberDetails.member().getId(), EntryStatus.INVITED)));
+    }
+
+    @GetMapping("/{roomId}/pending-status")
+    @Operation(summary = "[바니] 사용자가 해당 방에 참여 요청을 했는지 여부 조회", description = "로그인한 사용자가 roomId에 해당하는 방에 참여 요청을 했는지 여부를 조회합니다.")
+    @SwaggerApiError({
+        ErrorStatus._MEMBER_NOT_FOUND,
+        ErrorStatus._ROOM_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<Boolean>> isPendingToRoom(
+        @PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
+        Boolean response = roomQueryService.isEntryStatusToRoom(roomId, memberDetails.member().getId(), EntryStatus.PENDING);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -380,7 +380,7 @@ public class RoomController {
     }
 
     @GetMapping("/invited-status/{memberId}")
-    @Operation(summary = "[바니] 방장 -> 방장이 사용자를 초대 했는지 여부 조회", description = "방장이 memberId에 해당하는 사용자에게 방 참여 요청을 보냈는지 여부를 조회합니다.")
+    @Operation(summary = "[바니] 방장 -> 방장이 초대한 사용자인지 조회", description = "방장이 memberId에 해당하는 사용자에게 방 참여 요청을 보냈는지 여부를 조회합니다.")
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._ROOM_NOT_FOUND,
@@ -393,7 +393,7 @@ public class RoomController {
     }
 
     @GetMapping("pending-status/{memberId}")
-    @Operation(summary = "[바니] 방장 -> 사용자가 방에 참여 요청을 했는지 여부 조회", description = "memberId에 해당하는 사용자가 방장의 방에 참여 요청을 보냈는지 여부를 조회합니다.")
+    @Operation(summary = "[바니] 방장 -> 방에 참여 요청한 사용자인지 조회", description = "memberId에 해당하는 사용자가 방장의 방에 참여 요청을 보냈는지 여부를 조회합니다.")
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._ROOM_NOT_FOUND,
@@ -406,7 +406,7 @@ public class RoomController {
     }
 
     @GetMapping("/{roomId}/invited-status")
-    @Operation(summary = "[바니] 사용자가 해당 방에 초대 받았는지 여부 조회", description = "로그인한 사용자가 해당 roomId의 방에 초대받았는지 여부를 조회합니다.")
+    @Operation(summary = "[바니] 사용자 -> 사용자가 초대받은 방인지 조회", description = "로그인한 사용자가 해당 roomId의 방에 초대받았는지 여부를 조회합니다.")
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._ROOM_NOT_FOUND,
@@ -417,7 +417,7 @@ public class RoomController {
     }
 
     @GetMapping("/{roomId}/pending-status")
-    @Operation(summary = "[바니] 사용자가 해당 방에 참여 요청을 했는지 여부 조회", description = "로그인한 사용자가 roomId에 해당하는 방에 참여 요청을 했는지 여부를 조회합니다.")
+    @Operation(summary = "[바니] 사용자 -> 사용자가 참여 요청한 방인지 조회", description = "로그인한 사용자가 roomId에 해당하는 방에 참여 요청을 했는지 여부를 조회합니다.")
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND,
         ErrorStatus._ROOM_NOT_FOUND

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -315,16 +315,6 @@ public class RoomQueryService {
         return managerMate.getMember().getMemberStat().getDormitoryName();
     }
 
-    public Boolean getPendingStatus(Long roomId, Long memberId) {
-        memberRepository.findById(memberId).orElseThrow(
-            () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-
-        roomRepository.findById(roomId).orElseThrow(
-            () -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
-
-        return mateRepository.existsByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.PENDING);
-    }
-
     public Long isFavoritedRoom(Long memberId, Long roomId) {
         Member member = memberRepository.findById(memberId).orElseThrow(
             () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -400,7 +390,7 @@ public class RoomQueryService {
                 .isPresent());
     }
 
-    public Boolean getInvitedStatus(Long memberId, Long managerId) {
+    public Boolean isMemberInEntryStatus(Long memberId, Long managerId, EntryStatus entryStatus) {
         memberRepository.findById(memberId).orElseThrow(
             () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
@@ -414,6 +404,16 @@ public class RoomQueryService {
             throw new GeneralException(ErrorStatus._NOT_ROOM_MANAGER);
         }
 
-        return mateRepository.existsByRoomIdAndMemberIdAndEntryStatus(room.getId(), memberId, EntryStatus.INVITED);
+        return mateRepository.existsByRoomIdAndMemberIdAndEntryStatus(room.getId(), memberId, entryStatus);
+    }
+
+    public Boolean isEntryStatusToRoom(Long roomId, Long memberId, EntryStatus entryStatus) {
+        memberRepository.findById(memberId).orElseThrow(
+            () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        roomRepository.findById(roomId).orElseThrow(
+            () -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
+
+        return mateRepository.existsByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, entryStatus);
     }
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네 
## #️⃣ 작업 내용
사용자가 초대받은 방인지 조회, 방장이 방에 참여 요청한 사용자인지 조회하는 API 추가했습니다


## 동작 확인
**사용자가 초대받은 방인지 조회**
![image](https://github.com/user-attachments/assets/1b91c7cf-e0e3-4387-9176-ece7c20dea33)
초대 받았을 때
![image](https://github.com/user-attachments/assets/41efad07-939d-4953-a0cf-c06c9c47ef1a)
초대 안받았을 때

**방장이 방에 참여 요청한 사용자인지 memberId로 조회**
![image](https://github.com/user-attachments/assets/741eee0f-96c2-48db-b8a9-f3e49da2f097)
방장 아닐때
![image](https://github.com/user-attachments/assets/ac7fce1d-63b3-4f0a-b6ec-ebc0b1fbf6a2)
참여 요청 보낸 사용자일때
![image](https://github.com/user-attachments/assets/25054eac-e74f-4ade-9f59-0a2ffa6d0ae5)
참여 요청 보낸  사용자 아닐 때

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
