### PR TITLE
[COZY-502] fix: 참여요청한 사용자가 새로운 방 만들었을 경우 처리 추가, 코드 리팩토링

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -49,7 +49,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class RoomCommandService {
 
     private static final String UPPERCASE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -73,7 +72,7 @@ public class RoomCommandService {
     private final RoleCommandService roleCommandService;
     private final TodoCommandService todoCommandService;
 
-
+    @Transactional
     public RoomDetailResponseDTO createPrivateRoom(PrivateRoomCreateRequestDTO request,
         Member member) {
         Member creator = memberRepository.findById(member.getId())
@@ -99,6 +98,7 @@ public class RoomCommandService {
         return roomQueryService.getRoomById(room.getId(), member.getId());
     }
 
+    @Transactional
     public RoomDetailResponseDTO createPublicRoom(PublicRoomCreateRequestDTO request,
         Member member) {
         Member creator = memberRepository.findById(member.getId())
@@ -134,6 +134,7 @@ public class RoomCommandService {
         return roomQueryService.getRoomById(room.getId(), member.getId());
     }
 
+    @Transactional
     public void joinRoom(Long roomId, Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -178,6 +179,7 @@ public class RoomCommandService {
 
     }
 
+    @Transactional
     public void deleteRoom(Long roomId, Long memberId) {
         memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -202,6 +204,7 @@ public class RoomCommandService {
         return roomQueryService.isValidRoomName(roomName);
     }
 
+    @Transactional
     public void quitRoom(Long roomId, Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -294,6 +297,7 @@ public class RoomCommandService {
         }
     }
 
+    @Transactional
     public RoomDetailResponseDTO updateRoom(Long roomId, Long memberId,
         RoomUpdateRequestDTO request) {
 
@@ -321,6 +325,7 @@ public class RoomCommandService {
         return roomQueryService.getRoomById(roomId, memberId);
     }
 
+    @Transactional
     public void sendInvitation(Long inviteeId, Long inviterId) {
         Member inviteeMember = memberRepository.findById(inviteeId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -367,6 +372,7 @@ public class RoomCommandService {
                 NotificationType.ARRIVE_ROOM_INVITE, room));
     }
 
+    @Transactional
     public void respondToInvitation(Long roomId, Long inviteeId, boolean accept) {
         Member inviteeMember = memberRepository.findById(inviteeId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -448,6 +454,7 @@ public class RoomCommandService {
         quitRoom(roomId, targetMemberId);
     }
 
+    @Transactional
     public void cancelInvitation(Long inviteeId, Long inviterId) {
 
         memberRepository.findById(inviteeId)
@@ -471,6 +478,7 @@ public class RoomCommandService {
 
     }
 
+    @Transactional
     public void requestToJoin(Long roomId, Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -528,6 +536,7 @@ public class RoomCommandService {
         }
     }
 
+    @Transactional
     public void cancelRequestToJoin(Long roomId, Long memberId) {
         memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -542,6 +551,7 @@ public class RoomCommandService {
         mateRepository.delete(mate);
     }
 
+    @Transactional
     public void respondToJoinRequest(Long requesterId, boolean accept, Long managerId) {
         Member requestMember = memberRepository.findById(requesterId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -603,6 +613,7 @@ public class RoomCommandService {
         }
     }
 
+    @Transactional
     public void changeToPublicRoom(Long roomId, Long memberId) {
         Member manager = memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
@@ -641,6 +652,7 @@ public class RoomCommandService {
         room.changeToPublicRoom(roomGender, roomUniversity);
     }
 
+    @Transactional
     public void changeToPrivateRoom(Long roomId, Long memberId) {
         memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -314,7 +314,7 @@ public class RoomCommandService {
 
         if (room.getRoomType() == RoomType.PUBLIC) {
             roomHashtagCommandService.deleteRoomHashtags(room);
-            roomHashtagCommandService.updateRoomHashtags(room, request.hashtagList());
+            roomHashtagCommandService.createRoomHashtag(room, request.hashtagList());
         }
         room.updateRoom(request.name(), request.persona());
         roomRepository.save(room);

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -83,6 +83,9 @@ public class RoomCommandService {
             throw new GeneralException(ErrorStatus._ROOM_ALREADY_EXISTS);
         }
 
+        // 기존 참여 요청들 삭제
+        clearOtherRoomRequests(creator.getId());
+
         String inviteCode = generateUniqueUppercaseKey();
         Room room = RoomConverter.toPrivateRoom(request, inviteCode);
         room.enableRoom();
@@ -113,6 +116,9 @@ public class RoomCommandService {
         if (creator.getMemberStat() == null) {
             throw new GeneralException(ErrorStatus._MEMBERSTAT_NOT_EXISTS);
         }
+
+        // 기존 참여 요청들 삭제
+        clearOtherRoomRequests(creator.getId());
 
         Gender gender = creator.getGender();
         University university = creator.getUniversity();

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -51,9 +51,6 @@ public class RoomQueryService {
     private final FavoriteRepository favoriteRepository;
 
     public RoomDetailResponseDTO getRoomById(Long roomId, Long memberId) {
-
-        memberRepository.findById(memberId).orElseThrow(
-            () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
         Room room = roomRepository.findById(roomId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
 
@@ -111,9 +108,6 @@ public class RoomQueryService {
     }
 
     public RoomDetailResponseDTO getRoomByInviteCode(String inviteCode, Long memberId) {
-        memberRepository.findById(memberId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-
         Room room = roomRepository.findByInviteCode(inviteCode)
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
 
@@ -149,9 +143,6 @@ public class RoomQueryService {
     }
 
     public List<MateDetailResponseDTO> getInvitedMemberList(Long roomId, Long memberId) {
-        memberRepository.findById(memberId).orElseThrow(
-            () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-
         Room room = roomRepository.findById(roomId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND));
 
@@ -246,16 +237,10 @@ public class RoomQueryService {
 
 
     public List<RoomDetailResponseDTO> getRequestedRoomList(Long memberId) {
-        memberRepository.findById(memberId).orElseThrow(
-            () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-
         return getRoomList(memberId, EntryStatus.PENDING);
     }
 
     public InvitedRoomResponseDTO getInvitedRoomList(Long memberId) {
-        memberRepository.findById(memberId).orElseThrow(
-            () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-
         Integer invitedCount = mateRepository.countByMemberIdAndEntryStatus(memberId,
             EntryStatus.INVITED);
         return new InvitedRoomResponseDTO(invitedCount, getRoomList(memberId, EntryStatus.INVITED));
@@ -295,7 +280,6 @@ public class RoomQueryService {
     public List<RoomSearchResponseDTO> searchRooms(String keyword, Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(
             () -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-
         Long universityId = member.getUniversity().getId();
         Gender gender = member.getGender();
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomhashtag/service/RoomHashtagCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomhashtag/service/RoomHashtagCommandService.java
@@ -47,8 +47,4 @@ public class RoomHashtagCommandService {
     public void deleteRoomHashtags(Room room) {
         roomHashtagRepository.deleteAllByRoomId(room.getId());
     }
-
-    public void updateRoomHashtags(Room room, List<String> hashtags) {
-        createRoomHashtag(room, hashtags);
-    }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomhashtag/service/RoomHashtagCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomhashtag/service/RoomHashtagCommandService.java
@@ -37,7 +37,7 @@ public class RoomHashtagCommandService {
     }
 
     // 입력한 해시태그 중복 검사
-    public void validateHashtags(List<String> hashtags) {
+    private void validateHashtags(List<String> hashtags) {
         Set<String> uniqueHashtags = new HashSet<>(hashtags);
         if (uniqueHashtags.size() != hashtags.size()) {
             throw new GeneralException(ErrorStatus._DUPLICATE_HASHTAGS);


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네 

## #️⃣ 작업 내용
기존에 다른방에 입장했을때만 요청을 날리도록해서 새로운 방을 만들었을때도 기존에 보낸 요청들이 날아가도록 수정했습니다
이외에 코드를 살짝 리팩토링했습니다

## 동작 확인
![image](https://github.com/user-attachments/assets/c955ca8b-ac37-48ea-bfa7-e978a5775956)
방 생성시 기존 요청이 사라지는 것 확인했습니다
## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 방 생성, 참여, 업데이트 및 초대 응답 기능의 처리 로직을 개선하여 보다 일관되고 안정적인 경험을 제공합니다.
	- 중복 요청 정리 프로세스를 추가해 사용자 작업 흐름의 신뢰성을 향상시켰습니다.
	- 해시태그 관리 방식을 단순화해 사용 인터페이스의 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->