### PR TITLE
[COZY-460] fix : 탈퇴시 -> 방 나가기 -> 빈 방인 경우 삭제 로직 수정 

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
@@ -105,6 +105,12 @@ public class JwtFilter extends OncePerRequestFilter {
             MDC.put(MdcKey.USER_ID.name(), userName);
             UserDetails userDetails = userDetailsService.loadUserByUsername(userName);
 
+            if (jwtUtil.equalsTokenTypeWith(jwt, TokenType.ACCESS)){
+                if (userDetails.getAuthorities() == null || userDetails.getAuthorities().isEmpty()){
+                    throw new RuntimeException(ErrorStatus._TOKEN_AUTHORIZATION_EMPTY.getMessage());
+                }
+            }
+
             // 임시 토큰일 경우, 접근을 제한할 URL 목록에 대한 접근 여부 확인
             if (jwtUtil.equalsTokenTypeWith(jwt, TokenType.TEMPORARY)) {
                 if (isNotAllowTemporary(request)) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -95,4 +95,7 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     @Query("select mt from Mate mt join fetch mt.member m join fetch m.memberStat where mt.entryStatus = :entryStatus")
     List<Mate> findAllFetchMemberAndMemberStatByEntryStatus(@Param("entryStatus") EntryStatus entryStatus);
 
+
+    void deleteAllByRoomId(Long roomId);
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -96,6 +97,7 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     List<Mate> findAllFetchMemberAndMemberStatByEntryStatus(@Param("entryStatus") EntryStatus entryStatus);
 
 
-    void deleteAllByRoomId(Long roomId);
-
+    @Modifying
+    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    void deleteAllByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -94,10 +94,11 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
         @Param("entryStatus") EntryStatus entryStatus);
 
     @Query("select mt from Mate mt join fetch mt.member m join fetch m.memberStat where mt.entryStatus = :entryStatus")
-    List<Mate> findAllFetchMemberAndMemberStatByEntryStatus(@Param("entryStatus") EntryStatus entryStatus);
+    List<Mate> findAllFetchMemberAndMemberStatByEntryStatus(
+        @Param("entryStatus") EntryStatus entryStatus);
 
 
     @Modifying
-    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    @Query("DELETE FROM Mate m WHERE m.room.id = :roomId")
     void deleteAllByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberCommandService.java
@@ -154,7 +154,8 @@ public class MemberCommandService {
      * @param memberDetails 사용자 세부 정보
      */
     public void withdraw(WithdrawRequestDTO withdrawRequestDTO, MemberDetails memberDetails) {
-        String withdrawReason = withdrawRequestDTO.withdrawReason();
+        String withdrawReason = memberDetails.member().getNickname() + "님의 탈퇴 사유 입니다."
+            + withdrawRequestDTO.withdrawReason();
         String mailSubject = memberDetails.member().getNickname() + "탈퇴 사유";
 
         mailService.sendCustomMailToAdmin(mailSubject, withdrawReason);

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
@@ -83,7 +83,6 @@ public class MemberWithdrawService {
 
     @Transactional
     public void deleteRelatedWithMember(Member member) {
-        log.debug("사용자 관련 데이터 삭제 시작");
         tokenRepository.deleteById(member.getClientId());
         mailRepository.deleteById(member.getId());
         log.debug("토큰,메일 삭제 완료");

--- a/src/main/java/com/cozymate/cozymate_server/domain/role/repository/RoleRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/role/repository/RoleRepository.java
@@ -15,4 +15,7 @@ public interface RoleRepository extends JpaRepository<Role, Long> {
     void deleteByMateId(Long mateId);
 
     List<Role> findAllByMateId(Long mateId);
+
+    void deleteAllByRoomId(Long roomId);
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/role/repository/RoleRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/role/repository/RoleRepository.java
@@ -17,6 +17,6 @@ public interface RoleRepository extends JpaRepository<Role, Long> {
     List<Role> findAllByMateId(Long mateId);
 
     @Modifying
-    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    @Query("DELETE FROM Role r WHERE r.room.id  = :roomId")
     void deleteAllByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/role/repository/RoleRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/role/repository/RoleRepository.java
@@ -16,6 +16,7 @@ public interface RoleRepository extends JpaRepository<Role, Long> {
 
     List<Role> findAllByMateId(Long mateId);
 
-    void deleteAllByRoomId(Long roomId);
-
+    @Modifying
+    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    void deleteAllByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -261,13 +261,15 @@ public class RoomCommandService {
 
     private void deleteRoomDatas(Long roomId) {
         List<Mate> mates = mateRepository.findByRoomId(roomId);
-        for (Mate mate : mates) {
-            roleRepository.deleteByMateId(mate.getId());
-            todoRepository.deleteByMateId(mate.getId());
-        }
-        mateRepository.deleteByRoomId(roomId);
-        ruleRepository.deleteByRoomId(roomId);
-        roomLogRepository.deleteByRoomId(roomId);
+//        for (Mate mate : mates) {
+//            roleRepository.deleteByMateId(mate.getId());
+//            todoRepository.deleteByMateId(mate.getId());
+//        }
+        roomLogRepository.deleteAllByRoomId(roomId);
+        todoRepository.deleteAllByRoomId(roomId);
+        roleRepository.deleteAllByRoomId(roomId);
+        mateRepository.deleteAllByRoomId(roomId);
+        ruleRepository.deleteAllByRoomId(roomId);
 
         // 피드 삭제 로직
         if (feedRepository.existsByRoomId(roomId)) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
@@ -26,7 +26,7 @@ public interface RoomLogRepository extends JpaRepository<RoomLog, Long> {
     void bulkDeleteTodo(@Param("todo") Todo todo);
 
     @Modifying
-    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    @Query("DELETE FROM RoomLog r WHERE r.room.id  = :roomId")
     void deleteAllByRoomId(@Param("roomId") Long roomId);
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
@@ -25,4 +25,6 @@ public interface RoomLogRepository extends JpaRepository<RoomLog, Long> {
     @Query("UPDATE RoomLog rl SET rl.todo = null WHERE rl.todo = :todo")
     void bulkDeleteTodo(@Param("todo") Todo todo);
 
+    void deleteAllByRoomId(Long roomId);
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomlog/repository/RoomLogRepository.java
@@ -25,6 +25,8 @@ public interface RoomLogRepository extends JpaRepository<RoomLog, Long> {
     @Query("UPDATE RoomLog rl SET rl.todo = null WHERE rl.todo = :todo")
     void bulkDeleteTodo(@Param("todo") Todo todo);
 
-    void deleteAllByRoomId(Long roomId);
+    @Modifying
+    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    void deleteAllByRoomId(@Param("roomId") Long roomId);
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/repository/RuleRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/repository/RuleRepository.java
@@ -11,4 +11,7 @@ public interface RuleRepository extends JpaRepository<Rule, Long> {
     Integer countAllByRoomId(Long roomId);
 
     void deleteByRoomId(Long roomId);
+
+    void deleteAllByRoomId(Long roomId);
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/repository/RuleRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/repository/RuleRepository.java
@@ -3,6 +3,9 @@ package com.cozymate.cozymate_server.domain.rule.repository;
 import com.cozymate.cozymate_server.domain.rule.Rule;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RuleRepository extends JpaRepository<Rule, Long> {
 
@@ -12,6 +15,7 @@ public interface RuleRepository extends JpaRepository<Rule, Long> {
 
     void deleteByRoomId(Long roomId);
 
-    void deleteAllByRoomId(Long roomId);
-
+    @Modifying
+    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    void deleteAllByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/rule/repository/RuleRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/rule/repository/RuleRepository.java
@@ -16,6 +16,6 @@ public interface RuleRepository extends JpaRepository<Rule, Long> {
     void deleteByRoomId(Long roomId);
 
     @Modifying
-    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    @Query("DELETE FROM Rule r WHERE r.room.id = :roomId")
     void deleteAllByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
@@ -27,5 +27,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findAllByRoomId(Long roomId);
 
     @Modifying
-    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
-    void deleteAllByRoomId(@Param("roomId") Long roomId);}
+    @Query("DELETE FROM Todo t WHERE t.room.id = :roomId")
+    void deleteAllByRoomId(@Param("roomId") Long roomId);
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
@@ -25,4 +25,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     void deleteAllByRoleId(Long roleId);
 
     List<Todo> findAllByRoomId(Long roomId);
+
+    void deleteAllByRoomId(Long roomId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/repository/TodoRepository.java
@@ -26,5 +26,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     List<Todo> findAllByRoomId(Long roomId);
 
-    void deleteAllByRoomId(Long roomId);
-}
+    @Modifying
+    @Query("DELETE FROM RoomLog r WHERE r.roomId = :roomId")
+    void deleteAllByRoomId(@Param("roomId") Long roomId);}

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -40,6 +40,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _TOKEN_INVALID(HttpStatus.BAD_REQUEST, "TOKEN401", "토큰이 유효하지 않습니다."),
     _TEMPORARY_TOKEN_ACCESS_DENIED_(HttpStatus.BAD_REQUEST, "TOKEN402", "임시토큰으로 접근 할 수 없습니다."),
     _REFRESH_TOKEN_ACCESS_DENIED_(HttpStatus.BAD_REQUEST, "TOKEN403", "refresh 토큰으로 접근 할 수 없습니다."),
+    _TOKEN_AUTHORIZATION_EMPTY(HttpStatus.BAD_REQUEST, "TOKEN404", "사용자 권한이 비어있습니다."),
 
 
     // S3 관련


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
빈방인 경우 방을 삭제하는 로직을 수정했습니다.
- roomlog-> todo -> role -> mate -> rule 순서
- 삭제할때 쿼리를 하나씩 날리지 않도록 벌크연산으로 수정했습니다.
- 탈퇴한 사용자의 토큰이 유효합니다.(access token 은 저장 안함)
- 토큰으로 탈퇴한 사용자를 load하면 권한 배열이 비어있기 때문에 권한이 비어있는 경우에 대해 예외를 처리했습니다.

## 동작 확인
> 이미 탈퇴를 시켜버려서.. 디비보면 저랑 델로가 없을거에여 리뷰한 사이에 생겼을지도..?

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
