### PR TITLE
[COZY-488] test: Chat, ChatRoom 서비스 계층에 대한 단위 테스트

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryService.java
@@ -52,13 +52,21 @@ public class ChatQueryService {
     }
 
     private void checkMemberMisMatch(Member member, ChatRoom chatRoom) {
+        // ChatRoom의 MemberA가 null(탈퇴 회원)이고, 현재 요청 Member가 ChatRoom의 MemberB와 다른 경우
         if (Objects.isNull(chatRoom.getMemberA())
             && !member.getId().equals(chatRoom.getMemberB().getId())) {
             throw new GeneralException(ErrorStatus._CHATROOM_MEMBER_MISMATCH);
         }
 
+        // ChatRoom의 MemberB가 null(탈퇴 회원)이고, 현재 요청 Member가 ChatRoom의 MemberA와 다른 경우
         if (Objects.isNull(chatRoom.getMemberB())
             && !member.getId().equals(chatRoom.getMemberA().getId())) {
+            throw new GeneralException(ErrorStatus._CHATROOM_MEMBER_MISMATCH);
+        }
+
+        // ChatRoom의 두 Member가 모두 null(탈퇴 회원)이 아닌 경우, 현재 요청 Member가 MemberA, MemberB 둘다 아닌 경우
+        if (!member.getId().equals(chatRoom.getMemberA().getId())
+            && !member.getId().equals(chatRoom.getMemberB().getId())) {
             throw new GeneralException(ErrorStatus._CHATROOM_MEMBER_MISMATCH);
         }
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/ChatRoom.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/ChatRoom.java
@@ -40,12 +40,12 @@ public class ChatRoom extends BaseTimeEntity {
 
     private LocalDateTime memberBLastSeenAt;
 
-    public void updateMemberALastDeleteAt() {
-        this.memberALastDeleteAt = LocalDateTime.now();
+    public void updateMemberALastDeleteAt(LocalDateTime localDateTime) {
+        this.memberALastDeleteAt = localDateTime;
     }
 
-    public void updateMemberBLastDeleteAt() {
-        this.memberBLastDeleteAt = LocalDateTime.now();
+    public void updateMemberBLastDeleteAt(LocalDateTime localDateTime) {
+        this.memberBLastDeleteAt = localDateTime;
     }
     public boolean isEmpty() {
         return (this.memberA == null && this.memberB == null);

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
@@ -44,10 +44,10 @@ public class ChatRoomCommandService {
 
     private void softDeleteChatRoom(ChatRoom chatRoom, Long myId) {
         if (Objects.nonNull(chatRoom.getMemberA()) && chatRoom.getMemberA().getId().equals(myId)) {
-            chatRoom.updateMemberALastDeleteAt();
+            chatRoom.updateMemberALastDeleteAt(LocalDateTime.now());
         } else if (Objects.nonNull(chatRoom.getMemberB()) && chatRoom.getMemberB().getId()
             .equals(myId)) {
-            chatRoom.updateMemberBLastDeleteAt();
+            chatRoom.updateMemberBLastDeleteAt(LocalDateTime.now());
         } else {
             throw new GeneralException(ErrorStatus._CHATROOM_FORBIDDEN);
         }

--- a/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandService.java
@@ -32,10 +32,7 @@ public class ChatRoomCommandService {
     }
 
     public ChatRoomIdResponseDTO saveChatRoom(Member member, Member recipient) {
-        ChatRoom chatRoom = ChatRoom.builder()
-            .memberA(member)
-            .memberB(recipient)
-            .build();
+        ChatRoom chatRoom = ChatRoomConverter.toEntity(member, recipient);
 
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
 
@@ -57,22 +54,14 @@ public class ChatRoomCommandService {
         LocalDateTime memberALastDeleteAt = chatRoom.getMemberALastDeleteAt();
         LocalDateTime memberBLastDeleteAt = chatRoom.getMemberBLastDeleteAt();
 
-        // 멤버 둘다 해당 방을 나간 적이 있는 경우
+        // memberA or memberB 하나라도 null인 경우
+        if (Objects.isNull(chatRoom.getMemberA()) || Objects.isNull(chatRoom.getMemberB())) {
+            hardDeleteChatRoom(chatRoom);
+            return;
+        }
+
+        // 멤버 둘다 LastDeleteAt이 있는 경우
         if (canHardDeleteWhenBothLeft(memberALastDeleteAt, memberBLastDeleteAt, chatRoom)) {
-            hardDeleteChatRoom(chatRoom);
-            return;
-        }
-
-        // A는 해당 방을 나간적이 있고, B는 나간적은 없지만 null(탈퇴)인 경우
-        if (canHardDeleteWhenOneLeftAndOtherIsNull(memberALastDeleteAt, memberBLastDeleteAt,
-            chatRoom.getMemberB(), chatRoom)) {
-            hardDeleteChatRoom(chatRoom);
-            return;
-        }
-
-        // B는 해당 방을 나간적이 있고, A는 나간적이 없지만 (null)탈퇴인 경우
-        if (canHardDeleteWhenOneLeftAndOtherIsNull(memberBLastDeleteAt, memberALastDeleteAt,
-            chatRoom.getMemberA(), chatRoom)) {
             hardDeleteChatRoom(chatRoom);
         }
     }
@@ -83,25 +72,11 @@ public class ChatRoomCommandService {
             && canHardDelete(chatRoom, memberALastDeleteAt, memberBLastDeleteAt);
     }
 
-    private boolean canHardDeleteWhenOneLeftAndOtherIsNull(LocalDateTime nonNullMemberLastDeleteAt,
-        LocalDateTime nullMemberLastDeleteAt, Member nullMember, ChatRoom chatRoom) {
-        return Objects.nonNull(nonNullMemberLastDeleteAt) && Objects.isNull(nullMemberLastDeleteAt)
-            && Objects.isNull(nullMember)
-            && canHardDeleteWithNullMember(chatRoom, nonNullMemberLastDeleteAt);
-    }
-
     private boolean canHardDelete(ChatRoom chatRoom, LocalDateTime memberALastDeleteAt,
         LocalDateTime memberBLastDeleteAt) {
         return chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)
             .map(chat -> chat.getCreatedAt().isBefore(memberALastDeleteAt) && chat.getCreatedAt()
                 .isBefore(memberBLastDeleteAt))
-            .orElse(true);
-    }
-
-    private boolean canHardDeleteWithNullMember(ChatRoom chatRoom,
-        LocalDateTime lastDeleteAt) {
-        return chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)
-            .map(chat -> chat.getCreatedAt().isBefore(lastDeleteAt))
             .orElse(true);
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/BaseErrorCode.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/BaseErrorCode.java
@@ -2,4 +2,5 @@ package com.cozymate.cozymate_server.global.response.code;
 
 public interface BaseErrorCode {
     public ErrorReasonDto getReasonHttpStatus();
+    String getMessage();
 }

--- a/src/main/java/com/cozymate/cozymate_server/global/response/exception/GeneralException.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/exception/GeneralException.java
@@ -2,17 +2,20 @@ package com.cozymate.cozymate_server.global.response.exception;
 
 import com.cozymate.cozymate_server.global.response.code.BaseErrorCode;
 import com.cozymate.cozymate_server.global.response.code.ErrorReasonDto;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
     private final BaseErrorCode code;
 
     public GeneralException(String message, BaseErrorCode code) {
         super(message);
+        this.code = code;
+    }
+
+    public GeneralException(BaseErrorCode code) {
+        super(code.getMessage());
         this.code = code;
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/global/utils/BaseTimeEntity.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/utils/BaseTimeEntity.java
@@ -21,4 +21,9 @@ public class BaseTimeEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    // 테스트용
+    public void setCreatedAtForTest(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 }

--- a/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatCommandServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatCommandServiceTest.java
@@ -1,0 +1,114 @@
+package com.cozymate.cozymate_server.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.cozymate.cozymate_server.domain.chat.Chat;
+import com.cozymate.cozymate_server.domain.chat.dto.request.CreateChatRequestDTO;
+import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.dto.response.ChatRoomIdResponseDTO;
+import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
+import com.cozymate.cozymate_server.fixture.ChatFixture;
+import com.cozymate.cozymate_server.fixture.ChatRoomFixture;
+import com.cozymate.cozymate_server.fixture.MemberFixture;
+import com.cozymate.cozymate_server.fixture.UniversityFixture;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class ChatCommandServiceTest {
+
+    @Mock
+    ChatRepository chatRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    ChatRoomRepository chatRoomRepository;
+    @InjectMocks
+    ChatCommandService chatCommandService;
+
+    Member sender;
+    Member recipient;
+    ChatRoom chatRoom;
+    Chat chat;
+    CreateChatRequestDTO createChatRequestDTO;
+
+    @BeforeEach
+    void setUp() {
+        sender = MemberFixture.정상_1(UniversityFixture.createTestUniversity());
+        recipient = MemberFixture.정상_2(UniversityFixture.createTestUniversity());
+        chatRoom = ChatRoomFixture.정상_1(sender, recipient);
+        chat = ChatFixture.정상_1(sender, chatRoom);
+        createChatRequestDTO = ChatFixture.정상_1_생성_요청_DTO(chat);
+    }
+
+    @Nested
+    class createChat {
+
+        @Test
+        @DisplayName("둘 사이에 ChatRoom이 이미 존재하는 경우, 새로운 ChatRoom을 생성하지 않고 쪽지 작성에 성공한다.")
+        void success_when_chatroom_exists() {
+            // given
+            given(memberRepository.findById(recipient.getId()))
+                .willReturn(Optional.of(recipient));
+            given(chatRoomRepository.findByMemberAAndMemberB(sender, recipient)).willReturn(
+                Optional.of(chatRoom));
+            given(chatRepository.save(any(Chat.class))).willReturn(chat);
+
+            // when
+            ChatRoomIdResponseDTO result = chatCommandService.createChat(createChatRequestDTO,
+                sender, recipient.getId());
+
+            // then
+            assertThat(result.chatRoomId()).isEqualTo(chatRoom.getId());
+            then(chatRoomRepository).should(times(0)).save(any(ChatRoom.class));
+        }
+
+        @Test
+        @DisplayName("둘 사이에 ChatRoom이 존재하지 않는 경우, 새로운 ChatRoom을 생성하고 쪽지 작성에 성공한다.")
+        void success_when_chatroom_does_not_exist() {
+            // given
+            given(memberRepository.findById(recipient.getId()))
+                .willReturn(Optional.of(recipient));
+            given(chatRoomRepository.findByMemberAAndMemberB(sender, recipient)).willReturn(
+                Optional.empty());
+            given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(chatRoom);
+            given(chatRepository.save(any(Chat.class))).willReturn(chat);
+
+            // when
+            ChatRoomIdResponseDTO result = chatCommandService.createChat(createChatRequestDTO,
+                sender, recipient.getId());
+
+            // then
+            assertThat(result.chatRoomId()).isEqualTo(chatRoom.getId());
+            then(chatRoomRepository).should(times(1)).save(any(ChatRoom.class));
+        }
+
+        @Test
+        @DisplayName("수신자가 존재하지 않는 경우 예외가 발생한다.")
+        void failure_when_recipient_does_not_exist() {
+            // given
+            given(memberRepository.findById(recipient.getId())).willReturn(Optional.empty());
+
+            // when-then
+            assertThatThrownBy(
+                () -> chatCommandService.createChat(createChatRequestDTO, sender,
+                    recipient.getId()))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorStatus._CHAT_NOT_FOUND_RECIPIENT.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chat/service/ChatQueryServiceTest.java
@@ -1,0 +1,196 @@
+package com.cozymate.cozymate_server.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.cozymate.cozymate_server.domain.chat.Chat;
+import com.cozymate.cozymate_server.domain.chat.dto.response.ChatContentResponseDTO;
+import com.cozymate.cozymate_server.domain.chat.dto.response.ChatListResponseDTO;
+import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.fixture.ChatFixture;
+import com.cozymate.cozymate_server.fixture.ChatRoomFixture;
+import com.cozymate.cozymate_server.fixture.MemberFixture;
+import com.cozymate.cozymate_server.fixture.UniversityFixture;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class ChatQueryServiceTest {
+
+    @Mock
+    ChatRepository chatRepository;
+    @Mock
+    ChatRoomRepository chatRoomRepository;
+    @InjectMocks
+    ChatQueryService chatQueryService;
+
+    Member memberA;
+    Member memberB;
+    Member memberC;
+    ChatRoom chatRoom;
+    Chat memberAChat1;
+    Chat memberBChat1;
+    Chat memberAChat2;
+    List<Chat> chatList;
+
+    @BeforeEach
+    void setUp() {
+        memberA = MemberFixture.정상_1(UniversityFixture.createTestUniversity());
+        memberB = MemberFixture.정상_2(UniversityFixture.createTestUniversity());
+        memberC = MemberFixture.정상_3(UniversityFixture.createTestUniversity());
+        chatRoom = ChatRoomFixture.정상_1(memberA, memberB);
+        memberAChat1 = ChatFixture.정상_1(memberA, chatRoom);
+        memberBChat1 = ChatFixture.정상_2(memberB, chatRoom);
+        memberAChat2 = ChatFixture.정상_3(memberA, chatRoom);
+        chatList = List.of(memberAChat1, memberBChat1, memberAChat2);
+    }
+
+    @Nested
+    class getChatList {
+
+        @Test
+        @DisplayName("쪽지방의 멤버 둘다 해당 쪽지방을 삭제한 적이 없는 경우 모든 Chat 조회에 성공한다.")
+        void success_when_both_members_have_not_deleted_chatroom() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+            given(chatRepository.findAllByChatRoom(chatRoom)).willReturn(chatList);
+
+            // when
+            ChatListResponseDTO result = chatQueryService.getChatList(memberA, chatRoom.getId());
+
+            // then
+            assertThat(result.memberId()).isEqualTo(memberB.getId());
+            assertThat(result.content().size()).isEqualTo(chatList.size());
+
+            List<ChatContentResponseDTO> chatContentResponseDTOList = result.content();
+            for (int i = 0; i < chatContentResponseDTOList.size(); i++) {
+                String nickname = chatContentResponseDTOList.get(i).nickname();
+                if (i % 2 == 0) {
+                    assertThat(nickname).isEqualTo(memberA.getNickname() + " (나)");
+                } else {
+                    assertThat(nickname).isEqualTo(memberB.getNickname());
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("특정 사용자가 해당 쪽지방을 삭제한 이후 다시 쪽지가 이루어진 경우, 이전 쪽지 내용은 제외하고 조회에 성공한다.")
+        void success_when_one_member_sends_message_after_deleting_chatroom() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+            given(chatRepository.findAllByChatRoom(chatRoom)).willReturn(chatList);
+            chatRoom.updateMemberALastDeleteAt(LocalDateTime.now().plusMinutes(25));
+
+            // when
+            ChatListResponseDTO result = chatQueryService.getChatList(memberA, chatRoom.getId());
+
+            // then
+            assertThat(result.memberId()).isEqualTo(memberB.getId());
+            assertThat(result.content().size()).isEqualTo(1); // chat1, chat2는 memberA가 쪽지방 삭제 전의 쪽지
+            assertThat(result.content().get(0).nickname()).isEqualTo(
+                memberAChat2.getSender().getNickname() + " (나)");
+        }
+
+        @Test
+        @DisplayName("쪽지방 상대가 탈퇴 회원인 경우 recipientId는 null을 반환하고 조회에 성공한다.")
+        void success_when_recipient_is_withdrawn_member() {
+            // given
+            chatRoom = ChatRoomFixture.정상_4(memberA);
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+            memberBChat1 = ChatFixture.정상_4(chatRoom);
+            chatList = List.of(memberAChat1, memberBChat1, memberAChat2);
+            given(chatRepository.findAllByChatRoom(chatRoom)).willReturn(chatList);
+
+            // when
+            ChatListResponseDTO result = chatQueryService.getChatList(memberA, chatRoom.getId());
+
+            // then
+            assertThat(result.memberId()).isNull();
+            List<ChatContentResponseDTO> chatContentResponseDTOList = result.content();
+
+            for (int i = 0; i < chatContentResponseDTOList.size(); i++) {
+                String nickname = chatContentResponseDTOList.get(i).nickname();
+                if (i % 2 == 0) {
+                    assertThat(nickname).isEqualTo(memberA.getNickname() + " (나)");
+                } else {
+                    assertThat(nickname).isEqualTo("(알수없음)");
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ChatRoomId로 요청한 경우 예외가 발생한다.")
+        void failure_when_chatroom_does_not_exist() {
+            // given
+            given(chatRoomRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+            // when-then
+            assertThatThrownBy(
+                () -> chatQueryService.getChatList(memberA, 1L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorStatus._CHATROOM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("ChatRoom의 두 Member가 모두 null(탈퇴 회원)이 아닌 경우, 현재 요청 Member가 MemberA, MemberB 둘다 아닌 경우 예외가 발생한다.")
+        void failure_when_member_is_not_part_of_chatroom() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+
+            // when-then
+            assertThatThrownBy(
+                () -> chatQueryService.getChatList(memberC, chatRoom.getId()))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorStatus._CHATROOM_MEMBER_MISMATCH.getMessage());
+            assertThat(chatRoom.getMemberA().getNickname()).isEqualTo(memberA.getNickname());
+            assertThat(chatRoom.getMemberB().getNickname()).isEqualTo(memberB.getNickname());
+        }
+
+        @Test
+        @DisplayName("ChatRoom의 MemberA가 null(탈퇴 회원)이고, 현재 요청 Member가 ChatRoom의 MemberB와 다른 경우 예외가 발생한다.")
+        void failure_when_member_is_not_part_of_chatroom_with_null_member_a() {
+            // given
+            chatRoom = ChatRoomFixture.정상_5(memberB);
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+
+            // when-then
+            assertThatThrownBy(
+                () -> chatQueryService.getChatList(memberC, chatRoom.getId()))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorStatus._CHATROOM_MEMBER_MISMATCH.getMessage());
+            assertThat(chatRoom.getMemberA()).isNull();
+            assertThat(chatRoom.getMemberB().getNickname()).isEqualTo(memberB.getNickname());
+        }
+
+        @Test
+        @DisplayName("ChatRoom의 MemberB가 null(탈퇴 회원)이고, 현재 요청 Member가 ChatRoom의 MemberA와 다른 경우 예외가 발생한다.")
+        void failure_when_member_is_not_part_of_chatroom_with_null_member_b() {
+            // given
+            chatRoom = ChatRoomFixture.정상_4(memberA);
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+
+            // when-then
+            assertThatThrownBy(
+                () -> chatQueryService.getChatList(memberC, chatRoom.getId()))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorStatus._CHATROOM_MEMBER_MISMATCH.getMessage());
+            assertThat(chatRoom.getMemberA().getNickname()).isEqualTo(memberA.getNickname());
+            assertThat(chatRoom.getMemberB()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandServiceTest.java
@@ -1,0 +1,252 @@
+package com.cozymate.cozymate_server.domain.chatroom.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.cozymate.cozymate_server.domain.chat.Chat;
+import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.dto.response.ChatRoomIdResponseDTO;
+import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.fixture.ChatFixture;
+import com.cozymate.cozymate_server.fixture.ChatRoomFixture;
+import com.cozymate.cozymate_server.fixture.MemberFixture;
+import com.cozymate.cozymate_server.fixture.UniversityFixture;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ChatRoomCommandServiceTest {
+
+    @Mock
+    ChatRoomRepository chatRoomRepository;
+    @Mock
+    ChatRepository chatRepository;
+    @InjectMocks
+    ChatRoomCommandService chatRoomCommandService;
+
+    Member memberA;
+    Member memberB;
+    ChatRoom chatRoom;
+
+    @BeforeEach
+    void setUp() {
+        memberA = MemberFixture.정상_1(UniversityFixture.createTestUniversity());
+        memberB = MemberFixture.정상_2(UniversityFixture.createTestUniversity());
+        chatRoom = ChatRoomFixture.정상_1(memberA, memberB);
+    }
+
+    @Nested
+    class saveChatRoom {
+
+        @Test
+        @DisplayName("ChatRoom 저장에 성공한다.")
+        void success_when_valid_input() {
+            // given
+            given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(chatRoom);
+
+            // when
+            ChatRoomIdResponseDTO result = chatRoomCommandService.saveChatRoom(
+                memberA, memberB);
+
+            // then
+            assertThat(result.chatRoomId()).isEqualTo(chatRoom.getId());
+            then(chatRoomRepository).should(times(1)).save(any(ChatRoom.class));
+        }
+    }
+
+    @Nested
+    class deleteChatRoom {
+
+        Chat memberAChat1;
+        Chat memberBChat1;
+        Chat memberAChat2;
+        ChatRoom memberBIsNullChatRoom;
+        ChatRoom memberAIsNullChatRoom;
+
+        @BeforeEach
+        void setUp() {
+            memberAChat1 = ChatFixture.정상_6(memberA, chatRoom);
+            memberBChat1 = ChatFixture.정상_7(memberB, chatRoom);
+            memberAChat2 = ChatFixture.정상_8(memberA, chatRoom);
+
+            memberBIsNullChatRoom = ChatRoomFixture.정상_4(memberA);
+            memberAIsNullChatRoom = ChatRoomFixture.정상_5(memberB);
+        }
+
+        @Test
+        @DisplayName("memberA가 ChatRoom을 삭제할 때 memberB의 LastDeleteAt이 null인 경우, ChatRoom을 논리적으로 삭제한다.")
+        void success_when_memberB_lastDeleteAt_is_null() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+
+            // when
+            chatRoomCommandService.deleteChatRoom(memberA, chatRoom.getId());
+
+            // then
+            then(chatRepository).should(times(0)).findTopByChatRoomOrderByIdDesc(chatRoom);
+            then(chatRepository).should(times(0)).deleteAllByChatRoom(chatRoom);
+            then(chatRoomRepository).should(times(0)).delete(chatRoom);
+        }
+
+        @Test
+        @DisplayName("memberB가 ChatRoom을 삭제할 때 memberA의 LastDeleteAt이 null인 경우, ChatRoom을 논리적으로 삭제한다.")
+        void success_when_memberA_lastDeleteAt_is_null() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+
+            // when
+            chatRoomCommandService.deleteChatRoom(memberB, chatRoom.getId());
+
+            // then
+            then(chatRepository).should(times(0)).findTopByChatRoomOrderByIdDesc(chatRoom);
+            then(chatRepository).should(times(0)).deleteAllByChatRoom(chatRoom);
+            then(chatRoomRepository).should(times(0)).delete(chatRoom);
+        }
+
+        @Test
+        @DisplayName("memberA가 ChatRoom을 삭제할 때, memberB의 LastDeleteAt이 존재하면서 이후에 생성된 Chat이 존재하는 경우, ChatRoom을 논리적으로 삭제한다.")
+        void success_when_memberB_lastDeleteAt_exists_and_newer_chat_exists() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+            chatRoom.updateMemberBLastDeleteAt(memberAChat2.getCreatedAt().minusMinutes(1));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)).willReturn(
+                Optional.of(memberAChat2));
+
+            // when
+            chatRoomCommandService.deleteChatRoom(memberA, chatRoom.getId());
+
+            // then
+            then(chatRepository).should(times(1)).findTopByChatRoomOrderByIdDesc(chatRoom);
+            then(chatRepository).should(times(0)).deleteAllByChatRoom(chatRoom);
+            then(chatRoomRepository).should(times(0)).delete(chatRoom);
+        }
+
+        @Test
+        @DisplayName("memberB가 ChatRoom을 삭제할 때, memberA의 LastDeleteAt이 존재하면서 이후에 생성된 Chat이 존재하는 경우, ChatRoom을 논리적으로 삭제한다.")
+        void success_when_memberA_lastDeleteAt_exists_and_newer_chat_exists() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+            chatRoom.updateMemberALastDeleteAt(memberAChat2.getCreatedAt().minusMinutes(1));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)).willReturn(
+                Optional.of(memberAChat2));
+
+            // when
+            chatRoomCommandService.deleteChatRoom(memberB, chatRoom.getId());
+
+            // then
+            then(chatRepository).should(times(1)).findTopByChatRoomOrderByIdDesc(chatRoom);
+            then(chatRepository).should(times(0)).deleteAllByChatRoom(chatRoom);
+            then(chatRoomRepository).should(times(0)).delete(chatRoom);
+        }
+
+        @Test
+        @DisplayName("memberA가 ChatRoom을 삭제할 때, 마지막 Chat 생성일이 두 멤버의 LastDeleteAt 이전인 경우, ChatRoom과 해당 ChatRoom의 Chat을 물리적으로 삭제한다.")
+        void success_memberA_criteria_when_lastChat_is_before_both_lastDeleteAt() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+            chatRoom.updateMemberBLastDeleteAt(LocalDateTime.now().minusMinutes(9));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)).willReturn(
+                Optional.of(memberAChat2));
+
+            // when
+            chatRoomCommandService.deleteChatRoom(memberA, chatRoom.getId());
+
+            // then
+            then(chatRepository).should(times(1)).findTopByChatRoomOrderByIdDesc(chatRoom);
+            then(chatRepository).should(times(1)).deleteAllByChatRoom(chatRoom);
+            then(chatRoomRepository).should(times(1)).delete(chatRoom);
+        }
+
+        @Test
+        @DisplayName("memberB가 ChatRoom을 삭제할 때, 마지막 Chat 생성일이 두 멤버의 LastDeleteAt 이전인 경우, ChatRoom과 해당 ChatRoom의 Chat을 물리적으로 삭제한다.")
+        void success_memberB_criteria_when_lastChat_is_before_both_lastDeleteAt_memberB_기준() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+            chatRoom.updateMemberALastDeleteAt(LocalDateTime.now().minusMinutes(9));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(chatRoom)).willReturn(
+                Optional.of(memberAChat2));
+
+            // when
+            chatRoomCommandService.deleteChatRoom(memberB, chatRoom.getId());
+
+            // then
+            then(chatRepository).should(times(1)).findTopByChatRoomOrderByIdDesc(chatRoom);
+            then(chatRepository).should(times(1)).deleteAllByChatRoom(chatRoom);
+            then(chatRoomRepository).should(times(1)).delete(chatRoom);
+        }
+
+        @Test
+        @DisplayName("memberA가 ChatRoom을 삭제할 때, memberB가 탈퇴(null)인 경우 물리적으로 삭제한다.")
+        void success_when_memberB_is_null() {
+            // given
+            given(chatRoomRepository.findById(memberBIsNullChatRoom.getId())).willReturn(
+                Optional.of(memberBIsNullChatRoom));
+
+            // when
+            chatRoomCommandService.deleteChatRoom(memberA, memberBIsNullChatRoom.getId());
+
+            // then
+            then(chatRepository).should(times(0))
+                .findTopByChatRoomOrderByIdDesc(memberBIsNullChatRoom);
+            then(chatRepository).should(times(1)).deleteAllByChatRoom(memberBIsNullChatRoom);
+            then(chatRoomRepository).should(times(1)).delete(memberBIsNullChatRoom);
+        }
+
+        @Test
+        @DisplayName("memberB가 ChatRoom을 삭제할 때, memberA가 탈퇴(null)인 경우 물리적으로 삭제한다.")
+        void success_when_memberA_is_null() {
+            // given
+            given(chatRoomRepository.findById(memberAIsNullChatRoom.getId())).willReturn(
+                Optional.of(memberAIsNullChatRoom));
+
+            // when
+            chatRoomCommandService.deleteChatRoom(memberB, memberAIsNullChatRoom.getId());
+
+            // then
+            then(chatRepository).should(times(0))
+                .findTopByChatRoomOrderByIdDesc(memberAIsNullChatRoom);
+            then(chatRepository).should(times(1)).deleteAllByChatRoom(memberAIsNullChatRoom);
+            then(chatRoomRepository).should(times(1)).delete(memberAIsNullChatRoom);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ChatRoom id에 대한 요청인 경우 예외가 발생한다.")
+        void failure_when_chatroom_does_not_exists() {
+            // given
+            given(chatRoomRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+            // when-then
+            assertThatThrownBy(
+                () -> chatRoomCommandService.deleteChatRoom(memberA, 1L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorStatus._CHATROOM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("ChatRoom의 Member가 아닌 경우 예외가 발생한다.")
+        void failure_when_member_is_not_part_of_chatroom() {
+            // given
+            given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
+            Member memberC = MemberFixture.정상_3(UniversityFixture.createTestUniversity());
+
+            // when-then
+            assertThatThrownBy(
+                () -> chatRoomCommandService.deleteChatRoom(memberC, chatRoom.getId()))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorStatus._CHATROOM_FORBIDDEN.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomCommandServiceTest.java
@@ -189,7 +189,7 @@ class ChatRoomCommandServiceTest {
         }
 
         @Test
-        @DisplayName("memberA가 ChatRoom을 삭제할 때, memberB가 탈퇴(null)인 경우 물리적으로 삭제한다.")
+        @DisplayName("memberA가 ChatRoom을 삭제할 때, memberB가 탈퇴(null)인 경우, ChatRoom과 해당 ChatRoom의 Chat을 물리적으로 삭제한다.")
         void success_when_memberB_is_null() {
             // given
             given(chatRoomRepository.findById(memberBIsNullChatRoom.getId())).willReturn(
@@ -206,7 +206,7 @@ class ChatRoomCommandServiceTest {
         }
 
         @Test
-        @DisplayName("memberB가 ChatRoom을 삭제할 때, memberA가 탈퇴(null)인 경우 물리적으로 삭제한다.")
+        @DisplayName("memberB가 ChatRoom을 삭제할 때, memberA가 탈퇴(null)인 경우, ChatRoom과 해당 ChatRoom의 Chat을 물리적으로 삭제한다.")
         void success_when_memberA_is_null() {
             // given
             given(chatRoomRepository.findById(memberAIsNullChatRoom.getId())).willReturn(

--- a/src/test/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/chatroom/service/ChatRoomQueryServiceTest.java
@@ -1,0 +1,406 @@
+package com.cozymate.cozymate_server.domain.chatroom.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.cozymate.cozymate_server.domain.chat.Chat;
+import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.chatroom.dto.ChatRoomSimpleDTO;
+import com.cozymate.cozymate_server.domain.chatroom.dto.response.ChatRoomDetailResponseDTO;
+import com.cozymate.cozymate_server.domain.chatroom.dto.response.CountChatRoomsWithNewChatDTO;
+import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
+import com.cozymate.cozymate_server.fixture.ChatFixture;
+import com.cozymate.cozymate_server.fixture.ChatRoomFixture;
+import com.cozymate.cozymate_server.fixture.MemberFixture;
+import com.cozymate.cozymate_server.fixture.UniversityFixture;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomQueryServiceTest {
+
+    @Mock
+    ChatRoomRepository chatRoomRepository;
+    @Mock
+    ChatRepository chatRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @InjectMocks
+    ChatRoomQueryService chatRoomQueryService;
+
+    Member memberA;
+    Member memberB;
+    Member memberC;
+
+    ChatRoom abChatRoom;
+    ChatRoom acChatRoom;
+
+    Chat memberAToMemberBChat1;
+    Chat memberBToMemberAChat1;
+    Chat memberAToMemberBChat2;
+
+    Chat memberCToMemberAChat1;
+    Chat memberAToMemberCChat1;
+    Chat memberCToMemberAChat2;
+
+    ChatRoom memberBIsNullChatRoom;
+    Chat senderIsNullChat;
+
+    @BeforeEach
+    void setUp() {
+        memberA = MemberFixture.정상_1(UniversityFixture.createTestUniversity());
+        memberB = MemberFixture.정상_2(UniversityFixture.createTestUniversity());
+        memberC = MemberFixture.정상_3(UniversityFixture.createTestUniversity());
+
+        abChatRoom = ChatRoomFixture.정상_1(memberA, memberB);
+        acChatRoom = ChatRoomFixture.정상_2(memberA, memberC);
+
+        memberAToMemberBChat1 = ChatFixture.정상_1(memberA, abChatRoom);
+        memberBToMemberAChat1 = ChatFixture.정상_2(memberB, abChatRoom);
+        memberAToMemberBChat2 = ChatFixture.정상_3(memberA, abChatRoom); // 현재시간 + 30분
+
+        memberCToMemberAChat1 = ChatFixture.정상_6(memberC, acChatRoom);
+        memberAToMemberCChat1 = ChatFixture.정상_7(memberA, acChatRoom);
+        memberCToMemberAChat2 = ChatFixture.정상_8(memberC, acChatRoom); // 현재시간 - 10분
+
+        memberBIsNullChatRoom = ChatRoomFixture.정상_4(memberA);
+        senderIsNullChat = ChatFixture.정상_4(memberBIsNullChatRoom); // +40분
+    }
+
+    @Nested
+    class getChatRoomList {
+
+        @Test
+        @DisplayName("조회된 ChatRoom이 없는 경우 빈 리스트를 반환한다.")
+        void success_when_no_chatrooms_exist() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(List.of());
+
+            // when
+            List<ChatRoomDetailResponseDTO> result = chatRoomQueryService.getChatRoomList(memberA);
+
+            // then
+            assertThat(result).isEmpty();
+
+            then(chatRepository).should(times(0))
+                .findTopByChatRoomOrderByIdDesc(any(ChatRoom.class));
+            then(chatRepository).should(times(0))
+                .existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(any(Member.class),
+                    any(ChatRoom.class), any());
+        }
+
+        @Test
+        @DisplayName("memberA 조회 기준 두 ChatRoom의 가장 최근 Chat이 abChatRoom인 경우 abChatRoom, acChatRoom 순으로 조회된다.")
+        void success_when_latest_chat_is_abChatRoom() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(
+                List.of(abChatRoom, acChatRoom));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(abChatRoom)).willReturn(
+                Optional.of(memberAToMemberBChat2));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(acChatRoom)).willReturn(
+                Optional.of(memberCToMemberAChat2));
+
+            // when
+            List<ChatRoomDetailResponseDTO> result = chatRoomQueryService.getChatRoomList(memberA);
+
+            // then
+            ChatRoomDetailResponseDTO abChatRoomResult = result.get(0);
+            ChatRoomDetailResponseDTO acChatRoomResult = result.get(1);
+
+            assertThat(result.size()).isEqualTo(2);
+            assertThat(abChatRoomResult.persona()).isEqualTo(memberB.getPersona());
+            assertThat(abChatRoomResult.nickname()).isEqualTo(memberB.getNickname());
+            assertThat(abChatRoomResult.lastContent()).isEqualTo(
+                memberAToMemberBChat2.getContent());
+            assertThat(abChatRoomResult.chatRoomId()).isEqualTo(abChatRoom.getId());
+            assertThat(abChatRoomResult.memberId()).isEqualTo(memberB.getId());
+
+            assertThat(acChatRoomResult.persona()).isEqualTo(memberC.getPersona());
+            assertThat(acChatRoomResult.nickname()).isEqualTo(memberC.getNickname());
+            assertThat(acChatRoomResult.lastContent()).isEqualTo(
+                memberCToMemberAChat2.getContent());
+            assertThat(acChatRoomResult.chatRoomId()).isEqualTo(acChatRoom.getId());
+            assertThat(acChatRoomResult.memberId()).isEqualTo(memberC.getId());
+
+            then(chatRepository).should(times(2))
+                .findTopByChatRoomOrderByIdDesc(any(ChatRoom.class));
+            then(chatRepository).should(times(2))
+                .existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(any(Member.class),
+                    any(ChatRoom.class), any());
+        }
+
+        @Test
+        @DisplayName("memberA 조회 기준 두 ChatRoom의 가장 최근 Chat이 acChatRoom인 경우 acChatRoom, abChatRoom 순으로 조회된다.")
+        void success_success_when_latest_chat_is_acChatRoom() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(
+                List.of(abChatRoom, acChatRoom));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(abChatRoom)).willReturn(
+                Optional.of(memberAToMemberBChat2));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(acChatRoom)).willReturn(
+                Optional.of(memberCToMemberAChat2));
+            memberCToMemberAChat2.setCreatedAtForTest(LocalDateTime.now());
+            memberAToMemberBChat2.setCreatedAtForTest(LocalDateTime.now().minusMinutes(1));
+
+            // when
+            List<ChatRoomDetailResponseDTO> result = chatRoomQueryService.getChatRoomList(memberA);
+
+            // then
+            ChatRoomDetailResponseDTO acChatRoomResult = result.get(0);
+            ChatRoomDetailResponseDTO abChatRoomResult = result.get(1);
+
+            assertThat(result.size()).isEqualTo(2);
+            assertThat(acChatRoomResult.persona()).isEqualTo(memberC.getPersona());
+            assertThat(acChatRoomResult.nickname()).isEqualTo(memberC.getNickname());
+            assertThat(acChatRoomResult.lastContent()).isEqualTo(
+                memberCToMemberAChat2.getContent());
+            assertThat(acChatRoomResult.chatRoomId()).isEqualTo(acChatRoom.getId());
+            assertThat(acChatRoomResult.memberId()).isEqualTo(memberC.getId());
+
+            assertThat(abChatRoomResult.persona()).isEqualTo(memberB.getPersona());
+            assertThat(abChatRoomResult.nickname()).isEqualTo(memberB.getNickname());
+            assertThat(abChatRoomResult.lastContent()).isEqualTo(
+                memberAToMemberBChat2.getContent());
+            assertThat(abChatRoomResult.chatRoomId()).isEqualTo(abChatRoom.getId());
+            assertThat(abChatRoomResult.memberId()).isEqualTo(memberB.getId());
+
+            then(chatRepository).should(times(2))
+                .findTopByChatRoomOrderByIdDesc(any(ChatRoom.class));
+            then(chatRepository).should(times(2))
+                .existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(any(Member.class),
+                    any(ChatRoom.class), any());
+        }
+
+        @Test
+        @DisplayName("새로운 Chat이 존재하는 ChatRoom의 hasNewChat은 true, 존재하지 않는 경우 false를 반환한다.")
+        void success_when_chatroom_has_new_chat_flag_is_set_correctly() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(
+                List.of(abChatRoom, acChatRoom));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(abChatRoom)).willReturn(
+                Optional.of(memberBToMemberAChat1));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(acChatRoom)).willReturn(
+                Optional.of(memberCToMemberAChat2));
+
+            abChatRoom.updateMemberALastSeenAt();
+            acChatRoom.updateMemberALastSeenAt();
+
+            given(chatRepository.existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+                memberB, abChatRoom, abChatRoom.getMemberALastSeenAt())).willReturn(true);
+            given(chatRepository.existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+                memberC, acChatRoom, acChatRoom.getMemberALastSeenAt())).willReturn(false);
+
+            // when
+            List<ChatRoomDetailResponseDTO> result = chatRoomQueryService.getChatRoomList(memberA);
+
+            // then
+            ChatRoomDetailResponseDTO abChatRoomResult = result.get(0);
+            ChatRoomDetailResponseDTO acChatRoomResult = result.get(1);
+
+            assertThat(abChatRoomResult.hasNewChat()).isTrue();
+            assertThat(acChatRoomResult.hasNewChat()).isFalse();
+
+            then(chatRepository).should(times(2))
+                .findTopByChatRoomOrderByIdDesc(any(ChatRoom.class));
+            then(chatRepository).should(times(2))
+                .existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(any(Member.class),
+                    any(ChatRoom.class), any(LocalDateTime.class));
+        }
+
+        @Test
+        @DisplayName("상대가 탈퇴한 ChatRoom이 존재하는 경우 탈퇴한 상대의 ChatRoom에 대해서는 (알수없음)으로 조회한다.")
+        void success_when_chatroom_has_null_member() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(
+                List.of(memberBIsNullChatRoom, acChatRoom));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(memberBIsNullChatRoom)).willReturn(
+                Optional.of(senderIsNullChat));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(acChatRoom)).willReturn(
+                Optional.of(memberCToMemberAChat2)); // -10분
+
+            // when
+            List<ChatRoomDetailResponseDTO> result = chatRoomQueryService.getChatRoomList(memberA);
+
+            // then
+            ChatRoomDetailResponseDTO memberBIsNullChatRoomResult = result.get(0);
+            ChatRoomDetailResponseDTO acChatRoomResult = result.get(1);
+
+            assertThat(result.size()).isEqualTo(2);
+
+            assertThat(memberBIsNullChatRoomResult.persona()).isNull();
+            assertThat(memberBIsNullChatRoomResult.nickname()).isEqualTo("(알수없음)");
+            assertThat(memberBIsNullChatRoomResult.lastContent()).isEqualTo(
+                senderIsNullChat.getContent());
+            assertThat(memberBIsNullChatRoomResult.chatRoomId()).isEqualTo(
+                memberBIsNullChatRoom.getId());
+            assertThat(memberBIsNullChatRoomResult.memberId()).isNull();
+            assertThat(memberBIsNullChatRoomResult.hasNewChat()).isFalse();
+
+            assertThat(acChatRoomResult.persona()).isEqualTo(memberC.getPersona());
+            assertThat(acChatRoomResult.nickname()).isEqualTo(memberC.getNickname());
+            assertThat(acChatRoomResult.lastContent()).isEqualTo(
+                memberCToMemberAChat2.getContent());
+            assertThat(acChatRoomResult.chatRoomId()).isEqualTo(acChatRoom.getId());
+            assertThat(acChatRoomResult.memberId()).isEqualTo(memberC.getId());
+
+            then(chatRepository).should(times(2))
+                .findTopByChatRoomOrderByIdDesc(any(ChatRoom.class));
+            then(chatRepository).should(times(1))
+                .existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(any(Member.class),
+                    any(ChatRoom.class), any());
+        }
+    }
+
+    @Nested
+    class getChatRoom {
+
+        @Test
+        @DisplayName("상대가 존재하고 둘 사이의 가존 ChatRoom이 존재하는 경우 ChatRoom 조회에 성공한다.")
+        void success_when_exists_recipient_and_exists_chatroom() {
+            // given
+            given(memberRepository.findById(memberB.getId())).willReturn(Optional.of(memberB));
+            given(chatRoomRepository.findByMemberAAndMemberB(memberA, memberB)).willReturn(
+                Optional.of(abChatRoom));
+
+            // when
+            ChatRoomSimpleDTO result = chatRoomQueryService.getChatRoom(memberA, memberB.getId());
+
+            // then
+            assertThat(result.chatRoom()).isPresent();
+            assertThat(result.chatRoom().get().getId()).isEqualTo(abChatRoom.getId());
+            assertThat(result.recipient().getId()).isEqualTo(memberB.getId());
+        }
+
+        @Test
+        @DisplayName("상대가 존재하고 둘 사이의 기존 ChatRoom이 없는 경우 Optional.empty 반환에 성공한다.")
+        void success_when_exists_recipient_and_does_not_exists_chatroom() {
+            // given
+            given(memberRepository.findById(memberB.getId())).willReturn(Optional.of(memberB));
+            given(chatRoomRepository.findByMemberAAndMemberB(memberA, memberB)).willReturn(
+                Optional.empty());
+
+            // when
+            ChatRoomSimpleDTO result = chatRoomQueryService.getChatRoom(memberA, memberB.getId());
+
+            // then
+            assertThat(result.chatRoom()).isEmpty();
+            assertThat(result.recipient().getId()).isEqualTo(memberB.getId());
+        }
+
+        @Test
+        @DisplayName("상대가 존재하지 않는 경우 예외가 발생한다.")
+        void failure_when_does_not_exists_recipient() {
+            // given
+            given(memberRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+            // when-then
+            assertThatThrownBy(
+                () -> chatRoomQueryService.getChatRoom(memberA, 1L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorStatus._MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class countChatRoomsWithNewChat {
+
+        @Test
+        @DisplayName("조회된 ChatRoom이 없는 경우 0을 반환한다.")
+        void success_when_does_not_exists_chatroom() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(List.of());
+
+            // when
+            CountChatRoomsWithNewChatDTO result = chatRoomQueryService.countChatRoomsWithNewChat(
+                memberA);
+
+            // then
+            assertThat(result.chatRoomsWithNewChatCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("조회된 ChatRoom이 2개이고 그 중 내가 조회하지 않은 ChatRoom은 0개인 경우 0을 반환한다.")
+        void success_when_unseen_chatrooms_are_zero_among_two_chatrooms() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(
+                List.of(abChatRoom, acChatRoom));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(abChatRoom)).willReturn(
+                Optional.of(memberAToMemberBChat2));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(acChatRoom)).willReturn(
+                Optional.of(memberCToMemberAChat2));
+            given(chatRepository.existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+                memberB, abChatRoom, abChatRoom.getMemberALastSeenAt())).willReturn(false);
+            given(chatRepository.existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+                memberC, acChatRoom, acChatRoom.getMemberALastSeenAt())).willReturn(false);
+
+            // when
+            CountChatRoomsWithNewChatDTO result = chatRoomQueryService.countChatRoomsWithNewChat(
+                memberA);
+
+            // then
+            assertThat(result.chatRoomsWithNewChatCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("조회된 ChatRoom이 2개이고 그 중 내가 조회하지 않은 ChatRoom은 1개인 경우 1을 반환한다.")
+        void success_when_unseen_chatrooms_are_one_among_two_chatrooms() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(
+                List.of(abChatRoom, acChatRoom));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(abChatRoom)).willReturn(
+                Optional.of(memberAToMemberBChat2));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(acChatRoom)).willReturn(
+                Optional.of(memberCToMemberAChat2));
+            given(chatRepository.existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+                memberB, abChatRoom, abChatRoom.getMemberALastSeenAt())).willReturn(true);
+            given(chatRepository.existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+                memberC, acChatRoom, acChatRoom.getMemberALastSeenAt())).willReturn(false);
+
+            // when
+            CountChatRoomsWithNewChatDTO result = chatRoomQueryService.countChatRoomsWithNewChat(
+                memberA);
+
+            // then
+            assertThat(result.chatRoomsWithNewChatCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("조회된 ChatRoom의 상대가 탈퇴한 경우 무조건 새로운 쪽지 없음 처리한다.")
+        void success_when_chatroom_has_null_member() {
+            // given
+            given(chatRoomRepository.findAllByMember(memberA)).willReturn(
+                List.of(memberBIsNullChatRoom, acChatRoom));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(memberBIsNullChatRoom)).willReturn(
+                Optional.of(senderIsNullChat));
+            given(chatRepository.findTopByChatRoomOrderByIdDesc(acChatRoom)).willReturn(
+                Optional.of(memberCToMemberAChat2));
+            given(chatRepository.existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+                memberC, acChatRoom, acChatRoom.getMemberALastSeenAt())).willReturn(true);
+
+            // when
+            CountChatRoomsWithNewChatDTO result = chatRoomQueryService.countChatRoomsWithNewChat(
+                memberA);
+
+            // then
+            assertThat(result.chatRoomsWithNewChatCount()).isEqualTo(1);
+
+            then(chatRepository).should(times(1))
+                .existsBySenderAndChatRoomAndCreatedAtAfterOrLastSeenAtIsNull(
+                    any(Member.class), any(ChatRoom.class), any());
+        }
+    }
+}

--- a/src/test/java/com/cozymate/cozymate_server/fixture/ChatFixture.java
+++ b/src/test/java/com/cozymate/cozymate_server/fixture/ChatFixture.java
@@ -4,58 +4,78 @@ import com.cozymate.cozymate_server.domain.chat.Chat;
 import com.cozymate.cozymate_server.domain.chat.dto.request.CreateChatRequestDTO;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.member.Member;
+import java.time.LocalDateTime;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ChatFixture {
 
     // 정상 더미데이터, content가 존재하는 경우
     public static Chat 정상_1(Member member, ChatRoom chatRoom) {
-        return Chat.builder()
+        Chat chat = Chat.builder()
             .id(1L)
             .chatRoom(chatRoom)
             .sender(member)
             .content("테스트 쪽지 내용 1")
             .build();
+
+        chat.setCreatedAtForTest(LocalDateTime.now().plusMinutes(10));
+
+        return chat;
     }
 
     // 정상 더미데이터, content가 존재하는 경우
     public static Chat 정상_2(Member member, ChatRoom chatRoom) {
-        return Chat.builder()
+        Chat chat = Chat.builder()
             .id(2L)
             .chatRoom(chatRoom)
             .sender(member)
             .content("테스트 쪽지 내용 2")
             .build();
+        chat.setCreatedAtForTest(LocalDateTime.now().plusMinutes(20));
+
+        return chat;
     }
 
     // 정상 더미데이터, content가 존재하는 경우
     public static Chat 정상_3(Member member, ChatRoom chatRoom) {
-        return Chat.builder()
+        Chat chat = Chat.builder()
             .id(3L)
             .chatRoom(chatRoom)
             .sender(member)
             .content("테스트 쪽지 내용 3")
             .build();
+
+        chat.setCreatedAtForTest(LocalDateTime.now().plusMinutes(30));
+
+        return chat;
     }
 
     // 정상 더미데이터, 탈퇴한 사용자에 대한 Chat인 경우
     public static Chat 정상_4(ChatRoom chatRoom) {
-        return Chat.builder()
+        Chat chat = Chat.builder()
             .id(4L)
             .chatRoom(chatRoom)
             .sender(null)
             .content("탈퇴한 사용자의 남아 있는 쪽지 내용 1")
             .build();
+
+        chat.setCreatedAtForTest(LocalDateTime.now().plusMinutes(40));
+
+        return chat;
     }
 
     // 정상 더미데이터, 탈퇴한 사용자에 대한 Chat인 경우
     public static Chat 정상_5(ChatRoom chatRoom) {
-        return Chat.builder()
+        Chat chat = Chat.builder()
             .id(5L)
             .chatRoom(chatRoom)
             .sender(null)
             .content("탈퇴한 사용자의 남아 있는 쪽지 내용 2")
             .build();
+
+        chat.setCreatedAtForTest(LocalDateTime.now().plusMinutes(50));
+
+        return chat;
     }
 
     // 에러 더미데이터, content가 빈 값인 경우

--- a/src/test/java/com/cozymate/cozymate_server/fixture/ChatFixture.java
+++ b/src/test/java/com/cozymate/cozymate_server/fixture/ChatFixture.java
@@ -78,10 +78,49 @@ public class ChatFixture {
         return chat;
     }
 
+    public static Chat 정상_6(Member member, ChatRoom chatRoom) {
+        Chat chat = Chat.builder()
+            .id(6L)
+            .chatRoom(chatRoom)
+            .sender(member)
+            .content("테스트 쪽지 내용 4")
+            .build();
+
+        chat.setCreatedAtForTest(LocalDateTime.now().minusMinutes(30));
+
+        return chat;
+    }
+
+    public static Chat 정상_7(Member member, ChatRoom chatRoom) {
+        Chat chat = Chat.builder()
+            .id(7L)
+            .chatRoom(chatRoom)
+            .sender(member)
+            .content("테스트 쪽지 내용 5")
+            .build();
+
+        chat.setCreatedAtForTest(LocalDateTime.now().minusMinutes(20));
+
+        return chat;
+    }
+
+    public static Chat 정상_8(Member member, ChatRoom chatRoom) {
+        Chat chat = Chat.builder()
+            .id(8L)
+            .chatRoom(chatRoom)
+            .sender(member)
+            .content("테스트 쪽지 내용 6")
+            .build();
+
+        chat.setCreatedAtForTest(LocalDateTime.now().minusMinutes(10));
+
+        return chat;
+    }
+
     // 에러 더미데이터, content가 빈 값인 경우
     public static Chat 값이_비어있는_content(Member member, ChatRoom chatRoom) {
         return Chat.builder()
-            .id(6L)
+            .id(9L)
             .chatRoom(chatRoom)
             .sender(member)
             .content("")
@@ -91,7 +130,7 @@ public class ChatFixture {
     // 에러 더미데이터, content가 null인 경우
     public static Chat 값이_null인_content(Member member, ChatRoom chatRoom) {
         return Chat.builder()
-            .id(7L)
+            .id(10L)
             .chatRoom(chatRoom)
             .sender(member)
             .content(null)
@@ -101,7 +140,7 @@ public class ChatFixture {
     // 에러 더미데이터, content가 500자 초과인 경우
     public static Chat 값이_500자_초과인_content(Member member, ChatRoom chatRoom) {
         return Chat.builder()
-            .id(8L)
+            .id(11L)
             .chatRoom(chatRoom)
             .sender(member)
             .content("가나다라마바사아자차카타파하".repeat(36)) // 504자

--- a/src/test/java/com/cozymate/cozymate_server/fixture/ChatFixture.java
+++ b/src/test/java/com/cozymate/cozymate_server/fixture/ChatFixture.java
@@ -1,6 +1,7 @@
 package com.cozymate.cozymate_server.fixture;
 
 import com.cozymate.cozymate_server.domain.chat.Chat;
+import com.cozymate.cozymate_server.domain.chat.dto.request.CreateChatRequestDTO;
 import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
 import com.cozymate.cozymate_server.domain.member.Member;
 
@@ -85,5 +86,9 @@ public class ChatFixture {
             .sender(member)
             .content("가나다라마바사아자차카타파하".repeat(36)) // 504자
             .build();
+    }
+
+    public static CreateChatRequestDTO 정상_1_생성_요청_DTO(Chat chat) {
+        return new CreateChatRequestDTO(chat.getContent());
     }
 }

--- a/src/test/java/com/cozymate/cozymate_server/fixture/ChatRoomFixture.java
+++ b/src/test/java/com/cozymate/cozymate_server/fixture/ChatRoomFixture.java
@@ -33,12 +33,21 @@ public class ChatRoomFixture {
             .build();
     }
 
-    // 정상 더미데이터, member 한명이 탈퇴한 경우
+    // 정상 더미데이터, memberB가 탈퇴한 경우
     public static ChatRoom 정상_4(Member member) {
         return ChatRoom.builder()
             .id(4L)
             .memberA(member)
             .memberB(null)
+            .build();
+    }
+
+    // 정상 더미데이터, memberA가 탈퇴한 경우
+    public static ChatRoom 정상_5(Member member) {
+        return ChatRoom.builder()
+            .id(5L)
+            .memberA(null)
+            .memberB(member)
             .build();
     }
 }

--- a/src/test/java/com/cozymate/cozymate_server/fixture/MemberFixture.java
+++ b/src/test/java/com/cozymate/cozymate_server/fixture/MemberFixture.java
@@ -19,23 +19,23 @@ public class MemberFixture {
     private static final SocialType DEFAULT_SOCIAL_TYPE = SocialType.KAKAO;
 
     public static Member 정상_1(University university) {
-        return 멤버_생성(university, Gender.MALE, "테스트닉네임1",
+        return 멤버_생성(1L, university, Gender.MALE, "테스트닉네임1",
             LocalDate.of(2000, 11, 1), "컴퓨터공학과");
     }
 
     public static Member 정상_2(University university) {
-        return 멤버_생성(university, Gender.MALE, "테스트닉네임2",
+        return 멤버_생성(2L, university, Gender.MALE, "테스트닉네임2",
             LocalDate.of(2001, 11, 1), "경영학과");
 
     }
 
     public static Member 정상_3(University university) {
-        return 멤버_생성(university, Gender.FEMALE, "테스트닉네임3",
+        return 멤버_생성(3L, university, Gender.FEMALE, "테스트닉네임3",
             LocalDate.of(2000, 11, 1), "컴퓨터공학과");
     }
 
     public static Member 정상_4(University university) {
-        return 멤버_생성(university, Gender.FEMALE, "테스트닉네임4",
+        return 멤버_생성(4L, university, Gender.FEMALE, "테스트닉네임4",
             LocalDate.of(2001, 11, 1), "컴퓨터공학과");
     }
 
@@ -76,15 +76,16 @@ public class MemberFixture {
         List<Member> members = new ArrayList<>();
 
         IntStream.range(0, count).forEach(i ->
-            members.add(멤버_생성(university, gender, "testUser" + (i + 1), startDate.plusDays(i), majorName))
+            members.add(멤버_생성((long) i + 1, university, gender, "testUser" + (i + 1), startDate.plusDays(i), majorName))
         );
 
         return members;
     }
 
-    private static Member 멤버_생성(University university, Gender gender, String nickname,
+    private static Member 멤버_생성(Long id, University university, Gender gender, String nickname,
         LocalDate birthDay, String majorName) {
         return Member.builder()
+            .id(id)
             .socialType(DEFAULT_SOCIAL_TYPE)
             .role(Role.USER)
             .clientId("clientId_" + nickname + ":" + SocialType.KAKAO.toString())


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. ChatCommandService, ChatQueryService, ChatRoomCommandService, ChatRoomQueryService에 대해 테스트 코드를 작성했습니다.
2. 테스트 코드를 작성의 편의(?)를 위해 코드 일부를 수정 추가 했습니다.
3. ChatRoom 삭제 로직을 수정했습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

- ChatCommandServiceTest
<img width="391" alt="image" src="https://github.com/user-attachments/assets/9db3e066-f104-43d6-bc0d-3d87aba923e8" />

- ChatQueryServiceTest
<img width="395" alt="image" src="https://github.com/user-attachments/assets/c82fe631-4981-42b7-92e5-fd0d2e0c33fd" />

- ChatRoomCommandServiceTest
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b9fcf494-bffa-46cb-af09-69c3407f0103" />

- ChatRoomQueryServiceTest
<img width="500" alt="image" src="https://github.com/user-attachments/assets/512ce75d-5a53-4f31-aa43-5339d7fb78d9" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

BaseTimeEntity에 테스트용 메서드 추가에 대한 의견이 궁금합니다~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 채팅 서비스의 멤버 검증 로직 개선
  - 오류 처리 메커니즘 강화
  - 채팅방의 마지막 삭제 타임스탬프 업데이트 방식 개선

- **버그 수정**
  - 멤버 부재 시나리오에 대한 예외 처리 개선

- **테스트**
  - 채팅 서비스 및 쿼리 서비스에 대한 포괄적인 단위 테스트 추가
  - 채팅방 저장 및 삭제 기능에 대한 테스트 케이스 확장

이번 업데이트는 채팅 서비스의 안정성과 신뢰성을 높이는 데 중점을 두었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->