### PR TITLE
[COZY-448] fix : 메일 인증 시 혼동 문자 제거

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -46,10 +46,10 @@ public class MailService {
     private final UniversityRepository universityRepository;
     private final AuthService authService;
 
-    @Value("${spring.mail.username}")
-    private static final String ADMIN_MAIL_USERNAME = "cozymate0";
 
-    private static final String ADMIN_MAIL_DOMAIN = "@gmail.com"; // 관리자 이메일 주소
+    private static final String ADMIN_MAIL_ADDRESS = "cozymate0@gmail.com"; // 관리자 이메일 주소
+
+    private static final String CONFUSION_CHARACTERS = "[IlOo0]";
 
 
     @Transactional
@@ -95,7 +95,7 @@ public class MailService {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
-            helper.setTo(ADMIN_MAIL_USERNAME + ADMIN_MAIL_DOMAIN);
+            helper.setTo(ADMIN_MAIL_ADDRESS);
             helper.setSubject(subject);
             helper.setText(content, true); // 전달받은 content를 그대로 전송
             mailSender.send(message);
@@ -130,6 +130,7 @@ public class MailService {
 
         String authenticationCode = Base64.getEncoder()
             .encodeToString(UUID.randomUUID().toString().getBytes())
+            .replaceAll(CONFUSION_CHARACTERS, "") // 제외할 문자 제거
             .substring(0, 6);
 
         String emailBody = makeMailBody(authenticationCode, universityName);


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네
## #️⃣ 작업 내용
메일 인증 시 혼동 문자 `IlOo0` 을 제외하고 코드를 생성합니다.
이게 다에요 진짜

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
