### PR TITLE
[COZY-608] feat : 사용자 학교,메일,학과 조회 API

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/repository/MailAuthenticationRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/repository/MailAuthenticationRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MailRepository extends JpaRepository<MailAuthentication, String> {
+public interface MailAuthenticationRepository extends JpaRepository<MailAuthentication, String> {
     Optional<MailAuthentication> findByMailAddress(String mailAddress);
 
     List<MailAuthentication> findAllByMailAddress(String mailAddress);

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/repository/MailAuthenticationRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/repository/MailAuthenticationRepositoryService.java
@@ -1,0 +1,35 @@
+package com.cozymate.cozymate_server.domain.mail.repository;
+
+import com.cozymate.cozymate_server.domain.mail.MailAuthentication;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailAuthenticationRepositoryService {
+
+    private final MailAuthenticationRepository mailAuthenticationRepository;
+
+    public MailAuthentication getMailAuthenticationByIdOrThrow(String clientId) {
+        return mailAuthenticationRepository.findById(clientId)
+            .orElseThrow(() -> new GeneralException(
+                ErrorStatus._MAIL_AUTHENTICATION_NOT_FOUND)
+            );
+    }
+
+    public Optional<MailAuthentication> getMailAuthenticationByIdOptional(String clientId){
+        return mailAuthenticationRepository.findById(clientId);
+    }
+
+    public MailAuthentication createMailAuthentication(MailAuthentication mailAuthentication){
+        return mailAuthenticationRepository.save(mailAuthentication);
+    }
+
+    public List<MailAuthentication> getMailAuthenticationListByMailAddress(String mailAddress){
+        return mailAuthenticationRepository.findAllByMailAddress(mailAddress);
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.cozymate.cozymate_server.domain.member.dto.request.SignUpRequestDTO;
 import com.cozymate.cozymate_server.domain.member.dto.request.UpdateRequestDTO;
 import com.cozymate.cozymate_server.domain.member.dto.request.WithdrawRequestDTO;
 import com.cozymate.cozymate_server.domain.member.dto.response.MemberDetailResponseDTO;
+import com.cozymate.cozymate_server.domain.member.dto.response.MemberUniversityInfoResponseDTO;
 import com.cozymate.cozymate_server.domain.member.dto.response.SignInResponseDTO;
 import com.cozymate.cozymate_server.domain.member.service.MemberService;
 import com.cozymate.cozymate_server.global.response.ApiResponse;
@@ -42,6 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+
     @GetMapping("/check-nickname")
     @Operation(summary = "[말즈] 닉네임 유효성 검증",
         description = "false : 사용 불가, true : 사용 가능")
@@ -66,10 +68,14 @@ public class MemberController {
             "&nbsp;&nbsp;&nbsp;&nbsp;\"persona\": 1,<br>" +
             "&nbsp;&nbsp;&nbsp;&nbsp;\"memberStatPreferenceDto\": {<br>" +
             "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"preferenceList\": [<br>" +
-            "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"wakeUpTime\",<br>" +
-            "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"sleepingTime\",<br>" +
-            "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"coolingIntensity\",<br>" +
-            "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"studying\"<br>" +
+            "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"wakeUpTime\",<br>"
+            +
+            "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"sleepingTime\",<br>"
+            +
+            "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"coolingIntensity\",<br>"
+            +
+            "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"studying\"<br>"
+            +
             "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>" +
             "&nbsp;&nbsp;&nbsp;&nbsp;}<br>" +
             "}" +
@@ -134,9 +140,19 @@ public class MemberController {
     public ResponseEntity<ApiResponse<String>> withdraw(
         @AuthenticationPrincipal MemberDetails memberDetails,
         @Valid WithdrawRequestDTO withdrawRequestDTO) {
-        memberService.withdraw(withdrawRequestDTO,memberDetails);
+        memberService.withdraw(withdrawRequestDTO, memberDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다."));
+    }
+
+    @Operation(summary = "[말즈] 인증된 학교 정보 API (신규 2025.5.12)", description = "사용자의 학교이름, 메일주소, 학과")
+    @GetMapping("/university-info")
+    public ResponseEntity<ApiResponse<MemberUniversityInfoResponseDTO>> getMemberUniversityInfo(
+        @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(memberService.getMemberUniversityInfo(memberDetails.member()))
+        );
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/converter/MemberConverter.java
@@ -5,6 +5,7 @@ import com.cozymate.cozymate_server.domain.auth.dto.response.TokenResponseDTO;
 import com.cozymate.cozymate_server.domain.auth.utils.ClientIdMaker;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.dto.response.MemberDetailResponseDTO;
+import com.cozymate.cozymate_server.domain.member.dto.response.MemberUniversityInfoResponseDTO;
 import com.cozymate.cozymate_server.domain.member.dto.response.SignInResponseDTO;
 import com.cozymate.cozymate_server.domain.member.enums.Gender;
 import com.cozymate.cozymate_server.domain.member.enums.Role;
@@ -76,6 +77,18 @@ public class MemberConverter {
             .universityId(universityId)
             .majorName(majorName)
             .persona(persona)
+            .build();
+    }
+
+    public static MemberUniversityInfoResponseDTO toMemberUniversityInfoResponseDTO(
+        String universityName,
+        String mailAddress,
+        String majorName
+    ){
+        return MemberUniversityInfoResponseDTO.builder()
+            .universityName(universityName)
+            .mailAddress(mailAddress)
+            .majorName(majorName)
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/dto/response/MemberUniversityInfoResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/dto/response/MemberUniversityInfoResponseDTO.java
@@ -1,0 +1,12 @@
+package com.cozymate.cozymate_server.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MemberUniversityInfoResponseDTO(
+    String universityName,
+    String mailAddress,
+    String majorName
+) {
+
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
@@ -5,7 +5,7 @@ import com.cozymate.cozymate_server.domain.chat.repository.ChatRepository;
 import com.cozymate.cozymate_server.domain.chatroom.repository.ChatRoomRepository;
 import com.cozymate.cozymate_server.domain.fcm.repository.FcmRepositoryService;
 import com.cozymate.cozymate_server.domain.inquiry.repository.InquiryRepository;
-import com.cozymate.cozymate_server.domain.mail.repository.MailRepository;
+import com.cozymate.cozymate_server.domain.mail.repository.MailAuthenticationRepository;
 import com.cozymate.cozymate_server.domain.mate.Mate;
 import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
 import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
@@ -37,7 +37,7 @@ public class MemberWithdrawService {
 
     private final MemberRepository memberRepository;
     private final TokenRepository tokenRepository;
-    private final MailRepository mailRepository;
+    private final MailAuthenticationRepository mailAuthenticationRepository;
     private final MemberStatRepository memberStatRepository;
     private final MemberStatPreferenceRepository memberStatPreferenceRepository;
     private final LifestyleMatchRateRepository lifestyleMatchRateRepository;
@@ -81,7 +81,7 @@ public class MemberWithdrawService {
     @Transactional
     public void deleteRelatedWithMember(Member member) {
         tokenRepository.deleteById(member.getClientId());
-        mailRepository.deleteById(member.getClientId());
+        mailAuthenticationRepository.deleteById(member.getClientId());
         log.debug("토큰,메일 삭제 완료");
 
         memberFavoriteRepository.deleteByMemberOrTargetMember(member);


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네 
## #️⃣ 작업 내용

- 사용자 학교,메일,학과 조회 API를 구현했습니다.
- 하면서 컨벤션에 맞게 `MailAuthenticationRepositoryServcie`만들었습니다.
- 메일을 보내는 다른 작업도 있으니 Repository 명을 좀 명확히 하면 좋겠다고 생각해서 `MailAuthenticationRepository`로 이름을 바꿨습니다.

## 동작 확인
![image](https://github.com/user-attachments/assets/66846600-b4eb-414e-9aac-3ba31589aa7f)
회원인데 인증받은 메일이 없는경우 이렇게 조회됩니다. 이렇게 한 이유는 메일인증에 대한 변경사항에 대응하기 위함입니다.
(+이스터 에그로 메일없이도 동작하게 하기위해ㅎㅎ)

![image](https://github.com/user-attachments/assets/9772fde2-c6de-4442-a580-d96bdbb17117)
메일인증을 받았으면 이런식으로 조회됩니다.

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 인증된 사용자의 학교명, 이메일, 전공 정보를 반환하는 `/university-info` 엔드포인트가 추가되었습니다.

- **버그 수정**
  - 회원 탈퇴 시 이메일 인증 정보 삭제가 정상적으로 동작하도록 개선되었습니다.

- **리팩터링**
  - 메일 인증 관련 데이터 접근이 서비스 계층으로 분리되어 코드 구조가 개선되었습니다.  
  - 일부 필드 및 클래스 명칭이 명확하게 변경되었습니다.

- **문서화**
  - 신규 엔드포인트에 대한 Swagger 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->