### PR TITLE
[COZY-574] fix: 사용자 찜 목록 조회 시 MemberStat value를 String으로 변환하여 반환하도록 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/converter/MemberStatConverter.java
@@ -222,9 +222,11 @@ public class MemberStatConverter {
 
     public static List<MemberStatPreferenceDetailColorDTO> toMemberStatPreferenceDetailWithoutColorDTOList(
         MemberStat memberStat, List<String> preferences) {
-        Map<String, Object> memberStatMap = FieldInstanceResolver.extractMultiMemberStatFields(
-            memberStat,
-            preferences);
+        Map<String, Object> rawMemberStatMap = FieldInstanceResolver.extractMultiMemberStatFields(
+            memberStat, preferences);
+
+        Map<String, String> memberStatMap = QuestionAnswerMapper.convertToStringMap(
+            rawMemberStatMap);
 
         return memberStatMap.entrySet().stream()
             .map(entry -> toMemberStatPreferenceDetailWithoutColorDTO(


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. 사용자 찜 목록 조회 시 MemberStat value를 String으로 변환하여 반환하도록 수정

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

요청자가 MemberStat이 있는 경우 (MemberStat 저장을 db에서 바로 해서 일치율이 null로 나오는 듯 해요)
<img width="350" alt="image" src="https://github.com/user-attachments/assets/c574cb01-917f-4861-b87c-4a1d1c4369c6" />

요청자가 MemberStat이 없는 경우
<img width="350" alt="image" src="https://github.com/user-attachments/assets/848618fd-604a-4622-a0c4-329c2dc1eddc" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 데이터 처리 과정을 명확하게 분리하여 내부 로직의 가독성과 유지보수성을 향상시켰습니다. 기능상 변화는 없으며, 더욱 효율적인 데이터 전환 과정을 구현하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->