### PR TITLE
[COZY-591] feat : memberstat , lifestyleMatchRate 캐싱하기

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/redis/LifestyleMatchRateRedisDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/redis/LifestyleMatchRateRedisDTO.java
@@ -1,0 +1,26 @@
+package com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LifestyleMatchRateRedisDTO implements Serializable {
+
+    private Long memberA;
+    private Long memberB;
+    private Integer matchRate;
+
+    public String generateKey() {
+        long first = Math.min(memberA, memberB);
+        long second = Math.max(memberA, memberB);
+        return "matchRate:" + first + ":" + second;
+    }
+}
+

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/redis/service/LifestyleMatchRateCacheService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/redis/service/LifestyleMatchRateCacheService.java
@@ -1,0 +1,50 @@
+package com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.service;
+
+import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.LifestyleMatchRate;
+import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.LifestyleMatchRateRedisDTO;
+import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.util.LifestyleMatchRateCacheMapper;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LifestyleMatchRateCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String PREFIX = "matchRate:";
+
+    public void save(LifestyleMatchRateRedisDTO dto) {
+        String key = generateKey(dto.getMemberA(), dto.getMemberB());
+        redisTemplate.opsForValue().set(key, dto);
+    }
+
+    public void saveLifeStyleMatchRate(List<LifestyleMatchRate> matchRateList) {
+        matchRateList.forEach(entity -> {
+            LifestyleMatchRateRedisDTO dto = LifestyleMatchRateCacheMapper.toDto(entity);
+            save(dto);
+        });
+    }
+
+    public Optional<LifestyleMatchRateRedisDTO> find(Long memberA, Long memberB) {
+        String key = generateKey(memberA, memberB);
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value instanceof LifestyleMatchRateRedisDTO dto) {
+            return Optional.of(dto);
+        }
+        return Optional.empty();
+    }
+
+    public void delete(Long memberA, Long memberB) {
+        String key = generateKey(memberA, memberB);
+        redisTemplate.delete(key);
+    }
+
+    private String generateKey(Long memberA, Long memberB) {
+        long first = Math.min(memberA, memberB);
+        long second = Math.max(memberA, memberB);
+        return PREFIX + first + ":" + second;
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/redis/util/LifestyleMatchRateCacheMapper.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/redis/util/LifestyleMatchRateCacheMapper.java
@@ -1,0 +1,23 @@
+package com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.util;
+
+import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.LifestyleMatchRate;
+import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.LifestyleMatchRateRedisDTO;
+
+public class LifestyleMatchRateCacheMapper {
+    public static LifestyleMatchRateRedisDTO toDto(Long memberA, Long memberB, Integer matchRate) {
+        return LifestyleMatchRateRedisDTO.builder()
+            .memberA(memberA)
+            .memberB(memberB)
+            .matchRate(matchRate)
+            .build();
+    }
+
+    public static LifestyleMatchRateRedisDTO toDto(LifestyleMatchRate entity) {
+        return LifestyleMatchRateRedisDTO.builder()
+            .memberA(entity.getId().getMemberA())
+            .memberB(entity.getId().getMemberB())
+            .matchRate(entity.getMatchRate())
+            .build();
+    }
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/service/LifestyleMatchRateService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/service/LifestyleMatchRateService.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.servic
 
 import com.cozymate.cozymate_server.domain.member.enums.Gender;
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.LifestyleMatchRate;
+import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.service.LifestyleMatchRateCacheService;
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.repository.LifestyleMatchRateRepositoryService;
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.util.MemberMatchRateCalculator;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.MemberStat;
@@ -25,10 +26,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @RequiredArgsConstructor
 public class LifestyleMatchRateService {
-
     private final LifestyleMatchRateRepositoryService lifestyleMatchRateRepositoryService;
     private final MemberStatRepository memberStatRepository;
     private final UniversityRepository universityRepository;
+    private final LifestyleMatchRateCacheService lifestyleMatchRateCacheService;
 
     private static final Integer NO_EQUALITY = null;
 
@@ -67,6 +68,8 @@ public class LifestyleMatchRateService {
             .toList();
 
         lifestyleMatchRateRepositoryService.createAndUpdateLifestyleMatchRateList(lifestyleMatchRateList);
+
+        lifestyleMatchRateCacheService.saveLifeStyleMatchRate(lifestyleMatchRateList);
     }
 
     @Transactional

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/redis/MemberStatRedisDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/redis/MemberStatRedisDTO.java
@@ -1,0 +1,46 @@
+package com.cozymate.cozymate_server.domain.memberstat.memberstat.redis;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberStatRedisDTO implements Serializable {
+    private Long memberId;
+
+    // University 정보
+    private Integer admissionYear;
+    private String dormitoryName;
+    private String numberOfRoommate;
+    private String acceptance;
+
+    // Lifestyle 정보
+    private Integer wakeUpTime;
+    private Integer sleepingTime;
+    private Integer turnOffTime;
+    private Integer smokingStatus;
+    private Integer sleepingHabit;
+    private Integer coolingIntensity;
+    private Integer heatingIntensity;
+    private Integer lifePattern;
+    private Integer intimacy;
+    private Integer itemSharing;
+    private Integer playingGameFrequency;
+    private Integer phoneCallingFrequency;
+    private Integer studyingFrequency;
+    private Integer eatingFrequency;
+    private Integer cleannessSensitivity;
+    private Integer noiseSensitivity;
+    private Integer cleaningFrequency;
+    private Integer drinkingFrequency;
+    private Integer personality;
+    private Integer mbti;
+
+    private String selfIntroduction;
+}
+

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/redis/service/MemberStatCacheService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/redis/service/MemberStatCacheService.java
@@ -1,0 +1,46 @@
+package com.cozymate.cozymate_server.domain.memberstat.memberstat.redis.service;
+
+import com.cozymate.cozymate_server.domain.memberstat.memberstat.redis.MemberStatRedisDTO;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberStatCacheService {
+    private static final String KEY_PREFIX = "memberStat:";
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void save(MemberStatRedisDTO dto) {
+        String key = getKey(dto.getMemberId());
+        redisTemplate.opsForValue().set(key, dto);
+        log.info("캐시 저장 완료 - {}", key);
+    }
+
+    public Optional<MemberStatRedisDTO> get(Long memberId) {
+        String key = getKey(memberId);
+        Object cached = redisTemplate.opsForValue().get(key);
+        if (cached instanceof MemberStatRedisDTO dto) {
+            return Optional.of(dto);
+        }
+        return Optional.empty();
+    }
+
+    public void delete(Long memberId) {
+        String key = getKey(memberId);
+        redisTemplate.delete(key);
+        log.info("캐시 삭제 - {}", key);
+    }
+
+    public boolean exists(Long memberId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(getKey(memberId)));
+    }
+
+    private String getKey(Long memberId) {
+        return KEY_PREFIX + memberId;
+    }
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/redis/util/MemberStatRedisMapper.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/redis/util/MemberStatRedisMapper.java
@@ -1,0 +1,40 @@
+package com.cozymate.cozymate_server.domain.memberstat.memberstat.redis.util;
+
+import com.cozymate.cozymate_server.domain.memberstat.memberstat.MemberStat;
+import com.cozymate.cozymate_server.domain.memberstat.memberstat.redis.MemberStatRedisDTO;
+
+public class MemberStatRedisMapper {
+    public static MemberStatRedisDTO toDto(MemberStat memberStat) {
+        return MemberStatRedisDTO.builder()
+            .memberId(memberStat.getMember().getId())
+            // memberUniversityStat
+            .admissionYear(memberStat.getMemberUniversityStat().getAdmissionYear())
+            .dormitoryName(memberStat.getMemberUniversityStat().getDormitoryName())
+            .numberOfRoommate(memberStat.getMemberUniversityStat().getNumberOfRoommate())
+            .acceptance(memberStat.getMemberUniversityStat().getAcceptance())
+            // lifestyle
+            .wakeUpTime(memberStat.getLifestyle().getWakeUpTime())
+            .sleepingTime(memberStat.getLifestyle().getSleepingTime())
+            .turnOffTime(memberStat.getLifestyle().getTurnOffTime())
+            .smokingStatus(memberStat.getLifestyle().getSmokingStatus())
+            .sleepingHabit(memberStat.getLifestyle().getSleepingHabit())
+            .coolingIntensity(memberStat.getLifestyle().getCoolingIntensity())
+            .heatingIntensity(memberStat.getLifestyle().getHeatingIntensity())
+            .lifePattern(memberStat.getLifestyle().getLifePattern())
+            .intimacy(memberStat.getLifestyle().getIntimacy())
+            .itemSharing(memberStat.getLifestyle().getItemSharing())
+            .playingGameFrequency(memberStat.getLifestyle().getPlayingGameFrequency())
+            .phoneCallingFrequency(memberStat.getLifestyle().getPhoneCallingFrequency())
+            .studyingFrequency(memberStat.getLifestyle().getStudyingFrequency())
+            .eatingFrequency(memberStat.getLifestyle().getEatingFrequency())
+            .cleannessSensitivity(memberStat.getLifestyle().getCleannessSensitivity())
+            .noiseSensitivity(memberStat.getLifestyle().getNoiseSensitivity())
+            .cleaningFrequency(memberStat.getLifestyle().getCleaningFrequency())
+            .drinkingFrequency(memberStat.getLifestyle().getDrinkingFrequency())
+            .personality(memberStat.getLifestyle().getPersonality())
+            .mbti(memberStat.getLifestyle().getMbti())
+            .selfIntroduction(memberStat.getSelfIntroduction())
+            .build();
+    }
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/service/MemberStatCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/service/MemberStatCommandService.java
@@ -5,11 +5,10 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.service.LifestyleMatchRateService;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.dto.request.CreateMemberStatRequestDTO;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.MemberStat;
-import com.cozymate.cozymate_server.domain.memberstat.memberstat.repository.MemberStatRepository;
+import com.cozymate.cozymate_server.domain.memberstat.memberstat.redis.service.MemberStatCacheService;
+import com.cozymate.cozymate_server.domain.memberstat.memberstat.redis.util.MemberStatRedisMapper;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.converter.MemberStatConverter;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.repository.MemberStatRepositoryService;
-import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
-import com.cozymate.cozymate_server.global.response.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +22,7 @@ public class MemberStatCommandService {
 
     private final LifestyleMatchRateService lifestyleMatchRateService;
     private final MemberStatRepositoryService memberStatRepositoryService;
+    private final MemberStatCacheService memberStatCacheService;
 
     @Transactional
     public Long createMemberStat(
@@ -31,6 +31,8 @@ public class MemberStatCommandService {
             MemberStatConverter.toEntity(member, createMemberStatRequestDTO));
 
         lifestyleMatchRateService.saveLifeStyleMatchRate(memberStat);
+
+        memberStatCacheService.save(MemberStatRedisMapper.toDto(memberStat));
 
         return memberStat.getMember().getId();
     }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네
## #️⃣ 작업 내용
memberstat , lifestyleMatchRate 캐싱했습니다.
조회 아직이구요 배치 아직이구요 그냥 save시에 redis에도 저장했습니다.
일단 풀 캐시할 예정입니다. 계산해보니까 80만 사용자 까진 문제 없을거 같아서요
80만되면 돈을 바르든 mongo를 쓰든ㅋㅋ
이거 머지 되면 마이그레이션은 해둘게요, 다른 기능 (캐시 통해서 조회)들 개발하는거 맞춰서 마이그레이션 하게요

## 동작 확인
![레디스에 저장 완](https://github.com/user-attachments/assets/0869e103-edab-48c4-9122-5bffd62758e8)
![일치율 캐시](https://github.com/user-attachments/assets/50603fba-20a4-4643-a734-657278917a15)
![일치율 리스트](https://github.com/user-attachments/assets/a7a5a3ab-4a1c-44c2-8b36-cdc1446aba51)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

캐싱전 기본 세팅만 해둔 상태라고 생각하시면 됩니다.
패키지 구조를 고민하다가 저런식으로 했는데 더 나은방법 있으면 알려주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 라이프스타일 매치율 및 회원 통계 정보를 Redis 캐시에 저장하고 조회하는 기능이 추가되었습니다.
    - 회원 통계 및 매치율 정보를 DTO 형태로 변환하여 효율적으로 관리할 수 있습니다.

- **리팩터**
    - 회원 통계 생성 시 캐시에 자동 저장되도록 서비스 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->