### PR TITLE
[COZY-560] fix: 푸시 알림 오류 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -32,6 +32,10 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     Optional<Mate> findByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId,
         EntryStatus status);
 
+    @EntityGraph(attributePaths = {"member"})
+    Optional<Mate> findFetchMemberByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId,
+        EntryStatus status);
+
     boolean existsByRoomIdAndMemberIdAndEntryStatus(Long roomId, Long memberId, EntryStatus status);
 
     List<Mate> findAllByMemberIdAndEntryStatus(Long memberId, EntryStatus entryStatus);

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepositoryService.java
@@ -24,4 +24,9 @@ public class MateRepositoryService {
             .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_ROOM_MATE));
     }
 
+    public Mate getJoinedMateFetchMemberOrThrow(Long roomId, Long memberId) {
+        return mateRepository.findFetchMemberByRoomIdAndMemberIdAndEntryStatus(roomId, memberId, EntryStatus.JOINED)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_ROOM_MATE));
+    }
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -177,7 +177,7 @@ public class RoomCommandService {
     @Transactional
     public void quitRoom(Long roomId, Long memberId) {
         Room room = roomRepositoryService.getRoomOrThrow(roomId);
-        Mate quittingMate = mateRepositoryService.getJoinedMateOrThrow(roomId, memberId);
+        Mate quittingMate = mateRepositoryService.getJoinedMateFetchMemberOrThrow(roomId, memberId);
 
         // 이미 나간 방에 대한 예외 처리
         if (quittingMate.getEntryStatus() == EntryStatus.EXITED) {
@@ -272,10 +272,12 @@ public class RoomCommandService {
         Member inviteeMember = memberRepository.findById(inviteeId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
         // 방장이 속한 방의 정보
-        Room room = roomRepositoryService.getRoomOrThrow(roomQueryService.getExistRoom(inviterMember.getId()).roomId());
+        Room room = roomRepositoryService.getRoomOrThrow(
+            roomQueryService.getExistRoom(inviterMember.getId()).roomId());
 
         // 초대한 사용자가 방장인지 검증
-        Mate inviter = mateRepositoryService.getJoinedMateOrThrow(room.getId(), inviterMember.getId());
+        Mate inviter = mateRepositoryService.getJoinedMateFetchMemberOrThrow(room.getId(),
+            inviterMember.getId());
         roomValidator.checkRoomManager(inviter);
 
         // 이미 참가한 방인지 검사
@@ -352,8 +354,10 @@ public class RoomCommandService {
         memberRepository.findById(inviteeId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
-        Room room = roomRepositoryService.getRoomOrThrow(roomQueryService.getExistRoom(inviter.getId()).roomId());
-        Mate inviterMate = mateRepositoryService.getJoinedMateOrThrow(room.getId(), inviter.getId());
+        Room room = roomRepositoryService.getRoomOrThrow(
+            roomQueryService.getExistRoom(inviter.getId()).roomId());
+        Mate inviterMate = mateRepositoryService.getJoinedMateOrThrow(room.getId(),
+            inviter.getId());
         // 초대한 사용자가 방장인지 검증
         roomValidator.checkRoomManager(inviterMate);
 
@@ -405,10 +409,12 @@ public class RoomCommandService {
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
         // 방장이 속한 방의 정보
-        Room room = roomRepositoryService.getRoomOrThrow(roomQueryService.getExistRoom(managerId).roomId());
+        Room room = roomRepositoryService.getRoomOrThrow(
+            roomQueryService.getExistRoom(managerId).roomId());
 
         // 방장인지 검증
-        Mate manager = mateRepositoryService.getJoinedMateOrThrow(room.getId(), managerId);
+        Mate manager = mateRepositoryService.getJoinedMateFetchMemberOrThrow(room.getId(),
+            managerId);
         roomValidator.checkRoomManager(manager);
 
         // 만약 WAITING 또는 ENABLE 상태의 방에 이미 참여했다면 예외 발생


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. 방 나가기, 방 초대하기, 방 참여 요청 거절에서 LazyInitializationException 예외 발생에 대한 처리
2. 방 참여 요청 수락에서 LazyInitializationException 예외 발생 대신 프록시 필드의 null을 읽어버리는 문제에 대한 처리

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

일단 오류 해결을 위해 페치 조인으로 처리를 했는데, 2번 같은 경우에서 예외 발생 대신에 null을 읽는 이유에 대해서 한번 공부해보겠습니다.
프록시 객체의 게터를 호출하면 지연 로딩되는걸로 알고 있고, 실제로 getNickname()으로 접근하고 있는데 왜 예외 발생이 아니라 필드 접근하듯 null을 읽어버리는지 모르겠네요.
혹시 이유를 아는 분 계신가여?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 방 관련 작업 시 사용자 멤버 정보가 함께 조회되어 보다 정확한 데이터 처리가 이루어집니다.
	- 관련 정보가 없을 경우 적절한 오류 처리가 적용됩니다.
- **리팩터**
	- 내부 데이터 조회 방식과 호출 로직이 개선되어 코드 가독성과 유지 관리 효율성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->