### PR TITLE
[COZY-491] fix : 방 사람들 일치 판단 색 오류 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberStatUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/util/MemberStatUtil.java
@@ -35,21 +35,20 @@ public class MemberStatUtil {
         boolean foundSame = false;
         boolean foundDifferent = false;
 
-        T firstValue = getter.apply(memberStatList.get(0).getMember(), memberStatList.get(0));
-
-        // FIXME: 첫번째 Stat과만 다름 여부를 판단하고 있어, WHITE인 경우도 RED일 때가 있음.
-        for (int i = 1; i < memberStatList.size(); i++) {
-
+        // 리스트 내 모든 값 비교
+        for (int i = 0; i < memberStatList.size(); i++) {
             T currentValue = getter.apply(memberStatList.get(i).getMember(), memberStatList.get(i));
+            for (int j = i + 1; j < memberStatList.size(); j++) {
+                T comparisonValue = getter.apply(memberStatList.get(j).getMember(), memberStatList.get(j));
+                if (currentValue.equals(comparisonValue)) {
+                    foundSame = true;
+                } else {
+                    foundDifferent = true;
+                }
 
-            if (firstValue.equals(currentValue)) {
-                foundSame = true;
-            } else {
-                foundDifferent = true;
-            }
-
-            if (foundSame && foundDifferent) {
-                return DifferenceStatus.WHITE;
+                if (foundSame && foundDifferent) {
+                    return DifferenceStatus.WHITE;
+                }
             }
         }
 
@@ -59,6 +58,7 @@ public class MemberStatUtil {
             return DifferenceStatus.RED;
         }
     }
+
 
     public static DifferenceStatus compareField(
         Object memberStatMapValue, Object criteriaMemberStatValue){


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
memberStatUtil에서  방에 속한 멤버들의 칩 색깔을 정하기 위해 Stat들을 비교해 Status를 리턴하는 메서드를 수정했습니다.
리스트 내 모든 값들을 비교하도록 수정했습니다.


## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요
![image](https://github.com/user-attachments/assets/3a785977-b8c8-47a9-a350-1e94c3dabcbd)
응답 
```json
  "result": {
    "memberList": [
      {
        "memberDetail": {
          "memberId": 5,
          "nickname": "포비",
          "gender": "MALE",
          "birthday": "2000-05-06",
          "universityName": "인하대학교",
          "universityId": 1,
          "majorName": "컴퓨터공학과",
          "persona": 15
        },
        "memberStat": {
          "personality": "낯을 가려요,부끄러움이 많아요,집이 좋아요"
        }
      },
      {
        "memberDetail": {
          "memberId": 2,
          "nickname": "베로",
          "gender": "MALE",
          "birthday": "2000-11-17",
          "universityName": "인하대학교",
          "universityId": 1,
          "majorName": "컴퓨터공학과",
          "persona": 4
        },
        "memberStat": {
          "personality": "집이 좋아요"
        }
      },
      {
        "memberDetail": {
          "memberId": 207,
          "nickname": "두디패두",
          "gender": "MALE",
          "birthday": "2000-05-29",
          "universityName": "인하대학교",
          "universityId": 1,
          "majorName": "",
          "persona": 9
        },
        "memberStat": {
          "personality": "집이 좋아요"
        }
      }
    ],
    "color": "white"

```

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 회원 통계 비교 로직을 개선하여 더 정확한 상태 결정을 가능하게 함
	- 모든 회원 통계를 포괄적으로 비교하도록 알고리즘 최적화
	- 첫 번째 통계에 의존하던 이전 접근 방식에서 벗어나 전체 데이터 세트를 분석하도록 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->