### PR TITLE
[COZY-559] fix: 내방으로 초대하기 오류 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -269,7 +269,7 @@ public class RoomCommandService {
 
     @Transactional
     public void sendInvitation(Long inviteeId, Member inviterMember) {
-        memberRepository.findById(inviteeId)
+        Member inviteeMember = memberRepository.findById(inviteeId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
         // 방장이 속한 방의 정보
         Room room = roomRepositoryService.getRoomOrThrow(roomQueryService.getExistRoom(inviterMember.getId()).roomId());
@@ -293,12 +293,12 @@ public class RoomCommandService {
             mate.setEntryStatus(EntryStatus.INVITED);
             mateRepository.save(mate);
         } else {
-            Mate mate = MateConverter.toInvitation(room, inviterMember, false);
+            Mate mate = MateConverter.toInvitation(room, inviteeMember, false);
             mateRepository.save(mate);
         }
 
         eventPublisher.publishEvent(
-            EventConverter.toSentInvitationEvent(inviter.getMember(), inviterMember, room));
+            EventConverter.toSentInvitationEvent(inviter.getMember(), inviteeMember, room));
     }
 
     @Transactional


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
리팩토링 과정에서 초대받은사람(invitee) 위치에 초대한 사람(inviter)을 넣는 실수가 있었습니다..
이전과 같이 동작하도록 수정했습니다

## 동작 확인
![image](https://github.com/user-attachments/assets/e5f23810-9e81-4e28-ad1a-8f56c7c7fbcf)
![image](https://github.com/user-attachments/assets/f0b4d8fa-4c56-4755-a27d-6c4c351c1c19)
![image](https://github.com/user-attachments/assets/c13872be-75f4-4498-a8f7-90ef4c8d4f58)
정상작동 확인했습니다

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 초대 처리 개선: 초대 기능과 관련된 처리 논리가 개선되어, 올바른 초대 대상이 정확하게 식별되고 전달됩니다. 이 업데이트를 통해 사용자들은 방 참여 초대를 받을 때 혼란이 줄어들고, 초대 상호작용의 일관성과 서비스 품질이 향상되었습니다. 이 개선사항은 사용자 경험을 향상시키기 위한 지속적인 노력의 일환으로, 서비스의 신뢰도를 높이고 초대 기능 사용 시 발생할 수 있는 불편함을 최소화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->