### PR TITLE
[COZY-449] fix: 쪽지 내용 앞뒤 공백 trim 처리

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatCommandService.java
@@ -38,7 +38,7 @@ public class ChatCommandService {
             recipient);
 
         if (findChatRoom.isPresent()) {
-            saveChat(findChatRoom.get(), sender, createChatRequestDTO.content().trim());
+            saveChat(findChatRoom.get(), sender, createChatRequestDTO.content());
 
             return ChatRoomConverter.toChatRoomIdResponseDTO(findChatRoom.get().getId());
         } else {
@@ -57,7 +57,7 @@ public class ChatCommandService {
     }
 
     private void saveChat(ChatRoom chatRoom, Member sender, String content) {
-        Chat chat = ChatConverter.toEntity(chatRoom, sender, content);
+        Chat chat = ChatConverter.toEntity(chatRoom, sender, content.trim());
         chatRepository.save(chat);
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatCommandService.java
@@ -38,7 +38,7 @@ public class ChatCommandService {
             recipient);
 
         if (findChatRoom.isPresent()) {
-            saveChat(findChatRoom.get(), sender, createChatRequestDTO.content());
+            saveChat(findChatRoom.get(), sender, createChatRequestDTO.content().trim());
 
             return ChatRoomConverter.toChatRoomIdResponseDTO(findChatRoom.get().getId());
         } else {

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/converter/ChatRoomConverter.java
@@ -21,7 +21,7 @@ public class ChatRoomConverter {
         Long chatRoomId, Integer persona, Long memberId, boolean hasNewChat) {
         return ChatRoomDetailResponseDTO.builder()
             .nickname(nickname)
-            .lastContent(content)
+            .lastContent(content.trim())
             .chatRoomId(chatRoomId)
             .persona(persona)
             .memberId(memberId)


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

- 쪽지 내용 앞뒤 공백 trim 처리

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

수정 전 쪽지방 목록 조회
<img width="165" alt="image" src="https://github.com/user-attachments/assets/15d0a0a6-3454-4128-9d03-c83cf81d511e" />

수정 후 쪽지방 목록 조회
<img width="182" alt="image" src="https://github.com/user-attachments/assets/b688373b-bf43-4fce-a8cd-10295ca00d70" />

---

쪽지 작성 시
<img width="297" alt="image" src="https://github.com/user-attachments/assets/61c0ed3b-f327-4713-b269-2003efa96cac" />

db 저장 상태 - trim 처리
<img width="1321" alt="image" src="https://github.com/user-attachments/assets/3e93b617-e82d-43a0-b9d7-57c98ef73867" />



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
