### PR TITLE
[COZY-506] fix : 사용자 id List로 일치율 조회 빈 List 에러 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/service/LifestyleMatchRateService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/service/LifestyleMatchRateService.java
@@ -9,6 +9,7 @@ import com.cozymate.cozymate_server.domain.memberstat.memberstat.repository.Memb
 
 import com.cozymate.cozymate_server.domain.university.University;
 import com.cozymate.cozymate_server.domain.university.repository.UniversityRepository;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,9 @@ public class LifestyleMatchRateService {
     public Map<Long, Integer> getMatchRateWithMemberIdAndIdList(Long memberId,
         List<Long> memberIdList) {
 
+        if(memberIdList.isEmpty()){
+            return Collections.emptyMap();
+        }
         List<LifestyleMatchRate.LifestyleMatchRateId> idList = memberIdList.stream()
             .map(id -> new LifestyleMatchRate.LifestyleMatchRateId(memberId, id))
             .toList();

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/response/RoomMemberStatDetailDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/response/RoomMemberStatDetailDTO.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 @Builder
 public record RoomMemberStatDetailDTO(
     MemberDetailResponseDTO memberDetail,
-    Map<String, Object> memberStat
+    Map<String, String> memberStat
 ) {
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roommemberstat/converter/RoomMemberStatDetailConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roommemberstat/converter/RoomMemberStatDetailConverter.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class RoomMemberStatDetailConverter {
 
-    public static RoomMemberStatDetailDTO toRoomMemberStatDetailDTO (Member member, Map<String, Object> stat){
+    public static RoomMemberStatDetailDTO toRoomMemberStatDetailDTO (Member member, Map<String, String> stat){
         return RoomMemberStatDetailDTO.builder()
             .memberDetail(MemberConverter.toMemberDetailResponseDTOFromEntity(member))
             .memberStat(stat)


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네
## #️⃣ 작업 내용
사용자 id List로 일치율 조회인 경우 빈 List 분기처리를 추가했습니다.
`roomMemberstat`부분 정수형으로 반환돼서 수정했습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

`rooms/141/invited-members` 
![image](https://github.com/user-attachments/assets/a17449f9-b521-4757-aef9-30d2c08793cc)

`rooms/{roomId}/memberStat/{memberStatKey}`
![image](https://github.com/user-attachments/assets/8ec7ec1c-acf9-4ae0-8816-de5331e5f77d)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 멤버 ID 목록이 비어 있는 경우 불필요한 처리와 데이터 조회를 방지하여 안정성을 개선했습니다.
- **리팩터링**
  - 회원 통계 데이터 타입을 문자열 전용으로 통일하고, 관련 변환 로직 및 코드 포맷을 개선해 데이터 일관성과 가독성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->