### PR TITLE
[COZY-548] refac: MemberFavorite, RoomFavorite 도메인 Validator, RepositoryService 분리 리팩토링

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/repository/MemberFavoriteRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/repository/MemberFavoriteRepositoryService.java
@@ -1,0 +1,39 @@
+package com.cozymate.cozymate_server.domain.memberfavorite.repository;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.memberfavorite.MemberFavorite;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberFavoriteRepositoryService {
+
+    private final MemberFavoriteRepository memberFavoriteRepository;
+
+    public boolean existMemberFavoriteByMemberAndTargetMember(Member member, Member targetMember) {
+        return memberFavoriteRepository.existsByMemberAndTargetMember(member, targetMember);
+    }
+
+    public void createMemberFavorite(MemberFavorite memberFavorite) {
+        memberFavoriteRepository.save(memberFavorite);
+    }
+
+    public MemberFavorite getMemberFavoriteByIdOrThrow(Long memberFavoriteId) {
+        return memberFavoriteRepository.findById(memberFavoriteId)
+            .orElseThrow(
+                () -> new GeneralException(ErrorStatus._MEMBERFAVORITE_NOT_FOUND)
+            );
+    }
+
+    public void deleteMemberFavorite(MemberFavorite memberFavorite) {
+        memberFavoriteRepository.delete(memberFavorite);
+    }
+
+    public List<MemberFavorite> getMemberFavoriteListByMember(Member member) {
+        return memberFavoriteRepository.findByMember(member);
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/service/MemberFavoriteQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/service/MemberFavoriteQueryService.java
@@ -4,7 +4,7 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberfavorite.MemberFavorite;
 import com.cozymate.cozymate_server.domain.memberfavorite.converter.MemberFavoriteConverter;
 import com.cozymate.cozymate_server.domain.memberfavorite.dto.response.MemberFavoriteResponseDTO;
-import com.cozymate.cozymate_server.domain.memberfavorite.repository.MemberFavoriteRepository;
+import com.cozymate.cozymate_server.domain.memberfavorite.repository.MemberFavoriteRepositoryService;
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.service.LifestyleMatchRateService;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.MemberStat;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.converter.MemberStatConverter;
@@ -23,15 +23,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberFavoriteQueryService {
 
-    private final MemberFavoriteRepository memberFavoriteRepository;
+    private final MemberFavoriteRepositoryService memberFavoriteRepositoryService;
     private final LifestyleMatchRateService lifestyleMatchRateService;
     private final MemberStatPreferenceQueryService memberStatPreferenceQueryService;
 
     public List<MemberFavoriteResponseDTO> getMemberFavoriteList(Member member) {
-        List<MemberFavorite> memberFavoriteList = memberFavoriteRepository.findByMember(member);
+        List<MemberFavorite> memberFavoriteList = memberFavoriteRepositoryService.getMemberFavoriteListByMember(
+            member);
 
         if (memberFavoriteList.isEmpty()) {
-            return new ArrayList<>();
+            return List.of();
         }
 
         Map<Member, Long> targetMemberFavoriteIdMap = memberFavoriteList.stream()
@@ -39,7 +40,8 @@ public class MemberFavoriteQueryService {
 
         List<Member> findTargetMemberList = new ArrayList<>(targetMemberFavoriteIdMap.keySet());
 
-        Map<Long, Integer> equalityMap = lifestyleMatchRateService.getMatchRateWithMemberIdAndIdList(member.getId(),
+        Map<Long, Integer> equalityMap = lifestyleMatchRateService.getMatchRateWithMemberIdAndIdList(
+            member.getId(),
             findTargetMemberList.stream().map(Member::getId).toList());
 
         List<String> criteriaPreferences = memberStatPreferenceQueryService.getPreferencesToList(

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/validator/MemberFavoriteValidator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/validator/MemberFavoriteValidator.java
@@ -1,0 +1,43 @@
+package com.cozymate.cozymate_server.domain.memberfavorite.validator;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.memberfavorite.MemberFavorite;
+import com.cozymate.cozymate_server.domain.memberfavorite.repository.MemberFavoriteRepositoryService;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberFavoriteValidator {
+
+    private final MemberFavoriteRepositoryService memberFavoriteRepositoryService;
+
+    public void checkSameMember(Member member, Long targetMemberId) {
+        if (targetMemberId.equals(member.getId())) {
+            throw new GeneralException(ErrorStatus._MEMBERFAVORITE_CANNOT_REQUEST_SELF);
+        }
+    }
+
+    public void checkMemberStatIsNull(Member member) {
+        if (Objects.isNull(member.getMemberStat())) {
+            throw new GeneralException(
+                ErrorStatus._MEMBERFAVORITE_CANNOT_FAVORITE_MEMBER_WITHOUT_MEMBERSTAT);
+        }
+    }
+
+    public void checkDuplicateMemberFavorite(Member member, Member targetMember) {
+        if (memberFavoriteRepositoryService.existMemberFavoriteByMemberAndTargetMember(member,
+            targetMember)) {
+            throw new GeneralException(ErrorStatus._MEMBERFAVORITE_ALREADY_EXISTS);
+        }
+    }
+
+    public void checkDeletePermission(MemberFavorite memberFavorite, Member member) {
+        if (!memberFavorite.getMember().getId().equals(member.getId())) {
+            throw new GeneralException(ErrorStatus._MEMBERFAVORITE_MEMBER_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepository.java
@@ -19,7 +19,7 @@ public interface RoomFavoriteRepository extends JpaRepository<RoomFavorite, Long
     List<RoomFavorite> findByMember(Member member);
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("delete from RoomFavorite rf where rf.room.id in :roomIds")
     void deleteAllByRoomIds(@Param("roomIds") List<Long> roomIds);
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepositoryService.java
@@ -1,0 +1,44 @@
+package com.cozymate.cozymate_server.domain.roomfavorite.repository;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.room.Room;
+import com.cozymate.cozymate_server.domain.roomfavorite.RoomFavorite;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomFavoriteRepositoryService {
+
+    private final RoomFavoriteRepository roomFavoriteRepository;
+
+    public void createRoomFavorite(RoomFavorite roomFavorite) {
+        roomFavoriteRepository.save(roomFavorite);
+    }
+
+    public RoomFavorite getRoomFavoriteByIdOrThrow(Long roomFavoriteId) {
+        return roomFavoriteRepository.findById(roomFavoriteId)
+            .orElseThrow(
+                () -> new GeneralException(ErrorStatus._ROOMFAVORITE_NOT_FOUND)
+            );
+    }
+
+    public void deleteRoomFavorite(RoomFavorite roomFavorite) {
+        roomFavoriteRepository.delete(roomFavorite);
+    }
+
+    public boolean existRoomFavoriteByMemberAndRoom(Member member, Room room) {
+        return roomFavoriteRepository.existsByMemberAndRoom(member, room);
+    }
+
+    public List<RoomFavorite> getRoomFavoriteListByMember(Member member) {
+        return roomFavoriteRepository.findByMember(member);
+    }
+
+    public void deleteRoomFavoriteByRoomIds(List<Long> deleteTargetRoomIdList) {
+        roomFavoriteRepository.deleteAllByRoomIds(deleteTargetRoomIdList);
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/service/RoomFavoriteCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/service/RoomFavoriteCommandService.java
@@ -2,12 +2,11 @@ package com.cozymate.cozymate_server.domain.roomfavorite.service;
 
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.room.Room;
-import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
-import com.cozymate.cozymate_server.domain.room.enums.RoomType;
 import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
 import com.cozymate.cozymate_server.domain.roomfavorite.RoomFavorite;
 import com.cozymate.cozymate_server.domain.roomfavorite.converter.RoomFavoriteConverter;
-import com.cozymate.cozymate_server.domain.roomfavorite.repository.RoomFavoriteRepository;
+import com.cozymate.cozymate_server.domain.roomfavorite.repository.RoomFavoriteRepositoryService;
+import com.cozymate.cozymate_server.domain.roomfavorite.validator.RoomFavoriteValidator;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -19,53 +18,26 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class RoomFavoriteCommandService {
 
-    private final RoomFavoriteRepository roomFavoriteRepository;
     private final RoomRepository roomRepository;
+    private final RoomFavoriteValidator roomFavoriteValidator;
+    private final RoomFavoriteRepositoryService roomFavoriteRepositoryService;
 
     public void saveRoomFavorite(Member member, Long roomId) {
-        Room room = validRoom(roomId);
-        checkDuplicateFavorite(member, room);
-
-        roomFavoriteRepository.save(RoomFavoriteConverter.toEntity(member, room));
-    }
-
-    public void deleteRoomFavorite(Member member, Long roomFavoriteId) {
-        RoomFavorite roomFavorite = roomFavoriteRepository.findById(roomFavoriteId).orElseThrow(
-            () -> new GeneralException(ErrorStatus._ROOMFAVORITE_NOT_FOUND)
-        );
-
-        if (!roomFavorite.getMember().getId().equals(member.getId())) {
-            throw new GeneralException(ErrorStatus._ROOMFAVORITE_MEMBER_MISMATCH);
-        }
-
-        roomFavoriteRepository.delete(roomFavorite);
-    }
-
-    private Room validRoom(Long roomId) {
         Room room = roomRepository.findById(roomId).orElseThrow(
             () -> new GeneralException(ErrorStatus._ROOM_NOT_FOUND)
         );
 
-        if (RoomType.PRIVATE.equals(room.getRoomType())) {
-            throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_PRIVATE_ROOM);
-        }
+        roomFavoriteValidator.checkRoomCanBeFavorited(room);
+        roomFavoriteValidator.checkDuplicateRoomFavorite(member, room);
 
-        if (room.getNumOfArrival() == room.getMaxMateNum()) {
-            throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_FULL_ROOM);
-        }
-
-        if (RoomStatus.DISABLE.equals(room.getStatus())) {
-            throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_DISABLE_ROOM);
-        }
-
-        return room;
+        roomFavoriteRepositoryService.createRoomFavorite(RoomFavoriteConverter.toEntity(member, room));
     }
 
-    private void checkDuplicateFavorite(Member member, Room room) {
-        boolean isExists = roomFavoriteRepository.existsByMemberAndRoom(member, room);
+    public void deleteRoomFavorite(Member member, Long roomFavoriteId) {
+        RoomFavorite roomFavorite = roomFavoriteRepositoryService.getRoomFavoriteByIdOrThrow(roomFavoriteId);
 
-        if (isExists) {
-            throw new GeneralException(ErrorStatus._ROOMFAVORITE_ALREADY_EXISTS);
-        }
+        roomFavoriteValidator.checkDeletePermission(roomFavorite, member);
+
+        roomFavoriteRepositoryService.deleteRoomFavorite(roomFavorite);
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/validator/RoomFavoriteValidator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/validator/RoomFavoriteValidator.java
@@ -1,0 +1,45 @@
+package com.cozymate.cozymate_server.domain.roomfavorite.validator;
+
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.room.Room;
+import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
+import com.cozymate.cozymate_server.domain.room.enums.RoomType;
+import com.cozymate.cozymate_server.domain.roomfavorite.RoomFavorite;
+import com.cozymate.cozymate_server.domain.roomfavorite.repository.RoomFavoriteRepositoryService;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomFavoriteValidator {
+
+    private final RoomFavoriteRepositoryService roomFavoriteRepositoryService;
+
+    public void checkRoomCanBeFavorited(Room room) {
+        if (RoomType.PRIVATE.equals(room.getRoomType())) {
+            throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_PRIVATE_ROOM);
+        }
+
+        if (room.getNumOfArrival() == room.getMaxMateNum()) {
+            throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_FULL_ROOM);
+        }
+
+        if (RoomStatus.DISABLE.equals(room.getStatus())) {
+            throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_DISABLE_ROOM);
+        }
+    }
+
+    public void checkDuplicateRoomFavorite(Member member, Room room) {
+        if (roomFavoriteRepositoryService.existRoomFavoriteByMemberAndRoom(member, room)) {
+            throw new GeneralException(ErrorStatus._ROOMFAVORITE_ALREADY_EXISTS);
+        }
+    }
+
+    public void checkDeletePermission(RoomFavorite roomFavorite, Member member) {
+        if (!roomFavorite.getMember().getId().equals(member.getId())) {
+            throw new GeneralException(ErrorStatus._ROOMFAVORITE_MEMBER_MISMATCH);
+        }
+    }
+}


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. MemberFavorite, RoomFavorite 도메인 Validator, RepositoryService 분리
2. 코드 일부 수정

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

Validator, RepositoryService 분리 외에 코드 수정한 부분들 코멘트 달아두었고,
분리 리팩토링에서 변수명 컨벤션 위주로 리뷰 부탁드려요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 회원과 룸 즐겨찾기를 관리하기 위한 새로운 서비스 레이어가 도입되었습니다.
  - 즐겨찾기 작업 시, 중복 체크, 권한 검증 등 다양한 유효성 검사 기능이 추가되었습니다.

- **리팩토링**
  - 기존 로직이 새로운 서비스 및 검증 컴포넌트를 활용하도록 전반적으로 업데이트되었습니다.
  - 즐겨찾기 목록 반환 시 빈 리스트 처리가 불변 리스트 방식으로 개선되었습니다.

- **Chores**
  - 룸 즐겨찾기 삭제 시, 기본 영속성 컨텍스트 동작에 맞추어 데이터 처리 방식이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->