### PR TITLE
[COZY-612] fix: 쪽지 상세 조회 시 NPE 발생 문제 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/chat/validator/ChatValidator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/chat/validator/ChatValidator.java
@@ -13,21 +13,25 @@ import org.springframework.stereotype.Component;
 public class ChatValidator {
 
     public void checkMemberMisMatch(Member member, ChatRoom chatRoom) {
-        // ChatRoom의 MemberA가 null(탈퇴 회원)이고, 현재 요청 Member가 ChatRoom의 MemberB와 다른 경우
-        if (Objects.isNull(chatRoom.getMemberA())
-            && !member.getId().equals(chatRoom.getMemberB().getId())) {
-            throw new GeneralException(ErrorStatus._CHATROOM_MEMBERB_REQUIRED_WHEN_MEMBERA_NULL);
+        // ChatRoom의 MemberA가 null(탈퇴 회원)인 경우
+        if (isNullMember(chatRoom.getMemberA())) {
+            if (!isSameMember(member, chatRoom.getMemberB())) {
+                throw new GeneralException(ErrorStatus._CHATROOM_MEMBERB_REQUIRED_WHEN_MEMBERA_NULL);
+            }
+            return;
         }
 
-        // ChatRoom의 MemberB가 null(탈퇴 회원)이고, 현재 요청 Member가 ChatRoom의 MemberA와 다른 경우
-        if (Objects.isNull(chatRoom.getMemberB())
-            && !member.getId().equals(chatRoom.getMemberA().getId())) {
-            throw new GeneralException(ErrorStatus._CHATROOM_MEMBERA_REQUIRED_WHEN_MEMBERB_NULL);
+        // ChatRoom의 MemberB가 null(탈퇴 회원)인 경우
+        if (isNullMember(chatRoom.getMemberB())) {
+            if (!isSameMember(member, chatRoom.getMemberA())) {
+                throw new GeneralException(ErrorStatus._CHATROOM_MEMBERA_REQUIRED_WHEN_MEMBERB_NULL);
+            }
+            return;
         }
 
         // ChatRoom의 두 Member가 모두 null(탈퇴 회원)이 아닌 경우, 현재 요청 Member가 MemberA, MemberB 둘다 아닌 경우
-        if (!member.getId().equals(chatRoom.getMemberA().getId())
-            && !member.getId().equals(chatRoom.getMemberB().getId())) {
+        if (!isSameMember(member, chatRoom.getMemberA())
+            && !isSameMember(member, chatRoom.getMemberB())) {
             throw new GeneralException(ErrorStatus._CHATROOM_INVALID_MEMBER);
         }
     }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

쪽지방에서 한명이 탈퇴한 경우, 나머지 한 명이 해당 쪽지방 조회 시 해당 방의 멤버인지 확인하는 로직에 오류가 있어서 NPE 발생한 문제를 수정했습니다.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c91e323a-e9c3-4e1b-a0c3-8ef9d7efc3ab" />


## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

에러 알림 온 계정 로그인해서 정상 동작 확인 완료
<img width="350" alt="image" src="https://github.com/user-attachments/assets/6314bc61-ca41-41ba-99c4-ffebe650f8ec" />


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
