### PR TITLE
[COZY-467] fix: Todo 완료시 알림 전송 에러 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -101,4 +101,15 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     @Modifying
     @Query("DELETE FROM Mate m WHERE m.room.id = :roomId")
     void deleteAllByRoomId(@Param("roomId") Long roomId);
+
+    /**
+     * TODO에서 Mate를 가져와서 Mate 데이터와 Member를 사용해야하는데 지연 로딩 문제로 Member가 Proxy 에러가 발생하여 다음과 같이 Fetch Join을 사용함
+     * 내가 완료하지 못한 데이터가 있는지 확인하고, 모두 완료했으면 룸메이트에게 FCM 알림을 보내기 위함
+     */
+    @Query("""
+    SELECT mt FROM Mate mt
+    JOIN FETCH mt.member m
+    WHERE mt.room.id = :roomId AND mt.id != :mateId
+    """)
+    List<Mate> findByRoomIdAndNotMateId(@Param("roomId") Long roomId, @Param("mateId") Long mateId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
@@ -207,7 +207,8 @@ public class TodoCommandService {
         List<Todo> todoList = todoRepository.findAllByRoomIdAndTimePoint(mate.getRoom().getId(),
             now);
 
-        List<Mate> mateList = mateRepository.findByRoomId(mate.getRoom().getId());
+        List<Mate> mateList = mateRepository.findByRoomIdAndNotMateId(mate.getRoom().getId(),
+            mate.getId());
 
         // 모든 투두중 내가 할당되었는데, 완료되지 않은 투두가 있는지 확인
         if (todoList.stream().filter(


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

네

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

기존에 Todo 완료시 FCM이 제대로 전송되지 않는 에러가 있엇는데, 해당 에러를 해결했습니다.
아래의 에러가 발생했습니다.
해당 원인은 Mate를 가져올 때 Member를 지연 로딩을 통해 가져와야하는데, 가져오지 못하는 문제였고,
Fetch join을 사용하여 해결했습니다.

<img width="1329" alt="SCR-20250110-ohpx" src="https://github.com/user-attachments/assets/05f6ef91-9639-469f-ad35-d7c02e658fc4" />



## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요
아래처럼 수정이 완료되었습니다.

<img width="1532" alt="SCR-20250110-ohhs" src="https://github.com/user-attachments/assets/e8ca0737-8933-4625-8a2b-dd4bb8c4e350" />



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
