### PR TITLE
[COZY-516] fix: Todo 할당자 조회시 입력된 할당자 수와 맞지 않을 때 예외처리 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/service/TodoCommandService.java
@@ -61,7 +61,7 @@ public class TodoCommandService {
         // 사용자의 mate 정보 조회
         Mate todoCreator = getMate(member.getId(), roomId);
 
-        List<Mate> assignedMateList = mateRepository.findAllByIdIn(requestDto.mateIdList());
+        List<Mate> assignedMateList = getMateList(requestDto.mateIdList());
 
         // 생성자와 할당자가 모두 동일한 방에 있는지 검증
         validateSameRoom(todoCreator, assignedMateList);
@@ -358,6 +358,19 @@ public class TodoCommandService {
      */
     private void addAssignedMateList(Todo todo, List<Mate> mateList) {
         mateList.forEach(mate -> todoAssignmentCommandService.createAssignment(mate, todo));
+    }
+
+    /**
+     * <p>입력받은 mateIdList에 해당하는 모든 메이트가 존재하는지 체크하고 가져오는 함수</p>
+     */
+    private List<Mate> getMateList(List<Long> mateIdList) {
+        List<Mate> assignedMateList = mateRepository.findAllByIdIn(mateIdList);
+
+        // 할당을 위해서 입력받은 리스트가 모두 존재하지 않으면 예외 발생
+        if (assignedMateList.size() != mateIdList.size()) {
+            throw new GeneralException(ErrorStatus._MATE_NOT_FOUND);
+        }
+        return assignedMateList;
     }
 
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

네

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

여러 테스트를 하다가 mateIdList가 일치하지 않는 경우 그냥 빈 배열을 반환하게 되는데, 이 경우 예외로 체크할 수 있도록 처리했습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

### 정상 추가 동작

<img width="611" alt="image" src="https://github.com/user-attachments/assets/83cde5b2-40f6-44c9-860b-90308e97a92c" />

<img width="429" alt="image" src="https://github.com/user-attachments/assets/05cd3962-607c-421c-9b45-535b2fd10e20" />


### 방에 존재하지 않는 메이트로 추가하려고 할 때 (에러)

<img width="361" alt="image" src="https://github.com/user-attachments/assets/e9baeb0a-59f1-4958-abc0-bbe40b6df478" />

<img width="476" alt="image" src="https://github.com/user-attachments/assets/ccc83a4a-83b5-4aae-bd07-51d616d67da2" />

### 가능한 메이트와 다른 번호가 함께 들어왔을 때 (에러)

9는 불가능한 mate고 375는 방에 속한 mate입니다.

<img width="602" alt="image" src="https://github.com/user-attachments/assets/45ce3251-e753-43d2-82e3-a1016104e2b0" />

<img width="472" alt="image" src="https://github.com/user-attachments/assets/4f53ee1b-8a42-45eb-9a68-cb7a2669dee8" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터링**
	- 할 일 생성 과정에서 필요한 관련자 검증 로직이 개선되어, 누락 시 명확한 오류 메시지를 제공함으로써 보다 견고한 처리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->