### PR TITLE
[COZY-555] fix: RoomHashtag의 엔티티 관계 변경으로 발생한 EntityMapping 참조 문제 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
@@ -32,9 +32,7 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
     /**
      * 사용자에게 방 추천을 해줄 때 조회할 수 있는 방 목록을 보는 쿼리
-     * roomHashtags, hashtag로 인한 N+1 문제를 해결하기 위해 EntityGraph 사용
      */
-    @EntityGraph(attributePaths = {"roomHashtags", "roomHashtags.hashtag"})
     @Query("""
         SELECT distinct r FROM Room r
         WHERE r.roomType = :roomType


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

Room 엔티티에 관계가 변경되면서 발생한 문제였습니다.
EntityMapping에 RoomHashTag가 있었는데, 변경되면서 참조할 수 없게 되니 문제가 발생한거였습니다.
해당 연관을 삭제했고, 이제는 정상 동작 합니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

<img width="666" alt="image" src="https://github.com/user-attachments/assets/abfd3245-2e3b-4864-b119-c4972d03a815" />

<img width="1321" alt="image" src="https://github.com/user-attachments/assets/27cc9eda-cff5-4a9a-88f9-b56376df4c82" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 룸 목록 표시를 위한 데이터 조회 및 처리 로직을 내부적으로 개선하였습니다.
  - 이번 내부 변경은 데이터 로딩 방식에 일부 차이가 발생할 수 있으며, 전반적인 시스템 안정성과 성능 최적화를 목표로 하고 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->