### PR TITLE
[COZY-592] feat : 방 초대, 참여 요청시 라이프스타일 검증

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/PublicRoomCreateRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/PublicRoomCreateRequestDTO.java
@@ -21,6 +21,7 @@ public record PublicRoomCreateRequestDTO (
     @Range(min=2, max=6, message = "방 인원은 2~6명 사이여야 합니다.")
     Integer maxMateNum,
     @Size(min = 1, max = 3, message = "해시태그는 1개에서 3개까지 입력할 수 있습니다.")
-    List<@NotBlank @Pattern(regexp = "^(?!_)[가-힣a-zA-Z0-9]+(_[가-힣a-zA-Z0-9]+)*(?<!_)$",
+    List<@Size(min =1,max = 5, message = "해시태그는 1글자에서 5글자까지 입력할 수 있습니다.")
+        @NotBlank @Pattern(regexp = "^(?!_)[가-힣a-zA-Z0-9]+(_[가-힣a-zA-Z0-9]+)*(?<!_)$",
         message = "해시태그는 한글, 영어, 숫자 및 '_'만 사용할 수 있으며, '_'는 앞이나 뒤에 올 수 없습니다.") String> hashtagList
 ) { }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/RoomUpdateRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/dto/request/RoomUpdateRequestDTO.java
@@ -16,8 +16,9 @@ public record RoomUpdateRequestDTO(
     @Range(min=1, max=16)
     Integer persona,
     @Size(min = 1, max = 3, message = "해시태그는 1개에서 3개까지 입력할 수 있습니다.")
-    List<@NotBlank @Pattern(regexp = "^(?!_)[가-힣a-zA-Z0-9]+(_[가-힣a-zA-Z0-9]+)*(?<!_)$",
-    message = "해시태그는 한글, 영어, 숫자 및 '_'만 사용할 수 있으며, '_'는 앞이나 뒤에 올 수 없습니다.") String> hashtagList
+    List<@Size(min = 1, max = 5, message = "해시태그는 1글자에서 5글자까지 입력할 수 있습니다.")
+        @NotBlank @Pattern(regexp = "^(?!_)[가-힣a-zA-Z0-9]+(_[가-힣a-zA-Z0-9]+)*(?<!_)$",
+        message = "해시태그는 한글, 영어, 숫자 및 '_'만 사용할 수 있으며, '_'는 앞이나 뒤에 올 수 없습니다.") String> hashtagList
 ) {
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -269,6 +269,9 @@ public class RoomCommandService {
 
     @Transactional
     public void sendInvitation(Long inviteeId, Member inviterMember) {
+        // 초대하려는 사용자가 MemberStat이 있는 지 검사
+        roomValidator.checkMemberStatIsNull(inviteeId);
+
         Member inviteeMember = memberRepository.findById(inviteeId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
         // 방장이 속한 방의 정보
@@ -370,6 +373,10 @@ public class RoomCommandService {
 
     @Transactional
     public void requestToJoin(Long roomId, Member member) {
+        // 참여 요청을 보내는 사용자가 MemberStat이 있는 지 검사
+        roomValidator.checkMemberStatIsNull(member.getId());
+
+
         Room room = roomRepositoryService.getRoomOrThrow(roomId);
 
         roomValidator.checkAlreadyJoinedRoom(member.getId());

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/validator/RoomValidator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/validator/RoomValidator.java
@@ -3,6 +3,9 @@ package com.cozymate.cozymate_server.domain.room.validator;
 import com.cozymate.cozymate_server.domain.mate.Mate;
 import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
 import com.cozymate.cozymate_server.domain.mate.repository.MateRepositoryService;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.memberstat.memberstat.MemberStat;
+import com.cozymate.cozymate_server.domain.memberstat.memberstat.repository.MemberStatRepositoryService;
 import com.cozymate.cozymate_server.domain.room.Room;
 import com.cozymate.cozymate_server.domain.room.enums.RoomType;
 import com.cozymate.cozymate_server.domain.room.repository.RoomRepositoryService;
@@ -17,6 +20,8 @@ public class RoomValidator {
 
     private final MateRepositoryService mateRepositoryService;
     private final RoomRepositoryService roomRepositoryService;
+
+    private final MemberStatRepositoryService memberStatRepositoryService;
 
     // 방 이름 중복 검사
     public Boolean isUniqueRoomName(String roomName) {
@@ -64,6 +69,10 @@ public class RoomValidator {
             default:
                 break;
         }
+    }
+
+    public void checkMemberStatIsNull(Long memberId){
+        memberStatRepositoryService.getMemberStatOrThrow(memberId);
     }
 
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네
## #️⃣ 작업 내용
참여 요청, 초대 요청 시 MemberStat여부를 검증합니다.

## 동작 확인
![image](https://github.com/user-attachments/assets/30833bdf-a388-4a8a-866e-c0c4d59b71be)
## 💬 리뷰 요구사항(선택)
@suuu0719 
빨리 해달래서 했어요. 별로면 나중에 수정 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 초대 및 참여 요청 시, 사용자의 통계 정보(MemberStat)가 존재하는지 추가로 검증하여 예외 상황을 방지했습니다.
- **기능 개선**
  - 공개 방 및 방 정보 수정 시 해시태그 길이를 1자에서 5자 사이로 제한하여 입력 유효성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->