### PR TITLE
[COZY-556] fix: RoomHashTag 생성시 Room 데이터를 먼저 저장하지 않고 넣어서 발생한 에러 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -120,8 +120,8 @@ public class RoomCommandService {
         Room room = RoomConverter.toPublicRoom(request, inviteCode, gender, university);
 
         // 해시태그 저장 과정
-        roomHashtagCommandService.createRoomHashtag(room, request.hashtagList());
         room = roomRepositoryService.save(room);
+        roomHashtagCommandService.createRoomHashtag(room, request.hashtagList());
         roomLogCommandService.addRoomLogCreationRoom(room);
 
         Mate mate = MateConverter.toEntity(room, member, true);


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

### 에러 내용
<img width="1777" alt="image" src="https://github.com/user-attachments/assets/95876af2-7eb5-4768-b690-e3d0d76c1bc3" />

### 에러 발생 원인
``` java

roomHashtagCommandService.createRoomHashtag(room, request.hashtagList());
room = roomRepositoryService.save(room);

```
위의 순서 기존의 코드가 잇었는데, createRoomHashtag에서 저장되기 전(id가 생성되기 전의 Room) 객체를 받아서 RoomHashTag를 생성하려고 하다가. RoomHashTag 엔티티에 외래키로 넣을 Room id값이 없어서 가져오라고 에러를 반환시키고 있었습니다.


## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

<img width="1344" alt="image" src="https://github.com/user-attachments/assets/1749f98d-c926-48e9-bd09-412e6d9ddc6a" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 내부 프로세스의 실행 순서를 조정하여 방 생성 시 데이터 처리가 보다 안정적으로 진행되도록 개선했습니다. 최종 사용자에게 제공되는 기능과 동작은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->