### PR TITLE
[COZY-568] fix: 사용자가 참여 요청한 방 목록 조회 페이징 적용, 로그인한 사용자가 참여한 방이 있는지 여부 조회에 방장여부 조회 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -9,6 +9,7 @@ import com.cozymate.cozymate_server.domain.room.dto.request.RoomUpdateRequestDTO
 import com.cozymate.cozymate_server.domain.room.dto.response.InvitedRoomResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.MateDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomDetailResponseDTO;
+import com.cozymate.cozymate_server.domain.room.dto.response.RoomExistResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomIdResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomSearchResponseDTO;
 import com.cozymate.cozymate_server.domain.room.service.RoomCommandService;
@@ -182,12 +183,18 @@ public class RoomController {
     }
 
     @GetMapping("/exist")
-    @Operation(summary = "[바니] 로그인한 사용자가 참여한 방이 있는지 여부 조회", description = "현재 참여중인 방이 있다면 해당 roomId가, 없다면 roomId값이 0으로 리턴됩니다.")
+    @Operation(
+        summary = "[바니] 로그인한 사용자가 참여한 방이 있는지 여부 조회(수정 - 25.03.28)",
+        description = """
+        로그인한 사용자가 현재 참여 중인 방이 있는 경우, 해당 roomId와 isRoomManager 값을 반환합니다.
+        참여 중인 방이 없을 경우, roomId는 0으로, isRoomManager는 false로 반환됩니다.
+        """
+    )
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND
     })
-    public ResponseEntity<ApiResponse<RoomIdResponseDTO>> getExistRoom(@AuthenticationPrincipal MemberDetails memberDetails) {
-        RoomIdResponseDTO response = roomQueryService.getExistRoom(memberDetails.member().getId());
+    public ResponseEntity<ApiResponse<RoomExistResponseDTO>> getExistRoom(@AuthenticationPrincipal MemberDetails memberDetails) {
+        RoomExistResponseDTO response = roomQueryService.getRoomExistInfo(memberDetails.member().getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/controller/RoomController.java
@@ -13,12 +13,15 @@ import com.cozymate.cozymate_server.domain.room.dto.response.RoomIdResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomSearchResponseDTO;
 import com.cozymate.cozymate_server.domain.room.service.RoomCommandService;
 import com.cozymate.cozymate_server.domain.room.service.RoomQueryService;
+import com.cozymate.cozymate_server.global.common.PageResponseDto;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.code.status.SuccessStatus;
 import com.cozymate.cozymate_server.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -307,13 +310,16 @@ public class RoomController {
     }
 
     @GetMapping("/requested")
-    @Operation(summary = "[바니] 사용자가 참여 요청한 방 목록 조회", description = "로그인한 사용자가 참여 요청한 방 목록을 조회합니다.")
+    @Operation(summary = "[바니] 사용자가 참여 요청한 방 목록 조회(수정 - 25.03.28)", description = "로그인한 사용자가 참여 요청한 방 목록을 조회합니다.")
     @SwaggerApiError({
         ErrorStatus._MEMBER_NOT_FOUND
     })
-    public ResponseEntity<ApiResponse<List<RoomDetailResponseDTO>>> getRequestedRoomList(
-        @AuthenticationPrincipal MemberDetails memberDetails) {
-        return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.getRequestedRoomList(memberDetails.member().getId())));
+    public ResponseEntity<ApiResponse<PageResponseDto<List<RoomDetailResponseDTO>>>> getRequestedRoomList(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+        @RequestParam(defaultValue = "10") @Positive int size
+        ) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(roomQueryService.getRequestedRoomList(memberDetails.member().getId(), page, size)));
     }
 
     @GetMapping("/invited")

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/converter/RoomConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/converter/RoomConverter.java
@@ -9,6 +9,7 @@ import com.cozymate.cozymate_server.domain.room.dto.request.PublicRoomCreateRequ
 import com.cozymate.cozymate_server.domain.room.dto.response.InvitedRoomResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.MateDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomDetailResponseDTO;
+import com.cozymate.cozymate_server.domain.room.dto.response.RoomExistResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomIdResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomSearchResponseDTO;
 import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
@@ -65,6 +66,13 @@ public class RoomConverter {
 
     public static RoomIdResponseDTO toRoomExistResponse(Room room) {
         return new RoomIdResponseDTO(room != null ? room.getId() : 0L);
+    }
+
+    public static RoomExistResponseDTO toRoomExistResponse(Room room, boolean isRoomManager) {
+        if (room == null) {
+            return new RoomExistResponseDTO(0L, false);
+        }
+        return new RoomExistResponseDTO(room.getId(), isRoomManager);
     }
 
     public static InvitedRoomResponseDTO toInvitedRoomResponseDTO(Integer invitedCount, List<RoomDetailResponseDTO> rooms) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/response/RoomExistResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/response/RoomExistResponseDTO.java
@@ -1,0 +1,8 @@
+package com.cozymate.cozymate_server.domain.room.dto.response;
+
+public record RoomExistResponseDTO(
+    Long roomId,
+    boolean isRoomManager
+) {
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepository.java
@@ -7,7 +7,8 @@ import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
 import com.cozymate.cozymate_server.domain.room.enums.RoomType;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,6 +30,11 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
         "WHERE r.id IN (SELECT m.room.id FROM Mate m " +
         "WHERE m.member.id = :memberId AND m.entryStatus = :status)")
     List<Room> findRoomsWithMates(Long memberId, EntryStatus status);
+
+    @Query("SELECT DISTINCT r FROM Room r " +
+        "WHERE r.id IN (SELECT m.room.id FROM Mate m " +
+        "WHERE m.member.id = :memberId AND m.entryStatus = :status)")
+    Slice<Room> findRoomSliceByMemberIdAndEntryStatus(Long memberId, EntryStatus status, Pageable pageable);
 
     /**
      * 사용자에게 방 추천을 해줄 때 조회할 수 있는 방 목록을 보는 쿼리

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/repository/RoomRepositoryService.java
@@ -9,6 +9,8 @@ import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -55,6 +57,10 @@ public class RoomRepositoryService {
 
     public List<Room> getRoomListByKeywordAndUniversityAndGender(String keyword, Long universityId, Gender gender) {
         return roomRepository.findMatchingPublicRooms(keyword, universityId, gender);
+    }
+
+    public Slice<Room> getRoomSliceByMemberIdAndEntryStatus(Long memberId, EntryStatus entryStatus, Pageable pageable) {
+        return roomRepository.findRoomSliceByMemberIdAndEntryStatus(memberId, entryStatus, pageable);
     }
 
     // 방 저장

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomQueryService.java
@@ -15,6 +15,7 @@ import com.cozymate.cozymate_server.domain.room.converter.RoomConverter;
 import com.cozymate.cozymate_server.domain.room.dto.response.InvitedRoomResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.MateDetailResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomDetailResponseDTO;
+import com.cozymate.cozymate_server.domain.room.dto.response.RoomExistResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomIdResponseDTO;
 import com.cozymate.cozymate_server.domain.room.dto.response.RoomSearchResponseDTO;
 import com.cozymate.cozymate_server.domain.room.enums.RoomStatus;
@@ -79,6 +80,17 @@ public class RoomQueryService {
         memberRepository.findById(otherMemberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
         return getExistRoom(otherMemberId);
+    }
+
+    public RoomExistResponseDTO getRoomExistInfo(Long memberId) {
+        Optional<Mate> mate = mateRepository.findByMemberIdAndEntryStatusAndRoomStatusIn(
+            memberId, EntryStatus.JOINED, List.of(RoomStatus.ENABLE, RoomStatus.WAITING));
+
+        if (mate.isPresent()) {
+            return RoomConverter.toRoomExistResponse(mate.get().getRoom(), mate.get().isRoomManager());
+        }
+
+        return RoomConverter.toRoomExistResponse(null, false);
     }
 
     public List<MateDetailResponseDTO> getInvitedMemberList(Long roomId, Long memberId) {


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
사용자가 참여 요청한 방 목록 조회에 페이지네이션을 적용했습니다
로그인한 사용자가 참여한 방이 있는지 여부 조회에 방장여부 조회를 추가했습니다

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

![image](https://github.com/user-attachments/assets/b5152d7c-792b-4116-aec2-674b7c6efc97)
![image](https://github.com/user-attachments/assets/540b4e00-4258-4577-bc01-2c61dfb80f9a)
![image](https://github.com/user-attachments/assets/b0ee6ab3-9181-436c-9adf-e0bda9247707)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 방 목록 조회 기능에 페이지네이션 옵션이 추가되어, 사용자가 페이지 번호와 한 페이지에 표시할 항목 수를 지정할 수 있습니다.
	- 방 존재 여부를 확인하고, 사용자가 방 관리자 여부를 반환하는 기능이 추가되었습니다.
	- 방 존재 여부와 관련된 응답 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->