### PR TITLE
[COZY-609] fix : 탈퇴시 라이프스타일 일치율 정합성 문제 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
@@ -12,7 +12,9 @@ import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 import com.cozymate.cozymate_server.domain.memberfavorite.repository.MemberFavoriteRepository;
+import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.service.LifestyleMatchRateCacheService;
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.repository.LifestyleMatchRateRepository;
+import com.cozymate.cozymate_server.domain.memberstat.memberstat.redis.service.MemberStatCacheService;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.repository.MemberStatRepository;
 import com.cozymate.cozymate_server.domain.memberstatpreference.repository.MemberStatPreferenceRepository;
 import com.cozymate.cozymate_server.domain.notificationlog.repository.NotificationLogRepositoryService;
@@ -41,6 +43,7 @@ public class MemberWithdrawService {
     private final MemberStatRepository memberStatRepository;
     private final MemberStatPreferenceRepository memberStatPreferenceRepository;
     private final LifestyleMatchRateRepository lifestyleMatchRateRepository;
+    private final MemberStatCacheService memberStatCacheService;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
     private final ReportRepository reportRepository;
@@ -91,6 +94,7 @@ public class MemberWithdrawService {
         memberStatRepository.deleteByMemberId(member.getId());
         memberStatPreferenceRepository.deleteByMemberId(member.getId());
         lifestyleMatchRateRepository.deleteAllByMemberId(member.getId());
+        memberStatCacheService.delete(member.getMemberStat());
 
         log.debug("사용자 상세정보 및 관련 통계 삭제 완료");
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/redis/service/LifestyleMatchRateCacheService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/lifestylematchrate/redis/service/LifestyleMatchRateCacheService.java
@@ -4,9 +4,11 @@ import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.Lifesty
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.LifestyleMatchRateRedisDTO;
 import com.cozymate.cozymate_server.domain.memberstat.lifestylematchrate.redis.util.LifestyleMatchRateCacheMapper;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -19,6 +21,7 @@ public class LifestyleMatchRateCacheService {
     private final RedisTemplate<String, Object> redisTemplate;
     private static final String PREFIX = "matchRate:";
     private static final String DELIM = ":";
+    private static final String ALL = "*";
 
     public void save(LifestyleMatchRateRedisDTO dto) {
         String key = generateKey(dto.getMemberA(), dto.getMemberB());
@@ -84,4 +87,22 @@ public class LifestyleMatchRateCacheService {
         long second = Math.max(memberA, memberB);
         return PREFIX + first + DELIM + second;
     }
+    public void deleteAllRelatedTo(Long memberId) {
+        // 1. 패턴 기반 키 조회
+        String pattern1 = PREFIX + memberId + DELIM + ALL;
+        String pattern2 = PREFIX + ALL + DELIM + memberId;
+
+        Set<String> keys1 = redisTemplate.keys(pattern1);
+        Set<String> keys2 = redisTemplate.keys(pattern2);
+
+        // 2. 합집합 후 삭제
+        Set<String> allKeys = new HashSet<>();
+        if (keys1 != null) allKeys.addAll(keys1);
+        if (keys2 != null) allKeys.addAll(keys2);
+
+        if (!allKeys.isEmpty()) {
+            redisTemplate.delete(allKeys);
+        }
+    }
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/redis/service/MemberStatCacheService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/redis/service/MemberStatCacheService.java
@@ -111,6 +111,51 @@ public class MemberStatCacheService {
             ));
     }
 
+    public void delete(MemberStat memberStat) {
+        Long universityId = memberStat.getMember().getUniversity().getId();
+        String gender = memberStat.getMember().getGender().toString();
+        Long memberId = memberStat.getMember().getId();
+
+        log.info("[삭제 시작] memberId={}, universityId={}, gender={}", memberId, universityId, gender);
+
+        // 1. 기본 풀에서 제거
+        String poolKey = generatePoolKey(universityId, gender);
+        Long removedFromPool = redisTemplate.opsForSet().remove(poolKey, memberId.toString());
+        log.info("기본 Pool Set 삭제 - key: {}, 삭제된 개수: {}", poolKey, removedFromPool);
+
+        // 2. 라이프스타일 Set에서 제거
+        Map<String, String> extractedAnswers = MemberStatExtractor.extractAnswers(memberStat);
+        for (Map.Entry<String, String> entry : extractedAnswers.entrySet()) {
+            String question = entry.getKey();
+            String answer = entry.getValue();
+
+            if (answer.isBlank()) continue;
+
+            if (MULTI_VALUE_QUESTION.contains(question)) {
+                for (String val : answer.split(",")) {
+                    if (!val.isBlank()) {
+                        String lifestyleKey = generateLifestyleKey(universityId, question, val.trim());
+                        Long removed = redisTemplate.opsForSet().remove(lifestyleKey, memberId.toString());
+                        log.info("라이프스타일 Set 삭제 [다중값] - key: {}, 값: {}, 삭제된 개수: {}", lifestyleKey, val.trim(), removed);
+                    }
+                }
+            } else {
+                String lifestyleKey = generateLifestyleKey(universityId, question, answer);
+                Long removed = redisTemplate.opsForSet().remove(lifestyleKey, memberId.toString());
+                log.info("라이프스타일 Set 삭제 - key: {}, 값: {}, 삭제된 개수: {}", lifestyleKey, answer, removed);
+            }
+        }
+
+        // 3. 매칭률 캐시도 삭제
+        log.info("매칭률 캐시 삭제 시작 - memberId={}", memberId);
+        lifestyleMatchRateCacheService.deleteAllRelatedTo(memberId);
+        log.info("매칭률 캐시 삭제 완료 - memberId={}", memberId);
+
+        log.info("[삭제 완료] memberId={}", memberId);
+    }
+
+
+
     /**
      * 필터 조건 기반 사용자 ID 리스트 필터링
      * - 각 조건별 Union 후, 전체 조건에 대해 교집합 수행

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/repository/MemberStatRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/repository/MemberStatRepositoryService.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class MemberStatRepositoryService {
 
     private final MemberStatRepository memberStatRepository;
@@ -90,13 +92,15 @@ public class MemberStatRepositoryService {
         Map<Long, MemberStat> idToStat = memberStats.stream()
             .collect(Collectors.toMap(stat -> stat.getMember().getId(), Function.identity()));
 
-        // 5. 정렬된 순서에 따라 Map 구성
+        // 5. 정렬된 순서에 따라 Map 구성 (null key 방지)
         List<Map<MemberStat, Integer>> content = pagedUserIds.stream()
+            .filter(idToStat::containsKey) // null 방지
             .map(id -> Map.of(idToStat.get(id), idToMatchRate.get(id)))
             .toList();
 
         return new SliceImpl<>(content, pageable, hasNext);
     }
+
 
 
     /**


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네
## #️⃣ 작업 내용
레디스 캐싱하면서 탈퇴시 정합성 문제가 생겼습니다.
- 탈퇴하면 레디스에서도 비우게 했습니다.
- 레디스에 있던 id 가 파라미터로 넘겨지더라도 DB에서 없으면 이를 무시하고 조회합니다.

## 동작 확인
![image](https://github.com/user-attachments/assets/eb792ae9-924e-4045-b3ea-fcdb250a93cf)
문제가 됐던 사용자의 응답이 잘 옵니다.

![image](https://github.com/user-attachments/assets/333cd46d-0dc3-4f5f-aecc-447b55abee4c)

탈퇴하면서 삭제로그를 찍어봤습니다.
## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 회원 탈퇴 시 회원의 통계 및 라이프스타일 관련 캐시 데이터가 함께 삭제되어 데이터 정합성이 향상되었습니다.
- **버그 수정**
	- 필터링된 회원 통계 조회 시, 존재하지 않는 ID로 인한 오류 가능성이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->