### PR TITLE
[COZY-576] fix: 선호 칩 순서 불일치 문제 해결, 찜한 방 목록 조회 반환 key 값 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/util/FieldInstanceResolver.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/util/FieldInstanceResolver.java
@@ -5,6 +5,7 @@ import com.cozymate.cozymate_server.domain.memberstat.memberstat.MemberStat;
 import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
 import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -84,7 +85,9 @@ public class FieldInstanceResolver {
         return fieldNameList.stream()
             .collect(Collectors.toMap(
                 fieldName -> fieldName,
-                fieldName -> extractMemberStatField(memberStat, fieldName)
+                fieldName -> extractMemberStatField(memberStat, fieldName),
+                (o1, o2) -> o1,
+                LinkedHashMap::new // fieldNameList 조회된 순서 유지
             ));
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/util/QuestionAnswerMapper.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/util/QuestionAnswerMapper.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -150,7 +151,9 @@ public class QuestionAnswerMapper {
                     }
 
                     return value.toString(); // Integer가 아니면 그냥 String 변환
-                }
+                },
+                (o1, o2) -> o1,
+                LinkedHashMap::new // fieldNameList 조회된 순서 유지
             ));
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/controller/RoomFavoriteController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/controller/RoomFavoriteController.java
@@ -47,7 +47,7 @@ public class RoomFavoriteController {
     }
 
     @GetMapping
-    @Operation(summary = "[베로] 찜한 방 목록 조회 (수정 - 25.03.27)", description = "")
+    @Operation(summary = "[베로] 찜한 방 목록 조회 (수정 - 25.04.03)", description = "")
     public ResponseEntity<ApiResponse<PageResponseDto<List<RoomFavoriteResponseDTO>>>> getFavoriteRoomList(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @RequestParam(defaultValue = "0") @PositiveOrZero int page,

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/converter/RoomFavoriteConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/converter/RoomFavoriteConverter.java
@@ -18,16 +18,16 @@ public class RoomFavoriteConverter {
 
     public static RoomFavoriteResponseDTO toRoomFavoriteResponseDTO(Long roomFavoriteId, Room room,
         Integer roomEquality, List<PreferenceMatchCountDTO> preferenceStatsMatchCountList,
-        List<String> roomHashTags, Integer currentMateNum) {
+        List<String> roomHashTags, Integer numOfArrival) {
         return RoomFavoriteResponseDTO.builder()
             .roomFavoriteId(roomFavoriteId)
             .roomId(room.getId())
             .equality(roomEquality)
             .name(room.getName())
             .preferenceMatchCountList(preferenceStatsMatchCountList)
-            .hashtagList(roomHashTags)
+            .hashtags(roomHashTags)
             .maxMateNum(room.getMaxMateNum())
-            .currentMateNum(currentMateNum)
+            .numOfArrival(numOfArrival)
             .build();
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/dto/response/RoomFavoriteResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/dto/response/RoomFavoriteResponseDTO.java
@@ -11,9 +11,9 @@ public record RoomFavoriteResponseDTO(
     Long roomId,
     String name,
     List<PreferenceMatchCountDTO> preferenceMatchCountList,
-    List<String> hashtagList,
+    List<String> hashtags,
     Integer maxMateNum,
-    Integer currentMateNum
+    Integer numOfArrival
 ) {
 
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. /rooms/list,  /favorites/rooms <-> /members/stat/random, /favorites/members 이렇게 서로 칩 순서가 안맞는 문제를 /members/stat/random, /favorites/members 이 둘을 /rooms/list,  /favorites/rooms 얘네한테 맞추도록 통일했습니다.

/rooms/list,  /favorites/rooms 이 둘은 db에 저장된 member_stat_preference 값 순서대로 나오는데,
/members/stat/random, /favorites/members 이 둘은 로직 내 Map 변환 과정에서 순서가 바뀌어서 이쪽이 바뀌는게 맞다고 판단했습니다.

2. 찜한 방 목록 조회 반환 key 값 수정 (방 추천과 통일)

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

- /rooms/list
<img width="350" alt="image" src="https://github.com/user-attachments/assets/f7db1ba3-6a63-4e31-aaf6-7b51a3ddb50a" />

- /favorites/rooms (+ 추가 hashtagList -> hashtags, currentMateNum -> numOfArrival 으로 수정)
<img width="350" alt="image" src="https://github.com/user-attachments/assets/4ce1f06d-9895-455b-b1a8-c7d86fbf91f0" />

- /members/stat/random
<img width="350" alt="image" src="https://github.com/user-attachments/assets/0c0b1566-e100-47f3-a2fa-1d8a98422570" />

- /favorites/members
<img width="350" alt="image" src="https://github.com/user-attachments/assets/2f458a30-8974-48de-a529-0de5b0770118" />

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩토링**
	- 데이터 매핑 처리 로직이 개선되어, 중복 항목 발생 시 첫 번째 값을 우선 선택하며 항목 순서를 안정적으로 유지하도록 업데이트되었습니다.
	- `RoomFavoriteResponseDTO`의 필드 이름이 변경되어 가독성이 향상되었습니다.
	- `getFavoriteRoomList` 메서드의 버전 날짜가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->