### PR TITLE
[COZY-601] fix : 메일 중복 사용시 오류 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/repository/MailRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/repository/MailRepository.java
@@ -1,9 +1,9 @@
 package com.cozymate.cozymate_server.domain.mail.repository;
 
 import com.cozymate.cozymate_server.domain.mail.MailAuthentication;
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MailRepository extends JpaRepository<MailAuthentication, String> {
-    Optional<MailAuthentication> findByMailAddress(String mailAddress);
+    List<MailAuthentication> findAllByMailAddress(String mailAddress);
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/repository/MailRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/repository/MailRepository.java
@@ -2,8 +2,11 @@ package com.cozymate.cozymate_server.domain.mail.repository;
 
 import com.cozymate.cozymate_server.domain.mail.MailAuthentication;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MailRepository extends JpaRepository<MailAuthentication, String> {
+    Optional<MailAuthentication> findByMailAddress(String mailAddress);
+
     List<MailAuthentication> findAllByMailAddress(String mailAddress);
 }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네
## #️⃣ 작업 내용
메일 중복 사용시 오류 해결
- A사용자가 M이라는 메일 주소를 이용해서 인증 코드를 보냅니다.
- B사용자가 같은 M 메일 주소를 이용해서 인증 코드를 보냅니다. (아직 A인증 전)
- 이때 B사용자가 M 메일의 주인이 됩니다. 

## 동작 확인

![메일 1](https://github.com/user-attachments/assets/e59cd52c-58ed-4b54-a19d-09300c9b034a)
1번사용자가 메일 인증 코드를 요청했습니다.

![메일 2](https://github.com/user-attachments/assets/de7b0e1d-ec22-4898-abce-f6cb9dd04455)
2번 사용자가 같은 메일로 메일 인증 코드를 요청했습니다.

![메일 탈취 성공](https://github.com/user-attachments/assets/4b661d8e-e774-4434-9abf-798b6d17851d)
2번 사용자가 빠르네요

![메일 인증 실패](https://github.com/user-attachments/assets/b1ee1b87-989a-4740-9d3f-aa07deeb6e7a)
1번은 실패했습니다.

## 💬 리뷰 요구사항(선택)
위와 같은 경우가 잘 없을거라고 생각해서 가장 단순한 방법으로 해결했습니다.
메일 탈취가 우려된다면 한번보내고 일정시간 해당 메일로 인증 코드를 보낼 수 없게 막아야겠다는 생각도 듭니다. 다만 해당 로직을 정확히 어떻게 구현할지 고민하는게 귀찮아서.. ㅋㅋㅋ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 하나의 메일 주소에 대해 여러 인증 정보를 조회할 수 있도록 기능이 확장되었습니다.

- **버그 수정**
  - 메일 인증 시, 동일 메일 주소로 이미 인증된 내역이 있는지 더 정확하게 확인하여 중복 인증을 방지합니다.

- **기타 개선**
  - 대학 메일 인증 시, 메일 패턴을 활용하여 인증 절차가 보다 엄격하게 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->