### PR TITLE
[COZY-432] feat: 사용자가 방에 들어가면 다른 요청들 날리기

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -27,12 +27,6 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     Optional<Mate> findByRoomIdAndMemberIdAndNotEntryStatus(@Param("roomId") Long roomId,
         @Param("memberId") Long memberId, @Param("entryStatus") EntryStatus entryStatus);
 
-
-    @Query("SELECT COUNT(m) FROM Mate m WHERE m.room.id = :roomId AND m.entryStatus = 'JOINED'")
-    long countActiveMatesByRoomId(@Param("roomId") Long roomId);
-
-    Long countByRoomId(Long roomId);
-
     @Query("SELECT COUNT(m) > 0 FROM Mate m WHERE m.member.id = :memberId AND (m.room.status = :status1 OR m.room.status = :status2)")
     boolean existsByMemberIdAndRoomStatuses(@Param("memberId") Long memberId,
         @Param("status1") RoomStatus status1, @Param("status2") RoomStatus status2);
@@ -41,8 +35,6 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
         EntryStatus status);
 
     boolean existsByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId, EntryStatus status);
-
-    Optional<Mate> findByMemberIdAndEntryStatus(Long memberId, EntryStatus entryStatus);
 
     List<Mate> findAllByMemberIdAndEntryStatus(Long memberId, EntryStatus entryStatus);
 
@@ -66,8 +58,6 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     List<Mate> findAllByMemberBirthDayMonthAndDayAndEntryStatus(@Param("month") int month,
         @Param("day") int day, @Param("entryStatus") EntryStatus entryStatus);
 
-    List<Mate> findByRoom(Room room);
-
     @Query("select m from Mate m join fetch m.member where m.room = :room and m.entryStatus = :entryStatus")
     List<Mate> findFetchMemberByRoom(@Param("room") Room room,
         @Param("entryStatus") EntryStatus entryStatus);
@@ -79,8 +69,6 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     @Query("select m.id from Mate m where m.member.id in :memberIds")
     Set<Long> findMateIdsByMemberIds(@Param("memberIds") Set<Long> memberIds);
-
-    void deleteByRoomIdAndMemberId(Long roomId, Long memberId);
 
     List<Mate> findByRoomIdAndEntryStatus(Long roomId, EntryStatus entryStatus);
 
@@ -97,4 +85,6 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     void deleteAllByMemberId(Long memberId);
 
     List<Mate> findAllByIdIn(List<Long> mateIds);
+
+    void deleteAllByMemberIdAndEntryStatusIn(Long memberId, List<EntryStatus> entryStatuses);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -135,25 +135,21 @@ public class RoomCommandService {
             throw new GeneralException(ErrorStatus._ROOM_ALREADY_EXISTS);
         }
 
-        if (mateRepository.countActiveMatesByRoomId(roomId) >= room.getMaxMateNum()) {
-            throw new GeneralException(ErrorStatus._ROOM_FULL);
+        if (room.getNumOfArrival() >= room.getMaxMateNum()) {
+            throw new GeneralException(ErrorStatus._ROOM_FULL); // 방이 가득 찼을 경우 예외 처리
         }
 
         if (existingMate.isPresent()) {
             // 재입장 처리
-            Mate exitingMate = existingMate.get();
-            exitingMate.setEntryStatus(EntryStatus.JOINED);
-            mateRepository.save(exitingMate);
-            room.arrive();
-            room.isRoomFull();
-            roomRepository.save(room);
+            processJoinRequest(existingMate.get(), room);
+            clearOtherRoomRequests(memberId);
         } else {
             Mate mate = MateConverter.toEntity(room, member, false);
             mateRepository.save(mate);
             room.arrive();
             room.isRoomFull();
-            roomRepository.save(room);
         }
+        roomRepository.save(room);
 
         // 푸시 알림 코드
         List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
@@ -326,8 +322,8 @@ public class RoomCommandService {
         }
 
         // 방 정원 검사
-        if (mateRepository.countActiveMatesByRoomId(room.getId()) >= room.getMaxMateNum()) {
-            throw new GeneralException(ErrorStatus._ROOM_FULL);
+        if (room.getNumOfArrival() >= room.getMaxMateNum()) {
+            throw new GeneralException(ErrorStatus._ROOM_FULL); // 방이 가득 찼을 경우 예외 처리
         }
 
         if (invitee.isPresent()) {
@@ -369,10 +365,8 @@ public class RoomCommandService {
 
         if (accept) {
             // 초대 요청을 수락하여 JOINED 상태로 변경
-            invitee.setEntryStatus(EntryStatus.JOINED);
-            mateRepository.save(invitee);
-            room.arrive();
-            room.isRoomFull();
+            processJoinRequest(invitee, room);
+            clearOtherRoomRequests(inviteeId);
         } else {
             // 초대 요청을 거절하여 PENDING 상태를 삭제
             mateRepository.delete(invitee);
@@ -546,15 +540,13 @@ public class RoomCommandService {
                 requesterId, EntryStatus.PENDING)
             .orElseThrow(() -> new GeneralException(ErrorStatus._REQUEST_NOT_FOUND));
 
-        if (room.getNumOfArrival() + 1 > room.getMaxMateNum()) {
-            throw new GeneralException(ErrorStatus._ROOM_FULL);
+        if (room.getNumOfArrival() >= room.getMaxMateNum()) {
+            throw new GeneralException(ErrorStatus._ROOM_FULL); // 방이 가득 찼을 경우 예외 처리
         }
 
         if (accept) {
-            requester.setEntryStatus(EntryStatus.JOINED);
-            mateRepository.save(requester);
-            room.arrive();
-            room.isRoomFull();
+            processJoinRequest(requester, room);
+            clearOtherRoomRequests(requesterId);
         } else {
             mateRepository.delete(requester); // 거절 시 요청자 삭제
         }
@@ -626,6 +618,19 @@ public class RoomCommandService {
         }
 
         room.changeToPrivateRoom();
+    }
+
+    private void processJoinRequest(Mate mate, Room room) {
+        mate.setEntryStatus(EntryStatus.JOINED);
+        mateRepository.save(mate);
+        room.arrive();
+        room.isRoomFull();
+    }
+
+    private void clearOtherRoomRequests(Long memberId) {
+        mateRepository.deleteAllByMemberIdAndEntryStatusIn(
+            memberId, List.of(EntryStatus.PENDING, EntryStatus.INVITED)
+        );
     }
 
     // 초대코드 생성 부분


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
예

## #️⃣ 작업 내용
어떤 방에 들어가는 순간 기존 초대 및 참여 요청을 자동으로 날립니다

## 동작 확인
![image](https://github.com/user-attachments/assets/0cd9d3af-9ef8-408c-a61b-5ea625366e19)
memberId 99 → 여러방(57,72,37)에 INVITED, PENDING 상태

방장에게 보이는 참여요청 리스트
![image](https://github.com/user-attachments/assets/5fa07ab2-c6c1-4e71-a2df-9f844bd4b406)

99번 참여 요청 수락함
![image](https://github.com/user-attachments/assets/bdbc8bf5-d478-4659-ac31-e8afc2bcaf5f)
![image](https://github.com/user-attachments/assets/fc512290-1e3a-44ea-96b7-90e4ef4e1df8)
37번 JOINED 룸 제외하고 모든 요청 지워짐
![image](https://github.com/user-attachments/assets/809cc2f6-e068-426d-9e8e-ae12ba04a447)
98번 요청을 거절했을때는 안날라감
![image](https://github.com/user-attachments/assets/979d5ba7-3f4c-4b4c-b0ce-cb5c0545dc30)



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
