### PR TITLE
[COZY-479] fix : 학교 메일 인증 로직 제외

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/auth/utils/JwtFilter.java
@@ -46,7 +46,7 @@ public class JwtFilter extends OncePerRequestFilter {
     );
 
     private static final List<String> VERIFIED_URLS = List.of(
-        "/university/get-member-univ-info"
+//        "/university/get-member-univ-info"
     );
 
     private static final List<String> REFRESH_URLS = List.of("/auth/reissue");

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/controller/MailController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/controller/MailController.java
@@ -31,6 +31,7 @@ public class MailController {
         description = "request body :  <br>"
             + "mailAddress : 12345@inha.edu <br>"
             + "universityId : 1 <br>")
+    @Deprecated
     public ResponseEntity<Void> sendUniversityAuthenticationCode(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @RequestBody MailSendRequestDTO sendDTO
@@ -46,6 +47,7 @@ public class MailController {
             + " universityId : 1 <br>"
             + "response :"
             + " 토큰")
+    @Deprecated
     public ResponseEntity<ApiResponse<VerifyResponseDTO>> verifyMemberUniversity(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @RequestBody VerifyRequestDTO verifyDTO
@@ -57,6 +59,7 @@ public class MailController {
 
     @GetMapping("/verify")
     @Operation(summary = "[무빗] 메일 인증 여부 반환", description = "메일인증을 받은적이 없거나, 받았는데 인증 확인이 안된 경우 빈 문자열 반환, 메일 인증을 받고, 인증 확인이 된 경우 인증된 메일 주소 반환")
+    @Deprecated
     public ResponseEntity<ApiResponse<String>> isVerified(
         @AuthenticationPrincipal MemberDetails memberDetails
     ) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/converter/MemberConverter.java
@@ -29,7 +29,7 @@ public class MemberConverter {
             .birthDay(signUpRequestDTO.birthday())
             .persona(signUpRequestDTO.persona())
             .university(university)
-            .majorName("")
+            .majorName(signUpRequestDTO.majorName())
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/dto/request/SignUpRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/dto/request/SignUpRequestDTO.java
@@ -35,7 +35,11 @@ public record SignUpRequestDTO(
     Integer persona,
 
     @NotNull(message = "null일 수 없습니다.")
-    Long universityId
+    Long universityId,
+
+    @NotNull(message = "null일 수 없습니다.")
+    @NotEmpty(message = "비어 있을 수 없습니다.")
+    String majorName
 ) {
 
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
- 메일 인증 api deprecate
- 회원 가입 dto 에 학과이름 추가

## 동작 확인
![메일취소](https://github.com/user-attachments/assets/20459daf-7183-4145-a939-0d7ab9c6db8c)
deprecate

[회원가입](https://github.com/user-attachments/assets/c8e08f89-1df6-4a63-b210-f403694e4bfd)
회원가입 Request에 학과이름 추가

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 회원가입 시 전공명 추가 지원

- **사용되지 않는 기능**
  - 메일 관련 일부 메서드가 더 이상 사용되지 않음으로 표시됨

- **버그 수정**
  - JWT 필터의 URL 검증 로직 조정

이러한 변경사항은 애플리케이션의 회원가입 프로세스와 인증 메커니즘을 개선하기 위한 업데이트를 포함하고 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->