### PR TITLE
[COZY-472] fix : 메일 인증 오류 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -54,24 +54,24 @@ public class MailService {
 
     @Transactional
     public void sendUniversityAuthenticationCode(MemberDetails memberDetails,
-                                                 MailSendRequestDTO sendDTO) {
+        MailSendRequestDTO sendDTO) {
         University university = universityRepository.findById(sendDTO.universityId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
+            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
 
         String mailAddress = sendDTO.mailAddress();
         validateMailAddress(mailAddress, university.getMailPattern());
 
         MailAuthentication mailAuthentication = createAndSendMail(memberDetails.member().getId(),
-                mailAddress, university.getName());
+            mailAddress, university.getName());
 
         mailRepository.save(mailAuthentication);
     }
 
     @Transactional
     public VerifyResponseDTO verifyMemberUniversity(MemberDetails memberDetails,
-                                                    VerifyRequestDTO verifyDTO) {
+        VerifyRequestDTO verifyDTO) {
         University memberUniversity = universityRepository.findById(verifyDTO.universityId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
+            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
 
         memberDetails.member().verifyMemberUniversity(memberUniversity, verifyDTO.majorName());
         memberRepository.save(memberDetails.member());
@@ -82,17 +82,10 @@ public class MailService {
     }
 
     public String isVerified(Member member) {
-//        if(Role.USER_VERIFIED.equals(member.getRole())) {
-//            Optional<MailAuthentication> mailAuthentication = mailRepository.findById(
-//                member.getId());
-//            if (mailAuthentication.isPresent()){
-//                return mailAuthentication.get().getMailAddress();
-//            }
-//        }
         Optional<MailAuthentication> mailAuthentication = mailRepository.findById(
-                member.getId());
+            member.getId());
         if (mailAuthentication.isPresent() && Boolean.TRUE.equals(
-                mailAuthentication.get().getIsVerified())) {
+            mailAuthentication.get().getIsVerified())) {
             return mailAuthentication.get().getMailAddress();
         }
         return "";
@@ -116,12 +109,12 @@ public class MailService {
     private void verifyAuthenticationCode(Member member, String requestCode) {
 
         MailAuthentication mailAuthentication = mailRepository.findById(member.getId())
-                .orElseThrow(() -> new GeneralException(
-                        ErrorStatus._MAIL_AUTHENTICATION_NOT_FOUND));
+            .orElseThrow(() -> new GeneralException(
+                ErrorStatus._MAIL_AUTHENTICATION_NOT_FOUND));
         // 만료 시간 초과 여부 확인
         if (LocalDateTime.now()
-                .isAfter(
-                        mailAuthentication.getUpdatedAt().plusMinutes(MAIL_AUTHENTICATION_EXPIRED_TIME))) {
+            .isAfter(
+                mailAuthentication.getUpdatedAt().plusMinutes(MAIL_AUTHENTICATION_EXPIRED_TIME))) {
             throw new GeneralException(ErrorStatus._MAIL_AUTHENTICATION_CODE_EXPIRED);
         }
 
@@ -134,16 +127,16 @@ public class MailService {
     }
 
     private MailAuthentication createAndSendMail(Long memberId, String mailAddress,
-                                                 String universityName) {
+        String universityName) {
         if (mailAddress.equals("test123@inha.edu")) {
             return MailConverter.toMailAuthenticationWithParams(memberId, mailAddress, "123456",
-                    false);
+                false);
         } // 애플심사를 위한 테스트 메일 인증
 
         String authenticationCode = Base64.getEncoder()
-                .encodeToString(UUID.randomUUID().toString().getBytes())
-                .replaceAll(CONFUSION_CHARACTERS, "") // 제외할 문자 제거
-                .substring(0, 6);
+            .encodeToString(UUID.randomUUID().toString().getBytes())
+            .replaceAll(CONFUSION_CHARACTERS, "") // 제외할 문자 제거
+            .substring(0, 6);
 
         String emailBody = makeMailBody(authenticationCode, universityName);
 
@@ -157,7 +150,7 @@ public class MailService {
             mailSender.send(message);
 
             return MailConverter.toMailAuthenticationWithParams(memberId, mailAddress,
-                    authenticationCode, false);
+                authenticationCode, false);
         } catch (MessagingException e) {
             throw new GeneralException(ErrorStatus._MAIL_SEND_FAIL);
         }
@@ -165,7 +158,7 @@ public class MailService {
 
     private void validateMailAddress(String mailAddress, String mailPattern) {
         Optional<MailAuthentication> mailAuthentication = mailRepository.findByMailAddress(
-                mailAddress);
+            mailAddress);
 
         if (!mailAddress.contains(mailPattern)) {
             throw new GeneralException(ErrorStatus._INVALID_MAIL_ADDRESS_DOMAIN);
@@ -178,7 +171,7 @@ public class MailService {
     private String makeMailBody(String authenticationCode, String universityName) {
         try {
             InputStream inputStream = getClass().getClassLoader().getResourceAsStream(
-                    "mail/mail_form.html");
+                "mail/mail_form.html");
 
             if (inputStream == null) {
                 throw new GeneralException(ErrorStatus._CANNOT_FIND_MAIL_FORM);
@@ -186,7 +179,7 @@ public class MailService {
             String template = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
 
             template = template.replace("{{universityName}}", universityName)
-                    .replace("{{authenticationCode}}", authenticationCode);
+                .replace("{{authenticationCode}}", authenticationCode);
 
             return template;
         } catch (IOException e) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -54,47 +54,47 @@ public class MailService {
 
     @Transactional
     public void sendUniversityAuthenticationCode(MemberDetails memberDetails,
-        MailSendRequestDTO sendDTO) {
+                                                 MailSendRequestDTO sendDTO) {
         University university = universityRepository.findById(sendDTO.universityId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
 
         String mailAddress = sendDTO.mailAddress();
         validateMailAddress(mailAddress, university.getMailPattern());
 
         MailAuthentication mailAuthentication = createAndSendMail(memberDetails.member().getId(),
-            mailAddress, university.getName());
+                mailAddress, university.getName());
 
         mailRepository.save(mailAuthentication);
     }
 
     @Transactional
     public VerifyResponseDTO verifyMemberUniversity(MemberDetails memberDetails,
-        VerifyRequestDTO verifyDTO) {
+                                                    VerifyRequestDTO verifyDTO) {
         University memberUniversity = universityRepository.findById(verifyDTO.universityId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._UNIVERSITY_NOT_FOUND));
 
         memberDetails.member().verifyMemberUniversity(memberUniversity, verifyDTO.majorName());
         memberRepository.save(memberDetails.member());
 
+        verifyAuthenticationCode(memberDetails.member(),verifyDTO.code());
         TokenResponseDTO tokenResponseDTO = authService.generateMemberTokenDTO(memberDetails);
         return MailConverter.toVerifyResponseDTO(tokenResponseDTO);
     }
 
     public String isVerified(Member member) {
-        if(Role.USER_VERIFIED.equals(member.getRole())) {
-            Optional<MailAuthentication> mailAuthentication = mailRepository.findById(
-                member.getId());
-            if (mailAuthentication.isPresent()){
-                return mailAuthentication.get().getMailAddress();
-            }
-        }
-        // TODO: 인증했을 때 getIsVerified가 변경되지 않아서 문제 발생 -> 일단 조치
-//        Optional<MailAuthentication> mailAuthentication = mailRepository.findById(
-//            member.getId());
-//        if (mailAuthentication.isPresent() && Boolean.TRUE.equals(
-//            mailAuthentication.get().getIsVerified())) {
-//            return mailAuthentication.get().getMailAddress();
+//        if(Role.USER_VERIFIED.equals(member.getRole())) {
+//            Optional<MailAuthentication> mailAuthentication = mailRepository.findById(
+//                member.getId());
+//            if (mailAuthentication.isPresent()){
+//                return mailAuthentication.get().getMailAddress();
+//            }
 //        }
+        Optional<MailAuthentication> mailAuthentication = mailRepository.findById(
+                member.getId());
+        if (mailAuthentication.isPresent() && Boolean.TRUE.equals(
+                mailAuthentication.get().getIsVerified())) {
+            return mailAuthentication.get().getMailAddress();
+        }
         return "";
     }
 
@@ -116,12 +116,12 @@ public class MailService {
     private void verifyAuthenticationCode(Member member, String requestCode) {
 
         MailAuthentication mailAuthentication = mailRepository.findById(member.getId())
-            .orElseThrow(() -> new GeneralException(
-                ErrorStatus._MAIL_AUTHENTICATION_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(
+                        ErrorStatus._MAIL_AUTHENTICATION_NOT_FOUND));
         // 만료 시간 초과 여부 확인
         if (LocalDateTime.now()
-            .isAfter(
-                mailAuthentication.getUpdatedAt().plusMinutes(MAIL_AUTHENTICATION_EXPIRED_TIME))) {
+                .isAfter(
+                        mailAuthentication.getUpdatedAt().plusMinutes(MAIL_AUTHENTICATION_EXPIRED_TIME))) {
             throw new GeneralException(ErrorStatus._MAIL_AUTHENTICATION_CODE_EXPIRED);
         }
 
@@ -134,16 +134,16 @@ public class MailService {
     }
 
     private MailAuthentication createAndSendMail(Long memberId, String mailAddress,
-        String universityName) {
+                                                 String universityName) {
         if (mailAddress.equals("test123@inha.edu")) {
             return MailConverter.toMailAuthenticationWithParams(memberId, mailAddress, "123456",
-                false);
+                    false);
         } // 애플심사를 위한 테스트 메일 인증
 
         String authenticationCode = Base64.getEncoder()
-            .encodeToString(UUID.randomUUID().toString().getBytes())
-            .replaceAll(CONFUSION_CHARACTERS, "") // 제외할 문자 제거
-            .substring(0, 6);
+                .encodeToString(UUID.randomUUID().toString().getBytes())
+                .replaceAll(CONFUSION_CHARACTERS, "") // 제외할 문자 제거
+                .substring(0, 6);
 
         String emailBody = makeMailBody(authenticationCode, universityName);
 
@@ -157,7 +157,7 @@ public class MailService {
             mailSender.send(message);
 
             return MailConverter.toMailAuthenticationWithParams(memberId, mailAddress,
-                authenticationCode, false);
+                    authenticationCode, false);
         } catch (MessagingException e) {
             throw new GeneralException(ErrorStatus._MAIL_SEND_FAIL);
         }
@@ -165,7 +165,7 @@ public class MailService {
 
     private void validateMailAddress(String mailAddress, String mailPattern) {
         Optional<MailAuthentication> mailAuthentication = mailRepository.findByMailAddress(
-            mailAddress);
+                mailAddress);
 
         if (!mailAddress.contains(mailPattern)) {
             throw new GeneralException(ErrorStatus._INVALID_MAIL_ADDRESS_DOMAIN);
@@ -178,7 +178,7 @@ public class MailService {
     private String makeMailBody(String authenticationCode, String universityName) {
         try {
             InputStream inputStream = getClass().getClassLoader().getResourceAsStream(
-                "mail/mail_form.html");
+                    "mail/mail_form.html");
 
             if (inputStream == null) {
                 throw new GeneralException(ErrorStatus._CANNOT_FIND_MAIL_FORM);
@@ -186,7 +186,7 @@ public class MailService {
             String template = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
 
             template = template.replace("{{universityName}}", universityName)
-                .replace("{{authenticationCode}}", authenticationCode);
+                    .replace("{{authenticationCode}}", authenticationCode);
 
             return template;
         } catch (IOException e) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -76,7 +76,7 @@ public class MailService {
         memberDetails.member().verifyMemberUniversity(memberUniversity, verifyDTO.majorName());
         memberRepository.save(memberDetails.member());
 
-        verifyAuthenticationCode(memberDetails.member(),verifyDTO.code());
+        verifyAuthenticationCode(memberDetails.member(), verifyDTO.code());
         TokenResponseDTO tokenResponseDTO = authService.generateMemberTokenDTO(memberDetails);
         return MailConverter.toVerifyResponseDTO(tokenResponseDTO);
     }


### PR DESCRIPTION
- 메일인증여부 엔티티의 is_verified 를 true 로 변경
- 메일 인증 여부 함수에서 메일 인증 엔티티의 is_verified 확인

# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용

- 메일인증여부 엔티티의 is_verified 를 true 로 변경
- 메일 인증 여부 함수에서 메일 인증 엔티티의 is_verified 확인

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

![메일인증api](https://github.com/user-attachments/assets/56245029-59ea-433e-8130-ca68e1710956)
메일인증 잘 보내집니다.

![메일인증성공](https://github.com/user-attachments/assets/34d2d10e-5419-4855-bb75-d3d17e7a6c4e)
메일 인증 성공한 사용자에 대해 인증이 잘 됐다고 하네요

![DB](https://github.com/user-attachments/assets/de2b03ba-69bc-4cfc-a5b8-3a2fcfbf91a7)
DB에도 반영이 잘 되어 있습니다.

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **버그 수정**
	- 메일 인증 코드 검증 로직 추가로 검증 프로세스 강화

- **리팩토링**
	- 메일 서비스 클래스의 검증 로직 단순화
	- 메서드 호출 및 조건문 간소화로 코드 흐름 개선

주요 변경사항은 메일 인증 프로세스의 기능을 강화하고 코드의 가독성을 높이는 데 중점을 두었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->