### PR TITLE
[COZY-440] fix: 사용자 탈퇴시 탈퇴사유 요청받아서 메일 보내기

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/controller/MailController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/controller/MailController.java
@@ -9,6 +9,7 @@ import com.cozymate.cozymate_server.domain.mail.service.MailService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members/mail")
+@Slf4j
 public class MailController {
 
     private final MailService mailService;
@@ -60,6 +62,16 @@ public class MailController {
     ) {
         return ResponseEntity.ok(
             ApiResponse.onSuccess(mailService.isVerified(memberDetails.member())));
+    }
+
+    @PostMapping("/test")
+    @Operation(summary = "[말즈] 관리자 메일 테스트", description = "관리자에게 메일 보내기 테스트")
+    @Deprecated
+    public ResponseEntity<ApiResponse<Boolean>> testMail(
+    ) {
+        log.info("controller 진입 성공");
+        mailService.sendCustomMailToAdmin("제목", "내용");
+        return ResponseEntity.ok(ApiResponse.onSuccess(true));
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.mail.service;
 
 
 import com.cozymate.cozymate_server.domain.auth.dto.TokenResponseDTO;
+import com.cozymate.cozymate_server.domain.auth.service.AuthService;
 import com.cozymate.cozymate_server.domain.auth.userdetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.mail.MailAuthentication;
 import com.cozymate.cozymate_server.domain.mail.converter.MailConverter;
@@ -10,7 +11,7 @@ import com.cozymate.cozymate_server.domain.mail.dto.request.VerifyRequestDTO;
 import com.cozymate.cozymate_server.domain.mail.dto.response.VerifyResponseDTO;
 import com.cozymate.cozymate_server.domain.mail.repository.MailRepository;
 import com.cozymate.cozymate_server.domain.member.Member;
-import com.cozymate.cozymate_server.domain.member.service.MemberCommandService;
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 import com.cozymate.cozymate_server.domain.university.University;
 import com.cozymate.cozymate_server.domain.university.repository.UniversityRepository;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
@@ -26,6 +27,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -40,8 +42,15 @@ public class MailService {
     private static final Integer MAIL_AUTHENTICATION_EXPIRED_TIME = 30;
     private final JavaMailSender mailSender;
     private final MailRepository mailRepository;
-    private final MemberCommandService memberCommandService;
+    private final MemberRepository memberRepository;
     private final UniversityRepository universityRepository;
+    private final AuthService authService;
+
+    @Value("${spring.mail.username}")
+    private static final String ADMIN_MAIL_USERNAME = "qnfn120";
+
+    private static final String ADMIN_MAIL_DOMAIN = "@gmail.com"; // 관리자 이메일 주소
+
 
     @Transactional
     public void sendUniversityAuthenticationCode(MemberDetails memberDetails,
@@ -61,24 +70,39 @@ public class MailService {
     @Transactional
     public VerifyResponseDTO verifyMemberUniversity(MemberDetails memberDetails,
         VerifyRequestDTO verifyDTO) {
-        Member member = memberDetails.member();
+        University memberUniversity = universityRepository.findById(verifyDTO.universityId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
 
-        verifyAuthenticationCode(member, verifyDTO.code());
+        memberDetails.member().verifyMemberUniversity(memberUniversity, verifyDTO.majorName());
+        memberRepository.save(memberDetails.member());
 
-        TokenResponseDTO tokenResponseDTO = memberCommandService.verifyMemberUniversity(
-            memberDetails,
-            verifyDTO.universityId(),
-            verifyDTO.majorName());
+        TokenResponseDTO tokenResponseDTO = authService.generateMemberTokenDTO(memberDetails);
         return MailConverter.toVerifyResponseDTO(tokenResponseDTO);
     }
 
     public String isVerified(Member member) {
         Optional<MailAuthentication> mailAuthentication = mailRepository.findById(member.getId());
 
-        if (mailAuthentication.isPresent() && Boolean.TRUE.equals(mailAuthentication.get().getIsVerified())) {
+        if (mailAuthentication.isPresent() && Boolean.TRUE.equals(
+            mailAuthentication.get().getIsVerified())) {
             return mailAuthentication.get().getMailAddress();
         }
         return "";
+    }
+
+    public void sendCustomMailToAdmin(String subject, String content) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(ADMIN_MAIL_USERNAME + ADMIN_MAIL_DOMAIN);
+            helper.setSubject(subject);
+            helper.setText(content, true); // 전달받은 content를 그대로 전송
+            mailSender.send(message);
+
+        } catch (MessagingException e) {
+            throw new GeneralException(ErrorStatus._MAIL_SEND_FAIL);
+        }
     }
 
     private void verifyAuthenticationCode(Member member, String requestCode) {
@@ -101,13 +125,14 @@ public class MailService {
         mailAuthentication.verify();
     }
 
-    private MailAuthentication createAndSendMail(Long memberId, String mailAddress, String universityName) {
+    private MailAuthentication createAndSendMail(Long memberId, String mailAddress,
+        String universityName) {
 
         String authenticationCode = Base64.getEncoder()
             .encodeToString(UUID.randomUUID().toString().getBytes())
             .substring(0, 6);
 
-        String emailBody = makeMailBody(authenticationCode,universityName);
+        String emailBody = makeMailBody(authenticationCode, universityName);
 
         try {
             MimeMessage message = mailSender.createMimeMessage();
@@ -120,7 +145,7 @@ public class MailService {
 
             return MailConverter.toMailAuthenticationWithParams(memberId, mailAddress,
                 authenticationCode, false);
-        }catch (MessagingException e){
+        } catch (MessagingException e) {
             throw new GeneralException(ErrorStatus._MAIL_SEND_FAIL);
         }
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.cozymate.cozymate_server.domain.member.controller;
 import com.cozymate.cozymate_server.domain.auth.userdetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.member.dto.request.SignInRequestDTO;
 import com.cozymate.cozymate_server.domain.member.dto.request.SignUpRequestDTO;
+import com.cozymate.cozymate_server.domain.member.dto.request.WithdrawRequestDTO;
 import com.cozymate.cozymate_server.domain.member.dto.response.MemberDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.member.dto.response.SignInResponseDTO;
 import com.cozymate.cozymate_server.domain.member.service.MemberCommandService;
@@ -171,8 +172,9 @@ public class MemberController {
     @Operation(summary = "[말즈] 회원 탈퇴 API", description = "현재 로그인한 사용자를 탈퇴시킵니다.")
     @DeleteMapping("/withdraw")
     public ResponseEntity<ApiResponse<String>> withdraw(
-        @AuthenticationPrincipal MemberDetails memberDetails) {
-        memberCommandService.withdraw(memberDetails);
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @Valid WithdrawRequestDTO withdrawRequestDTO) {
+        memberCommandService.withdraw(withdrawRequestDTO,memberDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다."));
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/dto/request/WithdrawRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/dto/request/WithdrawRequestDTO.java
@@ -1,0 +1,9 @@
+package com.cozymate.cozymate_server.domain.member.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+
+public record WithdrawRequestDTO(
+    @Length(max = 100, message = "탈퇴 사유는 최대 100자")
+    String withdrawReason
+) {
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/utils/SwaggerFilter.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/utils/SwaggerFilter.java
@@ -39,6 +39,7 @@ public class SwaggerFilter implements Filter {
         }
         Cookie cookie = new Cookie("JWT", jwtUtil.generateAdminToken()); // 쿠키 이름 및 값 설정
         cookie.setHttpOnly(true); // 클라이언트 측 스크립트에서 쿠키를 접근하지 못하게 함
+        cookie.setSecure(true);
         cookie.setPath("/"); // 쿠키의 유효 범위 설정
         cookie.setMaxAge(3600); // 쿠키의 만료 시간 설정 (예: 1시간)
         httpResponse.addCookie(cookie); // 응답에 쿠키 추가


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
사용자 탈퇴 탈퇴 사유 받아서 메일을 보냅니다
Request Body에 string 하나 추가했고 관리자에게 메일 보내는 기능을 추가했습니다.
메일 보내는 test api 하나 추가해서 메일 보내보고 `@Deprecated` 처리 했습니다.
관리자 토큰 만들때 cors오류 방지로 https로 바꿨습니다

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요
![image](https://github.com/user-attachments/assets/26d4f203-25ce-4277-a113-400071a4d7b9)

## 💬 리뷰 요구사항(선택)
일단 메일은 제 메일을 사용하고 ses로 메일인증쪽 고도화 하면서 수정하겠습니다.

문의나, 신고도 굳이 DB에 저장할거 없이 관리자에게 메일 보내는 방식으로 수정하는게 어떨까 싶습니다. @veronees 
