### PR TITLE
[COZY-547] refac: Fcm, NotificationLog 도메인 RepositoryService 분리 리팩토링

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/repository/FcmRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/repository/FcmRepository.java
@@ -20,6 +20,7 @@ public interface FcmRepository extends JpaRepository<Fcm, String> {
 
     List<Fcm> findAllByIsValidIsTrue();
 
+    @Modifying
     @Query("delete from Fcm f where f.member.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/repository/FcmRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/repository/FcmRepository.java
@@ -20,5 +20,6 @@ public interface FcmRepository extends JpaRepository<Fcm, String> {
 
     List<Fcm> findAllByIsValidIsTrue();
 
-    void deleteAllByMemberId(Long memberId);
+    @Query("delete from Fcm f where f.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/repository/FcmRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/repository/FcmRepositoryService.java
@@ -1,0 +1,29 @@
+package com.cozymate.cozymate_server.domain.fcm.repository;
+
+import com.cozymate.cozymate_server.domain.fcm.Fcm;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FcmRepositoryService {
+
+    private final FcmRepository fcmRepository;
+
+    public Optional<Fcm> getFcmOptionalByClientId(String clientId) {
+        return fcmRepository.findById(clientId);
+    }
+
+    public void createFcm(Fcm fcm) {
+        fcmRepository.save(fcm);
+    }
+
+    public void updateFcmValidToFalseByToken(String token) {
+        fcmRepository.updateValidByToken(token);
+    }
+
+    public void deleteFcmByMemberId(Long memberId) {
+        fcmRepository.deleteAllByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmCommandService.java
@@ -3,7 +3,7 @@ package com.cozymate.cozymate_server.domain.fcm.service;
 import com.cozymate.cozymate_server.domain.fcm.Fcm;
 import com.cozymate.cozymate_server.domain.fcm.converter.FcmConverter;
 import com.cozymate.cozymate_server.domain.fcm.dto.request.FcmRequestDTO;
-import com.cozymate.cozymate_server.domain.fcm.repository.FcmRepository;
+import com.cozymate.cozymate_server.domain.fcm.repository.FcmRepositoryService;
 import com.cozymate.cozymate_server.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,16 +14,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class FcmCommandService {
 
-    private final FcmRepository fcmRepository;
+    private final FcmRepositoryService fcmRepositoryService;
 
     public void createFcm(Member member, FcmRequestDTO fcmRequestDTO) {
-        fcmRepository.findById(member.getClientId())
-            .ifPresentOrElse(
-                fcm -> fcm.updateToken(fcmRequestDTO.token()),
-                () -> {
-                    Fcm fcm = FcmConverter.toEntity(member, fcmRequestDTO);
-                    fcmRepository.save(fcm);
-                }
-            );
+        fcmRepositoryService.getFcmOptionalByClientId(member.getClientId())
+                .ifPresentOrElse(
+                    fcm -> fcm.updateToken(fcmRequestDTO.token()),
+                    () -> {
+                        Fcm fcm = FcmConverter.toEntity(member, fcmRequestDTO);
+                        fcmRepositoryService.createFcm(fcm);
+                    }
+                );
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmCommandService.java
@@ -18,12 +18,12 @@ public class FcmCommandService {
 
     public void createFcm(Member member, FcmRequestDTO fcmRequestDTO) {
         fcmRepositoryService.getFcmOptionalByClientId(member.getClientId())
-                .ifPresentOrElse(
-                    fcm -> fcm.updateToken(fcmRequestDTO.token()),
-                    () -> {
-                        Fcm fcm = FcmConverter.toEntity(member, fcmRequestDTO);
-                        fcmRepositoryService.createFcm(fcm);
-                    }
-                );
+            .ifPresentOrElse(
+                fcm -> fcm.updateToken(fcmRequestDTO.token()),
+                () -> {
+                    Fcm fcm = FcmConverter.toEntity(member, fcmRequestDTO);
+                    fcmRepositoryService.createFcm(fcm);
+                }
+            );
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
@@ -3,7 +3,7 @@ package com.cozymate.cozymate_server.domain.member.service;
 import com.cozymate.cozymate_server.domain.auth.repository.TokenRepository;
 import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
 import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
-import com.cozymate.cozymate_server.domain.fcm.repository.FcmRepository;
+import com.cozymate.cozymate_server.domain.fcm.repository.FcmRepositoryService;
 import com.cozymate.cozymate_server.domain.inquiry.repository.InquiryRepository;
 import com.cozymate.cozymate_server.domain.mail.repository.MailRepository;
 import com.cozymate.cozymate_server.domain.mate.Mate;
@@ -15,7 +15,7 @@ import com.cozymate.cozymate_server.domain.memberfavorite.repository.MemberFavor
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.repository.LifestyleMatchRateRepository;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.repository.MemberStatRepository;
 import com.cozymate.cozymate_server.domain.memberstatpreference.repository.MemberStatPreferenceRepository;
-import com.cozymate.cozymate_server.domain.notificationlog.repository.NotificationLogRepository;
+import com.cozymate.cozymate_server.domain.notificationlog.repository.NotificationLogRepositoryService;
 import com.cozymate.cozymate_server.domain.post.Post;
 import com.cozymate.cozymate_server.domain.post.repository.PostRepository;
 import com.cozymate.cozymate_server.domain.postcomment.PostCommentRepository;
@@ -46,8 +46,8 @@ public class MemberWithdrawService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
     private final ReportRepository reportRepository;
-    private final FcmRepository fcmRepository;
-    private final NotificationLogRepository notificationLogRepository;
+    private final FcmRepositoryService fcmRepositoryService;
+    private final NotificationLogRepositoryService notificationLogRepositoryService;
     private final MateRepository mateRepository;
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
@@ -106,8 +106,8 @@ public class MemberWithdrawService {
 
         log.debug("문의, 신고내역 처리 완료");
 
-        fcmRepository.deleteAllByMemberId(member.getId());
-        notificationLogRepository.deleteAllByMemberId(member.getId());
+        fcmRepositoryService.deleteFcmByMemberId(member.getId());
+        notificationLogRepositoryService.deleteNotificationLogByMemberId(member.getId());
 
         log.debug("Fcm 토큰, 알림 내역 삭제 완료");
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/repository/NotificationLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/repository/NotificationLogRepository.java
@@ -5,10 +5,15 @@ import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
 import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType.NotificationCategory;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationLogRepository extends JpaRepository<NotificationLog, Long> {
 
     List<NotificationLog> findByMemberAndCategoryNotInOrderByIdDesc(Member member, List<NotificationCategory> categoryList);
 
-    void deleteAllByMemberId(Long memberId);
+    @Modifying
+    @Query("delete from NotificationLog n where n.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/repository/NotificationLogRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/repository/NotificationLogRepositoryService.java
@@ -1,0 +1,35 @@
+package com.cozymate.cozymate_server.domain.notificationlog.repository;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
+import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType.NotificationCategory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationLogRepositoryService {
+
+    private final NotificationLogRepository notificationLogRepository;
+    private final NotificationLogBulkRepository notificationLogBulkRepository;
+
+    public void createNotificationLog(NotificationLog notificationLog) {
+        notificationLogRepository.save(notificationLog);
+    }
+
+    public List<NotificationLog> getNotificationLogListByMember(Member member) {
+        return notificationLogRepository.findByMemberAndCategoryNotInOrderByIdDesc(
+            member, List.of(NotificationCategory.COZY_HOME, NotificationCategory.COZY_ROLE));
+    }
+
+    public void createNoticeNotificationLog(List<Long> successMemberIdList, String content,
+        Long targetId) {
+        notificationLogBulkRepository.saveAll(successMemberIdList, NotificationCategory.NOTICE,
+            content, targetId);
+    }
+
+    public void deleteNotificationLogByMemberId(Long memberId) {
+        notificationLogRepository.deleteAllByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/service/NotificationLogQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/service/NotificationLogQueryService.java
@@ -4,8 +4,7 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
 import com.cozymate.cozymate_server.domain.notificationlog.converter.NotificationLogConverter;
 import com.cozymate.cozymate_server.domain.notificationlog.dto.response.NotificationLogResponseDTO;
-import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType.NotificationCategory;
-import com.cozymate.cozymate_server.domain.notificationlog.repository.NotificationLogRepository;
+import com.cozymate.cozymate_server.domain.notificationlog.repository.NotificationLogRepositoryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,13 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class NotificationLogQueryService {
 
-    private final NotificationLogRepository notificationLogRepository;
+    private final NotificationLogRepositoryService notificationLogRepositoryService;
 
     public List<NotificationLogResponseDTO> getNotificationLogList(Member member) {
-        List<NotificationLog> notificationLogs = notificationLogRepository.findByMemberAndCategoryNotInOrderByIdDesc(
-            member, List.of(NotificationCategory.COZY_HOME, NotificationCategory.COZY_ROLE));
+        List<NotificationLog> notificationLogList = notificationLogRepositoryService.getNotificationLogListByMember(
+            member);
 
-        List<NotificationLogResponseDTO> notificationLogResponseDTOList = notificationLogs.stream()
+        List<NotificationLogResponseDTO> notificationLogResponseDTOList = notificationLogList.stream()
             .map(notificationLog -> NotificationLogConverter.toNotificationLogResponseDTO(
                 notificationLog.getContent(),
                 notificationLog.getCreatedAt(),


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. Fcm, NotificationLog 도메인 RepositoryService 분리 리팩토링
2. 분리 이후 멤버 탈퇴 도메인쪽 코드를 수정했습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

이쪽 도메인에서는 Validator를 분리할게 없어보여 Validator 분리는 하지 않았습니다.
분리 리팩토링에서 변수명 컨벤션 위주로 리뷰 부탁드려요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 푸시 알림과 알림 로그 관리 기능이 강화되어 사용자에게 전달되는 알림의 신뢰성과 일관성이 개선되었습니다.
- **리팩토링**
  - 내부 데이터 처리 구조가 재정비되어 회원 관련 작업과 알림, 메시지 처리 로직이 더욱 안정적이고 효율적으로 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->