### PR TITLE
[COZY-441] fix: 멤버 스탯 없는 사용자에 대한 찜 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/favorite/dto/response/PreferenceMatchCountDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/favorite/dto/response/PreferenceMatchCountDTO.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 @Builder
 public record PreferenceMatchCountDTO(
     String preferenceName,
-    int count
+    Integer count
 ) {
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteCommandService.java
@@ -12,7 +12,6 @@ import com.cozymate.cozymate_server.domain.room.enums.RoomType;
 import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,13 +57,10 @@ public class FavoriteCommandService {
 
     private void validTarget(FavoriteType favoriteType, Long targetId) {
         if (favoriteType.equals(FavoriteType.MEMBER)) {
-            Member member = memberRepository.findById(targetId).orElseThrow(
+            memberRepository.findById(targetId).orElseThrow(
                 () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND)
             );
 
-            if (Objects.isNull(member.getMemberStat())) {
-                throw new GeneralException(ErrorStatus._FAVORITE_CANNOT_MEMBER_WITHOUT_MEMBERSTAT);
-            }
         } else {
             Room room = roomRepository.findById(targetId).orElseThrow(
                 () -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND)

--- a/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteQueryService.java
@@ -69,18 +69,28 @@ public class FavoriteQueryService {
         List<String> criteriaPreferences = memberStatPreferenceQueryService.getPreferencesToList(
             member.getId());
 
+        MemberStat memberStat = member.getMemberStat();
+
         List<FavoriteMemberResponseDTO> favoriteMemberResponseDTOList = existFavoriteMemberList.stream()
             .filter(favoriteMember -> Objects.nonNull(favoriteMember.getMemberStat()))
-            .map(favoriteMember ->
-                FavoriteConverter.toFavoriteMemberResponseDTO(
-                    memberIdFavoriteIdMap.get(favoriteMember.getId()),
-                    MemberStatConverter.toPreferenceResponseDTO(
-                        favoriteMember.getMemberStat(),
-                        MemberStatConverter.toMemberStatPreferenceDetailColorDTOList(
-                            favoriteMember.getMemberStat(), member.getMemberStat(),
-                            criteriaPreferences
-                        ),
-                        equalityMap.get(favoriteMember.getId())))
+            .map(favoriteMember -> {
+                    if (Objects.isNull(memberStat)) {
+                        return FavoriteConverter.toFavoriteMemberResponseDTO(
+                            memberIdFavoriteIdMap.get(favoriteMember.getId()),
+                            MemberStatConverter.toPreferenceResponseDTO(
+                                favoriteMember.getMemberStat(),
+                                MemberStatConverter.toMemberStatPreferenceDetailWithoutColorDTOList(
+                                    favoriteMember.getMemberStat(), criteriaPreferences), null));
+                    }
+                    return FavoriteConverter.toFavoriteMemberResponseDTO(
+                        memberIdFavoriteIdMap.get(favoriteMember.getId()),
+                        MemberStatConverter.toPreferenceResponseDTO(
+                            favoriteMember.getMemberStat(),
+                            MemberStatConverter.toMemberStatPreferenceDetailColorDTOList(
+                                favoriteMember.getMemberStat(), member.getMemberStat(),
+                                criteriaPreferences
+                            ), equalityMap.get(favoriteMember.getId())));
+                }
             ).toList();
 
         // 탈퇴한 회원이 있다면 삭제 처리

--- a/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/favorite/service/FavoriteQueryService.java
@@ -197,7 +197,7 @@ public class FavoriteQueryService {
             .map(preference -> {
                 return PreferenceMatchCountDTO.builder()
                     .preferenceName(preference)
-                    .count(0)
+                    .count(null)
                     .build();
             }).toList();
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/converter/MemberStatConverter.java
@@ -67,7 +67,8 @@ public class MemberStatConverter {
     }
 
 
-    public static MemberStatDetailResponseDTO toMemberStatDetailDTOFromEntity(MemberStat memberStat) {
+    public static MemberStatDetailResponseDTO toMemberStatDetailDTOFromEntity(
+        MemberStat memberStat) {
 
         return MemberStatDetailResponseDTO.builder()
             .admissionYear(MemberStatUtil.formatNumber(memberStat.getAdmissionYear()))
@@ -101,13 +102,15 @@ public class MemberStatConverter {
             .build();
     }
 
-    public static MemberStatDetailAndRoomIdAndEqualityResponseDTO toMemberStatDetailAndRoomIdAndEqualityResponseDTO(MemberStat memberStat,
+    public static MemberStatDetailAndRoomIdAndEqualityResponseDTO toMemberStatDetailAndRoomIdAndEqualityResponseDTO(
+        MemberStat memberStat,
         Integer equality,
         Long roomId,
         Boolean hasRequestedRoomEntry,
         Long favoriteId) {
         return MemberStatDetailAndRoomIdAndEqualityResponseDTO.builder()
-            .memberDetail(MemberConverter.toMemberDetailResponseDTOFromEntity(memberStat.getMember()))
+            .memberDetail(
+                MemberConverter.toMemberDetailResponseDTOFromEntity(memberStat.getMember()))
             .memberStatDetail(MemberStatConverter.toMemberStatDetailDTOFromEntity(memberStat))
             .equality(equality)
             .roomId(roomId)
@@ -116,9 +119,11 @@ public class MemberStatConverter {
             .build();
     }
 
-    public static MemberStatDetailWithMemberDetailResponseDTO toMemberStatDetailWithMemberDetailDTO(MemberStat memberStat){
+    public static MemberStatDetailWithMemberDetailResponseDTO toMemberStatDetailWithMemberDetailDTO(
+        MemberStat memberStat) {
         return MemberStatDetailWithMemberDetailResponseDTO.builder()
-            .memberDetail(MemberConverter.toMemberDetailResponseDTOFromEntity(memberStat.getMember()))
+            .memberDetail(
+                MemberConverter.toMemberDetailResponseDTOFromEntity(memberStat.getMember()))
             .memberStatDetail(MemberStatConverter.toMemberStatDetailDTOFromEntity(memberStat))
             .build();
     }
@@ -140,7 +145,7 @@ public class MemberStatConverter {
                 .build();
         }
 
-        Map<String, BiFunction<Member,MemberStat, Object>> fieldGetters = createFieldGetters();
+        Map<String, BiFunction<Member, MemberStat, Object>> fieldGetters = createFieldGetters();
 
         // 방 초기 생성 시, 혹은 멤버 상세정보를 입력한 사람이 1명일 때
         if (memberStatList.size() == 1) {
@@ -175,13 +180,13 @@ public class MemberStatConverter {
     }
 
     public static DifferenceStatus toDifferenceStatus(List<MemberStat> memberStatList, String key) {
-        if(memberStatList.isEmpty()) {
+        if (memberStatList.isEmpty()) {
             return DifferenceStatus.WHITE;
         }
-        if(memberStatList.size() == 1) {
+        if (memberStatList.size() == 1) {
             return DifferenceStatus.WHITE;
         }
-        Map<String, BiFunction<Member,MemberStat, Object>> fieldGetters = createFieldGetters();
+        Map<String, BiFunction<Member, MemberStat, Object>> fieldGetters = createFieldGetters();
 
         return compareField(memberStatList, fieldGetters.get(key));
 
@@ -201,34 +206,59 @@ public class MemberStatConverter {
     // 랜덤에서 사용하는 Converter
     public static List<MemberStatPreferenceDetailColorDTO> toMemberStatPreferenceDetailColorDTOList(
         MemberStat memberStat, List<String> preferences
-    ){
-        Map<String, Object> memberStatMap = MemberStatUtil.getMemberStatFields(memberStat, preferences);
+    ) {
+        Map<String, Object> memberStatMap = MemberStatUtil.getMemberStatFields(memberStat,
+            preferences);
 
         return memberStatMap.entrySet().stream()
             .map(entry ->
-                MemberStatConverter.toMemberStatPreferenceDetailColorDTO(entry.getKey(), entry.getValue(), DifferenceStatus.WHITE))
+                MemberStatConverter.toMemberStatPreferenceDetailColorDTO(entry.getKey(),
+                    entry.getValue(), DifferenceStatus.WHITE))
             .toList();
     }
 
     // 일반 검색/ 필터링에서 사용하는 Converter
     public static List<MemberStatPreferenceDetailColorDTO> toMemberStatPreferenceDetailColorDTOList(
         MemberStat memberStat, MemberStat criteriaMemberStat, List<String> preferences
-    ){
-        Map<String, Object> memberStatMap = MemberStatUtil.getMemberStatFields(memberStat, preferences);
-        Map<String, Object> criteriaMemberStatMap = MemberStatUtil.getMemberStatFields(criteriaMemberStat, preferences);
+    ) {
+        Map<String, Object> memberStatMap = MemberStatUtil.getMemberStatFields(memberStat,
+            preferences);
+        Map<String, Object> criteriaMemberStatMap = MemberStatUtil.getMemberStatFields(
+            criteriaMemberStat, preferences);
 
         return memberStatMap.entrySet().stream()
-            .map(entry->
+            .map(entry ->
                 MemberStatConverter.toMemberStatPreferenceDetailColorDTO(
-                    entry.getKey(), entry.getValue(), MemberStatUtil.compareField(entry.getValue(), criteriaMemberStatMap.get(entry.getKey())
+                    entry.getKey(), entry.getValue(), MemberStatUtil.compareField(entry.getValue(),
+                        criteriaMemberStatMap.get(entry.getKey())
                     ))).toList();
     }
 
-    public static MemberStatPreferenceDetailColorDTO toMemberStatPreferenceDetailColorDTO(String stat, Object value, DifferenceStatus color){
+    public static List<MemberStatPreferenceDetailColorDTO> toMemberStatPreferenceDetailWithoutColorDTOList(
+        MemberStat memberStat, List<String> preferences) {
+        Map<String, Object> memberStatMap = MemberStatUtil.getMemberStatFields(memberStat,
+            preferences);
+
+        return memberStatMap.entrySet().stream()
+            .map(entry -> MemberStatConverter.toMemberStatPreferenceDetailWithoutColorDTO(
+                entry.getKey(), entry.getValue()))
+            .toList();
+    }
+
+    public static MemberStatPreferenceDetailColorDTO toMemberStatPreferenceDetailColorDTO(
+        String stat, Object value, DifferenceStatus color) {
         return MemberStatPreferenceDetailColorDTO.builder()
             .stat(stat)
             .value(value)
             .color(color.getValue())
+            .build();
+    }
+
+    public static MemberStatPreferenceDetailColorDTO toMemberStatPreferenceDetailWithoutColorDTO(
+        String stat, Object value) {
+        return MemberStatPreferenceDetailColorDTO.builder()
+            .stat(stat)
+            .value(value)
             .build();
     }
 
@@ -242,7 +272,7 @@ public class MemberStatConverter {
 
     public static MemberStatSearchResponseDTO toMemberStatSearchResponseDTO(
         Member member, Integer equality
-    ){
+    ) {
         return MemberStatSearchResponseDTO.builder()
             .memberDetail(MemberConverter.toMemberDetailResponseDTOFromEntity(member))
             .equality(equality)


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. 멤버 스탯 없는 사용자가 다른 사용자를 찜하는 것 허용
2. 멤버 스탯 없는 사용자가 찜한 사용자 목록 조회하는 경우 로직 추가
3. 멤버 스탯 없는 사용자가 찜한 방 조회할 때 count 값을 0 말고 null로 반환

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

멤버 스탯 없는 테스트 계정으로 사용자 찜하기
<img width="300" alt="image" src="https://github.com/user-attachments/assets/41f33047-aaa3-4fdc-a757-4e79cd88ebde">

찜한 사용자 목록 조회 결과
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2a37a0ae-ba51-483d-aab9-b7d1d91384ef">

찜한 방 목록 조회 결과
<img width="300" alt="image" src="https://github.com/user-attachments/assets/35fd2789-2841-4cd2-a478-9ed29e93677b">

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
