### PR TITLE
[COZY-473] fix: Room 조회시 Feed와 Hashtag로 인한 N+1 문제 에러 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/feed/Feed.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/feed/Feed.java
@@ -5,11 +5,9 @@ import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.global.utils.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,8 +26,8 @@ public class Feed extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "room_id", referencedColumnName = "id")
+    // LAZY 설정해도 room에 대한 프록시 정보를 확인하기 위해 EAGER로 동작함
+    @OneToOne(mappedBy = "feed")
     private Room room;
 
     @Column(length = 50)
@@ -38,7 +36,7 @@ public class Feed extends BaseTimeEntity {
     @Column(length = 200)
     private String description;
 
-    public void update(FeedRequestDTO feedRequestDTO){
+    public void update(FeedRequestDTO feedRequestDTO) {
         this.name = feedRequestDTO.getName();
         this.description = feedRequestDTO.getDescription();
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/Room.java
@@ -13,6 +13,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
@@ -60,7 +61,8 @@ public class Room extends BaseTimeEntity {
 
     private int numOfArrival = 1;
 
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "room")
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "feed_id", referencedColumnName = "id") // 외래 키 관리
     private Feed feed;
 
     public void arrive() {

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
@@ -7,6 +7,7 @@ import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
 import com.cozymate.cozymate_server.domain.room.enums.RoomType;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,10 +25,12 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
     Optional<Room> findByInviteCode(String inviteCode);
 
+    /**
+     * 사용자가
+     */
+    @EntityGraph(attributePaths = {"roomHashtags", "roomHashtags.hashtag"})
     @Query("""
-        SELECT r FROM Room r
-        JOIN FETCH r.roomHashtags rh
-        JOIN FETCH rh.hashtag h
+        SELECT distinct r FROM Room r
         WHERE r.roomType = :roomType
         AND r.status != :status
         AND r.maxMateNum > r.numOfArrival

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
@@ -26,6 +26,8 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
     @Query("""
         SELECT r FROM Room r
+        JOIN FETCH r.roomHashtags rh
+        JOIN FETCH rh.hashtag h
         WHERE r.roomType = :roomType
         AND r.status != :status
         AND r.maxMateNum > r.numOfArrival

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
@@ -26,7 +26,8 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     Optional<Room> findByInviteCode(String inviteCode);
 
     /**
-     * 사용자가
+     * 사용자에게 방 추천을 해줄 때 조회할 수 있는 방 목록을 보는 쿼리
+     * roomHashtags, hashtag로 인한 N+1 문제를 해결하기 위해 EntityGraph 사용
      */
     @EntityGraph(attributePaths = {"roomHashtags", "roomHashtags.hashtag"})
     @Query("""


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

넵

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

새벽에 Sentry로부터 알림이 왔습니다.

![image](https://github.com/user-attachments/assets/f09fc7cd-cca3-4334-89e3-d9c229260528)

그래서 확인해본 결과 다음과 같은 문제가 있었습니다.
1. Feed와 Room의 주종관계가 바뀌어있어서, OneToOne이지만, Room을 조회할 때마다 Feed도 쿼리를 통해 조회되고 있는 상태였습니다.
2. RoomHashtag가 Eager로 설정되어있는데, JPQL을 통해서 Room 데이터만 가져오니, RoomHashtag를 위해서 추가적인 쿼리를 날리는 상태였습니다.

따라서 이걸 해결하기 위해서 약간의 수정을 가미했습니다.
1. Feed는 현재 사용되지 않지만, 추후에 사용될 가능성이 있기 때문에, 일단 두고 있는 상태입니다. 따라서 OneToOne의 주종관계를 바꾸어 Room에서 Feed의 존재를 바로 확인할 수 있도록 하였습니다. - [문제 참고](https://jeong-pro.tistory.com/249)
2. RoomHashtag와 Hashtag에 대한 연관관계는 제가 맡은 도메인이 아니었기에 엔티티의 연관을 바꾸는 것보다, 쿼리를 변경하는 방식을 택했습니다. join fetch와 entitygraph를 사용하여, 연관된 데이터를 가져오도록 했습니다.


## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/4b222d76-f390-4312-be6e-ace5e3d23edf" />

위처럼 발생하던 N+1 문제를 해결하여

<img width="1153" alt="image" src="https://github.com/user-attachments/assets/53cef767-c4af-4f97-bafd-2953f163bb2c" />

아예 발생하지 않도록 했습니다.


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
	- 피드와 룸 엔티티 간의 관계 매핑 최적화
	- 데이터베이스 쿼리 성능 개선을 위한 엔티티 그래프 및 지연 로딩 전략 적용

- **성능 개선**
	- 중복 데이터 제거를 위해 쿼리 최적화
	- 룸 데이터 조회 시 N+1 문제 해결을 위한 최적화 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->