### PR TITLE
[COZY-565] fix: 사용자 찜, 방 찜 목록 조회 페이징 처리

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -48,7 +48,8 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     List<Mate> findAllByRoomIdAndEntryStatus(Long roomId, EntryStatus entryStatus);
 
     @Query("SELECT m FROM Mate m JOIN FETCH m.member WHERE m.room = :room AND m.entryStatus = :entryStatus")
-    List<Mate> findFetchMemberByRoomAndEntryStatus(@Param("room") Room room, @Param("entryStatus") EntryStatus entryStatus);
+    List<Mate> findFetchMemberByRoomAndEntryStatus(@Param("room") Room room,
+        @Param("entryStatus") EntryStatus entryStatus);
 
     // MemberBirthDay의 Localdate 값에서 Month와 Day가 같은 Member들을 찾는다.
     @Query("SELECT m FROM Mate m WHERE MONTH(m.member.birthDay) = :month AND DAY(m.member.birthDay) = :day AND m.entryStatus = :entryStatus")
@@ -80,7 +81,7 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     void deleteAllByMemberIdAndEntryStatusIn(Long memberId, List<EntryStatus> entryStatuses);
 
-    @Query("select mt from Mate mt join fetch mt.member m join fetch m.memberStat where mt.room = :room and mt.entryStatus = :entryStatus")
+    @Query("select mt from Mate mt join fetch mt.member m left join fetch m.memberStat where mt.room = :room and mt.entryStatus = :entryStatus")
     List<Mate> findFetchMemberAndMemberStatByRoom(@Param("room") Room room,
         @Param("entryStatus") EntryStatus entryStatus);
 
@@ -94,24 +95,25 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     void deleteAllByRoomId(@Param("roomId") Long roomId);
 
     /**
-     * TODO에서 Mate를 가져와서 Mate 데이터와 Member를 사용해야하는데 지연 로딩 문제로 Member가 Proxy 에러가 발생하여 다음과 같이 Fetch Join을 사용함
-     * 내가 완료하지 못한 데이터가 있는지 확인하고, 모두 완료했으면 룸메이트에게 FCM 알림을 보내기 위함
+     * TODO에서 Mate를 가져와서 Mate 데이터와 Member를 사용해야하는데 지연 로딩 문제로 Member가 Proxy 에러가 발생하여 다음과 같이 Fetch
+     * Join을 사용함 내가 완료하지 못한 데이터가 있는지 확인하고, 모두 완료했으면 룸메이트에게 FCM 알림을 보내기 위함
      */
     @Query("""
-    SELECT mt FROM Mate mt
-    JOIN FETCH mt.member m
-    WHERE mt.room.id = :roomId AND mt.id != :mateId
-    """)
+        SELECT mt FROM Mate mt
+        JOIN FETCH mt.member m
+        WHERE mt.room.id = :roomId AND mt.id != :mateId
+        """)
     List<Mate> findByRoomIdAndNotMateId(@Param("roomId") Long roomId, @Param("mateId") Long mateId);
 
     @Query("""
-    SELECT mt FROM Mate mt
-    JOIN FETCH mt.room r
-    JOIN FETCH mt.member m
-    JOIN FETCH m.university u
-    WHERE mt.room.id IN :roomIdList
-    AND mt.isRoomManager = :isRoomManager
-    AND mt.entryStatus = :entryStatus
-""")
-    List<Mate> findAllByRoomIdListAndIsRoomManagerAndEntryStatus(List<Long> roomIdList, boolean isRoomManager, EntryStatus entryStatus);
+            SELECT mt FROM Mate mt
+            JOIN FETCH mt.room r
+            JOIN FETCH mt.member m
+            JOIN FETCH m.university u
+            WHERE mt.room.id IN :roomIdList
+            AND mt.isRoomManager = :isRoomManager
+            AND mt.entryStatus = :entryStatus
+        """)
+    List<Mate> findAllByRoomIdListAndIsRoomManagerAndEntryStatus(List<Long> roomIdList,
+        boolean isRoomManager, EntryStatus entryStatus);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -95,8 +95,8 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     void deleteAllByRoomId(@Param("roomId") Long roomId);
 
     /**
-     * TODO에서 Mate를 가져와서 Mate 데이터와 Member를 사용해야하는데 지연 로딩 문제로 Member가 Proxy 에러가 발생하여 다음과 같이 Fetch
-     * Join을 사용함 내가 완료하지 못한 데이터가 있는지 확인하고, 모두 완료했으면 룸메이트에게 FCM 알림을 보내기 위함
+     * TODO에서 Mate를 가져와서 Mate 데이터와 Member를 사용해야하는데 지연 로딩 문제로 Member가 Proxy 에러가 발생하여 다음과 같이 Fetch Join을 사용함
+     * 내가 완료하지 못한 데이터가 있는지 확인하고, 모두 완료했으면 룸메이트에게 FCM 알림을 보내기 위함
      */
     @Query("""
         SELECT mt FROM Mate mt

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/controller/MemberFavoriteController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/controller/MemberFavoriteController.java
@@ -9,6 +9,8 @@ import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -47,7 +49,8 @@ public class MemberFavoriteController {
     @Operation(summary = "[베로] 찜한 사용자 목록 조회 (수정 - 25.03.27)", description = "")
     public ResponseEntity<ApiResponse<PageResponseDto<List<MemberFavoriteResponseDTO>>>> getMemberFavoriteList(
         @AuthenticationPrincipal MemberDetails memberDetails,
-        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+        @RequestParam(defaultValue = "10") @Positive int size) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
             memberFavoriteQueryService.getMemberFavoriteList(memberDetails.member(), page, size)));
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/controller/MemberFavoriteController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/controller/MemberFavoriteController.java
@@ -4,6 +4,7 @@ import com.cozymate.cozymate_server.domain.auth.userdetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.memberfavorite.dto.response.MemberFavoriteResponseDTO;
 import com.cozymate.cozymate_server.domain.memberfavorite.service.MemberFavoriteCommandService;
 import com.cozymate.cozymate_server.domain.memberfavorite.service.MemberFavoriteQueryService;
+import com.cozymate.cozymate_server.global.common.PageResponseDto;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -42,11 +44,12 @@ public class MemberFavoriteController {
     }
 
     @GetMapping
-    @Operation(summary = "[베로] 찜한 사용자 목록 조회", description = "")
-    public ResponseEntity<ApiResponse<List<MemberFavoriteResponseDTO>>> getMemberFavoriteList(
-        @AuthenticationPrincipal MemberDetails memberDetails) {
+    @Operation(summary = "[베로] 찜한 사용자 목록 조회 (수정 - 25.03.27)", description = "")
+    public ResponseEntity<ApiResponse<PageResponseDto<List<MemberFavoriteResponseDTO>>>> getMemberFavoriteList(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
-            memberFavoriteQueryService.getMemberFavoriteList(memberDetails.member())));
+            memberFavoriteQueryService.getMemberFavoriteList(memberDetails.member(), page, size)));
     }
 
     @DeleteMapping("/{memberFavoriteId}")

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/repository/MemberFavoriteRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/repository/MemberFavoriteRepository.java
@@ -2,8 +2,9 @@ package com.cozymate.cozymate_server.domain.memberfavorite.repository;
 
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberfavorite.MemberFavorite;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +14,13 @@ public interface MemberFavoriteRepository extends JpaRepository<MemberFavorite, 
 
     boolean existsByMemberAndTargetMember(Member member, Member targetMember);
 
-    List<MemberFavorite> findByMember(Member member);
+    @Query("""
+        select mf from MemberFavorite mf
+        join fetch mf.targetMember tm
+        join fetch tm.memberStat ms
+        where mf.member = :member
+    """)
+    Slice<MemberFavorite> findPagingByMember(@Param("member") Member member, Pageable pageable);
 
     @Modifying
     @Query("delete from MemberFavorite mf where mf.member = :member or mf.targetMember = :member")

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/repository/MemberFavoriteRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberfavorite/repository/MemberFavoriteRepositoryService.java
@@ -4,8 +4,9 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberfavorite.MemberFavorite;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,7 +34,7 @@ public class MemberFavoriteRepositoryService {
         memberFavoriteRepository.delete(memberFavorite);
     }
 
-    public List<MemberFavorite> getMemberFavoriteListByMember(Member member) {
-        return memberFavoriteRepository.findByMember(member);
+    public Slice<MemberFavorite> getMemberFavoriteListByMember(Member member, Pageable pageable) {
+        return memberFavoriteRepository.findPagingByMember(member, pageable);
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/controller/RoomFavoriteController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/controller/RoomFavoriteController.java
@@ -4,6 +4,7 @@ import com.cozymate.cozymate_server.domain.auth.userdetails.MemberDetails;
 import com.cozymate.cozymate_server.domain.roomfavorite.dto.response.RoomFavoriteResponseDTO;
 import com.cozymate.cozymate_server.domain.roomfavorite.service.RoomFavoriteCommandService;
 import com.cozymate.cozymate_server.domain.roomfavorite.service.RoomFavoriteQueryService;
+import com.cozymate.cozymate_server.global.common.PageResponseDto;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,11 +45,12 @@ public class RoomFavoriteController {
     }
 
     @GetMapping
-    @Operation(summary = "[베로] 찜한 방 목록 조회", description = "")
-    public ResponseEntity<ApiResponse<List<RoomFavoriteResponseDTO>>> getFavoriteRoomList(
-        @AuthenticationPrincipal MemberDetails memberDetails) {
+    @Operation(summary = "[베로] 찜한 방 목록 조회 (수정 - 25.03.27)", description = "")
+    public ResponseEntity<ApiResponse<PageResponseDto<List<RoomFavoriteResponseDTO>>>> getFavoriteRoomList(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
-            roomFavoriteQueryService.getFavoriteRoomList(memberDetails.member())));
+            roomFavoriteQueryService.getFavoriteRoomList(memberDetails.member(), page, size)));
     }
 
     @DeleteMapping("/{roomFavoriteId}")

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/controller/RoomFavoriteController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/controller/RoomFavoriteController.java
@@ -9,6 +9,8 @@ import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -48,7 +50,8 @@ public class RoomFavoriteController {
     @Operation(summary = "[베로] 찜한 방 목록 조회 (수정 - 25.03.27)", description = "")
     public ResponseEntity<ApiResponse<PageResponseDto<List<RoomFavoriteResponseDTO>>>> getFavoriteRoomList(
         @AuthenticationPrincipal MemberDetails memberDetails,
-        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+        @RequestParam(defaultValue = "10") @Positive int size) {
         return ResponseEntity.ok(ApiResponse.onSuccess(
             roomFavoriteQueryService.getFavoriteRoomList(memberDetails.member(), page, size)));
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepository.java
@@ -2,9 +2,12 @@ package com.cozymate.cozymate_server.domain.roomfavorite.repository;
 
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.room.Room;
+import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
 import com.cozymate.cozymate_server.domain.roomfavorite.RoomFavorite;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -32,4 +35,13 @@ public interface RoomFavoriteRepository extends JpaRepository<RoomFavorite, Long
     @Modifying
     @Query("delete from RoomFavorite rf where rf.room.id = :roomId")
     void deleteAllByRoomId(@Param("roomId") Long roomId);
+
+    @Query("""
+        select rf from RoomFavorite rf 
+        where rf.member = :member 
+        and rf.room.status <> :roomStatus 
+        and rf.room.numOfArrival < rf.room.maxMateNum
+        """)
+    Slice<RoomFavorite> findPagingByMemberAndRoomStatusNot(@Param("member") Member member,
+        @Param("roomStatus") RoomStatus roomStatus, Pageable pageable);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepositoryService.java
@@ -2,11 +2,13 @@ package com.cozymate.cozymate_server.domain.roomfavorite.repository;
 
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.room.Room;
+import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
 import com.cozymate.cozymate_server.domain.roomfavorite.RoomFavorite;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,11 +36,8 @@ public class RoomFavoriteRepositoryService {
         return roomFavoriteRepository.existsByMemberAndRoom(member, room);
     }
 
-    public List<RoomFavorite> getRoomFavoriteListByMember(Member member) {
-        return roomFavoriteRepository.findByMember(member);
-    }
-
-    public void deleteRoomFavoriteByRoomIds(List<Long> deleteTargetRoomIdList) {
-        roomFavoriteRepository.deleteAllByRoomIds(deleteTargetRoomIdList);
+    public Slice<RoomFavorite> getRoomFavoriteListByMember(Member member, Pageable pageable) {
+        return roomFavoriteRepository.findPagingByMemberAndRoomStatusNot(member, RoomStatus.DISABLE,
+            pageable);
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/service/RoomFavoriteQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/service/RoomFavoriteQueryService.java
@@ -9,22 +9,26 @@ import com.cozymate.cozymate_server.domain.memberstat.memberstat.MemberStat;
 import com.cozymate.cozymate_server.domain.memberstatpreference.service.MemberStatPreferenceQueryService;
 import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.domain.room.dto.response.PreferenceMatchCountDTO;
-import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
 import com.cozymate.cozymate_server.domain.room.util.RoomStatUtil;
 import com.cozymate.cozymate_server.domain.roomfavorite.RoomFavorite;
 import com.cozymate.cozymate_server.domain.roomfavorite.converter.RoomFavoriteConverter;
 import com.cozymate.cozymate_server.domain.roomfavorite.dto.response.RoomFavoriteResponseDTO;
 import com.cozymate.cozymate_server.domain.roomfavorite.repository.RoomFavoriteRepositoryService;
 import com.cozymate.cozymate_server.domain.roomhashtag.service.RoomHashtagQueryService;
+import com.cozymate.cozymate_server.global.common.PageResponseDto;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -36,37 +40,28 @@ public class RoomFavoriteQueryService {
     private final RoomHashtagQueryService roomHashtagQueryService;
     private final RoomFavoriteRepositoryService roomFavoriteRepositoryService;
 
-    public List<RoomFavoriteResponseDTO> getFavoriteRoomList(Member member) {
-        List<RoomFavorite> roomFavoriteList = roomFavoriteRepositoryService.getRoomFavoriteListByMember(
-            member);
+    public PageResponseDto<List<RoomFavoriteResponseDTO>> getFavoriteRoomList(Member member,
+        int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        Slice<RoomFavorite> roomFavoriteList = roomFavoriteRepositoryService.getRoomFavoriteListByMember(
+            member, pageRequest);
 
         if (roomFavoriteList.isEmpty()) {
-            return List.of();
+            return PageResponseDto.<List<RoomFavoriteResponseDTO>>builder()
+                .page(page)
+                .hasNext(false)
+                .result(List.of())
+                .build();
         }
 
         Map<Room, Long> roomFavoriteIdMap = roomFavoriteList.stream()
             .collect(Collectors.toMap(RoomFavorite::getRoom, RoomFavorite::getId));
 
-        List<Room> findFavoriteRoomIdList = new ArrayList<>(roomFavoriteIdMap.keySet());
-
-        // 방 상태가 disable과 그 외로 분리
-        Map<Boolean, List<Room>> partitionedRoomStatusMap = findFavoriteRoomIdList.stream()
-            .collect(
-                Collectors.partitioningBy(room -> !room.getStatus().equals(RoomStatus.DISABLE)));
-
-        // 방 상태가 disable이 아닌 방 리스트
-        List<Room> nonDisableFavoriteRoomList = partitionedRoomStatusMap.get(true);
-
-        // 방 상태가 disable이 아닌 방 리스트에서 방 인원이 꽉찬 방과 아닌 방으로 분리
-        Map<Boolean, List<Room>> partitionedMateNumMap = nonDisableFavoriteRoomList.stream()
-            .collect(
-                Collectors.partitioningBy(room -> room.getNumOfArrival() != room.getMaxMateNum()));
-
-        // 방이 꽉 차지 않은 방 리스트
-        List<Room> responseRoomList = partitionedMateNumMap.get(true);
+        List<Room> findFavoriteRoomList = new ArrayList<>(roomFavoriteIdMap.keySet());
 
         // <방 id, 해당 방의 mate 리스트>
-        Map<Long, List<Mate>> roomIdMatesMap = responseRoomList.stream().collect(
+        Map<Long, List<Mate>> roomIdMatesMap = findFavoriteRoomList.stream().collect(
             Collectors.toMap(Room::getId,
                 room -> mateRepository.findFetchMemberAndMemberStatByRoom(room,
                     EntryStatus.JOINED)));
@@ -79,9 +74,9 @@ public class RoomFavoriteQueryService {
         MemberStat memberStat = member.getMemberStat();
 
         Map<Long, List<String>> roomHashtagsMap = roomHashtagQueryService.getRoomHashtagsByRooms(
-            responseRoomList);
+            findFavoriteRoomList);
 
-        List<RoomFavoriteResponseDTO> favoriteRoomResponseList = responseRoomList.stream()
+        List<RoomFavoriteResponseDTO> favoriteRoomResponseList = findFavoriteRoomList.stream()
             .map(room -> {
                 List<Mate> mates = roomIdMatesMap.get(room.getId());
 
@@ -113,34 +108,10 @@ public class RoomFavoriteQueryService {
             })
             .toList();
 
-        // 조회 조건에 맞지 않는 방 찜 삭제 처리
-        deleteFavoriteRoom(partitionedRoomStatusMap.get(false), partitionedMateNumMap.get(false));
-
-        return favoriteRoomResponseList;
-    }
-
-    private void deleteFavoriteRoom(List<Room> disableFavoriteRoomList,
-        List<Room> fullRoomList) {
-
-        List<Long> deleteTargetRoomIdList = new ArrayList<>();
-
-        // 방 status가 disable인 방 리스트, 존재한다면 방이 있다면 deleteTargetRoomIdList에 추가
-        if (!disableFavoriteRoomList.isEmpty()) {
-            deleteTargetRoomIdList.addAll(disableFavoriteRoomList.stream()
-                .map(Room::getId)
-                .toList());
-        }
-
-        // 인원이 가득 찬 방 리스트, 존재한다면 deleteTargetRoomIdList에 추가
-        if (!fullRoomList.isEmpty()) {
-            deleteTargetRoomIdList.addAll(fullRoomList.stream()
-                .map(Room::getId)
-                .toList());
-        }
-
-        // deletedRoomIdList에 들어 있는 roomId에 해당하는 방 찜 삭제 처리
-        if (!deleteTargetRoomIdList.isEmpty()) {
-            roomFavoriteRepositoryService.deleteRoomFavoriteByRoomIds(deleteTargetRoomIdList);
-        }
+        return PageResponseDto.<List<RoomFavoriteResponseDTO>>builder()
+            .page(page)
+            .hasNext(roomFavoriteList.hasNext())
+            .result(favoriteRoomResponseList)
+            .build();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/service/RoomFavoriteQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/service/RoomFavoriteQueryService.java
@@ -22,13 +22,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. 사용자 찜, 방 찜 조회 페이징 처리

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

사용자 찜 목록 조회
<img width="300" alt="image" src="https://github.com/user-attachments/assets/bb9bd1cb-035a-43fd-87ba-886bf35fba92" />

방 찜 목록 조회
<img width="300" alt="image" src="https://github.com/user-attachments/assets/c96d1bb2-c165-42da-9145-f9294017ca44" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 멤버 및 룸 즐겨찾기 조회 결과가 페이징되어, 페이지와 사이즈 매개변수를 통해 보다 효율적으로 데이터를 탐색할 수 있습니다.

- **리팩토링**
  - 내부 데이터 처리 및 쿼리 로직을 개선하여, 전체적인 응답 구조와 코드 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->