### PR TITLE
[COZY-624] fix : 방안에 룸메이트 칼라칩 오류 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/converter/MemberStatConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/converter/MemberStatConverter.java
@@ -23,6 +23,7 @@ import com.cozymate.cozymate_server.domain.memberstat.memberstat.util.QuestionAn
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 
@@ -296,17 +297,18 @@ public class MemberStatConverter {
     }
 
     public static DifferenceStatus toDifferenceStatus(List<MemberStat> memberStatList, String key) {
-        if (memberStatList.isEmpty()) {
-            return DifferenceStatus.NOT_SAME_NOT_DIFFERENT;
-        }
-        if (memberStatList.size() == 1) {
+        if (memberStatList.size() <= 1) {
             return DifferenceStatus.NOT_SAME_NOT_DIFFERENT;
         }
 
-        return MemberStatComparator.compareField(memberStatList,
-            FieldInstanceResolver.getFIELD_MAPPER());
+        BiFunction<Member, MemberStat, ?> getter = FieldInstanceResolver.getFIELD_MAPPER().get(key);
+        if (getter == null) {
+            return DifferenceStatus.NOT_SAME_NOT_DIFFERENT;
+        }
 
+        return MemberStatComparator.compareField(memberStatList, getter);
     }
+
 
     public static MemberStatDifferenceListResponseDTO toMemberStatDifferenceResponseDTO(
         List<MemberStat> memberStatList) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/util/MemberStatComparator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/memberstat/memberstat/util/MemberStatComparator.java
@@ -22,7 +22,8 @@ public class MemberStatComparator {
         for (int i = 0; i < memberStatList.size(); i++) {
             T currentValue = getter.apply(memberStatList.get(i).getMember(), memberStatList.get(i));
             for (int j = i + 1; j < memberStatList.size(); j++) {
-                T comparisonValue = getter.apply(memberStatList.get(j).getMember(), memberStatList.get(j));
+                T comparisonValue = getter.apply(memberStatList.get(j).getMember(),
+                    memberStatList.get(j));
                 if (currentValue.equals(comparisonValue)) {
                     foundSame = true;
                 } else {

--- a/src/main/java/com/cozymate/cozymate_server/domain/university/converter/UniversityConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/university/converter/UniversityConverter.java
@@ -13,6 +13,7 @@ public class UniversityConverter {
   public static University toUniversity(UniversityRequestDTO universityDTO) {
     return University.builder()
         .name(universityDTO.name())
+        .mailPattern(universityDTO.mailPattern())
         .dormitoryNames(universityDTO.dormitoryNames())
         .departments(universityDTO.departments())
         .build();


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
방안에 룸메이트 칼라칩 오류 해결
- member stat에서 특정 key에 대한 비교를 해야 하는데, 전체 맵을 주고 있었습니다.
- key에 해당하는 Function<MemberStat, ?>만 추출해서 각 MemberStat에 적용한 결과를 동일한지 비교 했습니다.

## 동작 확인

<img src="https://github.com/user-attachments/assets/cfba752e-081d-451b-bf65-f0c226707fa7" width="300"/>
방 정보 조회 /rooms/83 에서는 dormJoiningStatus이 blue인데


<img src="https://github.com/user-attachments/assets/0975a23e-b120-46e7-99e4-8dd60bdc1740" width="300"/>

방에 속해 있는 메이트 멤버 상세정보 조회 /rooms/83/memberStat/dormJoiningStatus 에서는 red로 주는중이었습니다.


<img src="https://github.com/user-attachments/assets/6c35d116-be84-42f5-b035-69bff8ddcf63" width="300"/>

blue 로 줍니다!!

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
