### PR TITLE
[COZY-484] fix: 방검색 필터링 조건 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
@@ -67,6 +67,6 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
         "AND r.maxMateNum > r.numOfArrival " +
         "AND member.university.id = :universityId " +
         "AND member.gender = :gender " +
-        "AND r.name LIKE %:keyword% ")
+        "AND LOWER(r.name) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     List<Room> findMatchingPublicRooms(String keyword, Long universityId, Gender gender);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -282,15 +282,24 @@ public class RoomQueryService {
         Long universityId = member.getUniversity().getId();
         Gender gender = member.getGender();
 
-        if (memberStatRepository.existsByMemberId(memberId)) {
-            List<Room> roomList = roomRepository.findMatchingPublicRooms(
-                keyword,
-                universityId,
-                gender,
-                member.getMemberStat().getNumOfRoommate(),
-                member.getMemberStat().getDormitoryName()
-            );
+//        if (memberStatRepository.existsByMemberId(memberId)) {
+//            List<Room> roomList = roomRepository.findMatchingPublicRooms(
+//                keyword,
+//                universityId,
+//                gender,
+//                member.getMemberStat().getNumOfRoommate(),
+//                member.getMemberStat().getDormitoryName()
+//            );
 
+        // 학교, 성별로만 필터링
+        List<Room> roomList = roomRepository.findMatchingPublicRooms(
+            keyword,
+            universityId,
+            gender
+        );
+
+        // memberstat 있는 경우 일치율 순으로 정렬
+        if (memberStatRepository.existsByMemberId(memberId)) {
             return roomList.stream()
                 .map(room -> {
                     List<Mate> joinedMates = mateRepository.findAllByRoomIdAndEntryStatus(room.getId(), EntryStatus.JOINED);
@@ -307,13 +316,7 @@ public class RoomQueryService {
                 .toList();
         }
 
-        // memberStat이 존재하지 않을 때
-        List<Room> roomList = roomRepository.findMatchingPublicRooms(
-            keyword,
-            universityId,
-            gender
-        );
-
+        // memberstat 없는 경우 가나다 순으로 정렬
         return roomList.stream()
             .map(room -> {
                 List<Mate> joinedMates = mateRepository.findAllByRoomIdAndEntryStatus(room.getId(), EntryStatus.JOINED);


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네
## #️⃣ 작업 내용
기존 방검색에서 학교, 성별 정보로만 필터링하도록 수정했습니다

## 동작 확인
memberstat 있을때 일치율순 정렬
![image](https://github.com/user-attachments/assets/801ca7e5-1edf-44fe-9dfb-0bdadda1c4cd)
memberstat 없을 때 가나다순 정렬
![image](https://github.com/user-attachments/assets/7b201d85-ecc1-47a0-9cd5-db3b59fd518a)


![image](https://github.com/user-attachments/assets/487ef944-a2d2-4f21-95b1-70d2f8081d54)
![image](https://github.com/user-attachments/assets/a11ecbe4-3ee5-44d1-af9a-f864d2242179)
영어로된 방의 경우 대소문자 구분 없이 검색되도록 수정했습니다
![image](https://github.com/user-attachments/assets/4ddb1f5f-1ade-415e-a8d0-68e49e6bfe07)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 룸 검색 기능 개선
	- 대소문자 구분 없는 룸 이름 검색 지원
	- 추가 검색 파라미터 (룸메이트 수, 기숙사 이름) 도입

- **버그 수정**
	- 검색 알고리즘의 유연성 향상
	- 검색 결과 정렬 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->