### PR TITLE
[COZY-492] feat: 방 추천에 대학교, 성별 필터링 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -112,4 +112,15 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     WHERE mt.room.id = :roomId AND mt.id != :mateId
     """)
     List<Mate> findByRoomIdAndNotMateId(@Param("roomId") Long roomId, @Param("mateId") Long mateId);
+
+    @Query("""
+    SELECT mt FROM Mate mt
+    JOIN FETCH mt.room r
+    JOIN FETCH mt.member m
+    JOIN FETCH m.university u
+    WHERE mt.room.id IN :roomIdList
+    AND mt.isRoomManager = :isRoomManager
+    AND mt.entryStatus = :entryStatus
+""")
+    List<Mate> findAllByRoomIdListAndIsRoomManagerAndEntryStatus(List<Long> roomIdList, boolean isRoomManager, EntryStatus entryStatus);
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

넵

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

Room 엔티티에 university와 gender 값이 들어오길 기다리다가, 일단 배포를 하게 되었으니 Mate를 통해서 필터링하도록 했습니다.
이후에 추가되게 되면 다시 원상복구 시키고, Room 엔티티를 참조하도록 하겠습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

### 기존에 성별이 동일할 때 검색 결과 -> 우심방 나옴

<img width="571" alt="SCR-20250124-qlpg" src="https://github.com/user-attachments/assets/21ca589e-7ebe-4f2a-a195-9227f20c8c4c" />

### 델로롱을 여자로 변경 (우심방의 방장임)

![SCR-20250124-qlrb](https://github.com/user-attachments/assets/730d3618-9699-4e1e-a2f6-b45886e70c96)

### 이후 검색 결과 -> 우심방이 나오지 않음

<img width="742" alt="SCR-20250124-qlrx" src="https://github.com/user-attachments/assets/a6681daa-9f1b-4c7f-800b-e28f2e7bd54c" />

### 기존에 대학이 같을 때 검색 결과 -> 우심방 나옴

<img width="528" alt="SCR-20250124-qnse" src="https://github.com/user-attachments/assets/e162cf97-b068-4c75-ad85-4d3b07c42a00" />

### 델로롱을 인하대에서 다른 학교로 변경 (우심방의 방장임)

![SCR-20250124-qntc](https://github.com/user-attachments/assets/c0a4e401-ab0e-40e8-aee7-b7d6d48cefe0)

### 이후 검색 결과 -> 우심방이 나오지 않음

<img width="632" alt="SCR-20250124-qnub" src="https://github.com/user-attachments/assets/d6b175a6-f374-4d16-a5db-1f7dd0293284" />



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

개발하면서 점점 많이 알아가고 있는 중입니다.
근데 Member와 MemberStat의 연관 관계의 주인이 MemberStat이라 불필요한 N+1 쿼리가 계속 날라가게 됩니다.
이 연관관계는 주종 관계를 바꾸는게 좋을 것 같습니다. (Member가 주인이고, MemberStat에서 mapped By로 참조하는 식으로)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 메이트 저장소에 새로운 쿼리 메서드 추가
	- 방 추천 서비스에 대학 및 성별 기반 필터링 로직 도입

- **개선 사항**
	- 방 추천 서비스에 로깅 기능 추가
	- 방 필터링 프로세스 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->