### PR TITLE
[COZY-575] hotfix : 대학교 지연로딩 문제 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/member/Member.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/Member.java
@@ -54,7 +54,7 @@ public class Member extends BaseTimeEntity {
     @NonNull
     private String clientId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @NonNull
     @JoinColumn(name = "university_id")
     private University university;


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

네
## #️⃣ 작업 내용
대학교 지연로딩 문제를 즉시로딩으로 바꿨습니다.
다음과 같은 이유로 즉시로딩을 선택했습니다.
1. 대학교가 많지 않음.
2. 사용자 관련 응답을 만드는 `MemberConverter` 에 대학교를 파라미터에 추가하지 않아 공사가 필요함.
   - 급하게 공사하면 예기치 못한 오류 생길 수도있음
   - 다른 도메인에서 `Member.getUniversity.get{}`를 어떻게 사용하는지 모름 
      - 다른 객체와 달리 `Member` 객체는 필터에서 로드 하기 때문에 명확하지 않음.
   - 필터에서 조회할때 대학교 까지 `fetch join`할까 고민했지만 그러면 즉시로딩이랑 크게 다를게 없어 보임

## 동작 확인
![image](https://github.com/user-attachments/assets/b120dab3-576f-4cd4-93a3-e3c074f841d1)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
	- 회원 정보 조회 시 관련 대학 데이터가 즉시 함께 로드되도록 개선되었습니다. 이로 인해 데이터 접근 방식이 변경되어 성능에 약간의 영향이 있을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->