### PR TITLE
[COZY-625] fix: 알림 요구 사항 변경에 따른 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/dto/push/target/OneTargetReverseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/dto/push/target/OneTargetReverseDTO.java
@@ -2,6 +2,7 @@ package com.cozymate.cozymate_server.domain.fcm.dto.push.target;
 
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
+import com.cozymate.cozymate_server.domain.room.Room;
 
 /**
  * 알림 내용에 포함되는 멤버의 닉네임과 실제 알림을 받는 멤버가 다른 경우 사용
@@ -14,10 +15,17 @@ import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationTyp
 public record OneTargetReverseDTO(
     Member contentMember,
     Member recipientMember,
-    NotificationType notificationType
+    NotificationType notificationType,
+    Room room
 ) {
+
     public static OneTargetReverseDTO create(Member contentMember, Member recipientMember,
         NotificationType notificationType) {
-        return new OneTargetReverseDTO(contentMember, recipientMember, notificationType);
+        return new OneTargetReverseDTO(contentMember, recipientMember, notificationType, null);
+    }
+
+    public static OneTargetReverseDTO create(Member contentMember, Member recipientMember,
+        NotificationType notificationType, Room room) {
+        return new OneTargetReverseDTO(contentMember, recipientMember, notificationType, room);
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/listener/EventListener.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/listener/EventListener.java
@@ -134,7 +134,7 @@ public class EventListener {
         Member managerMember = managerMate.getMember();
 
         OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(member, managerMember,
-            NotificationType.ARRIVE_ROOM_JOIN_REQUEST);
+            NotificationType.ARRIVE_ROOM_JOIN_REQUEST, room);
 
         fcmPushService.sendNotification(oneTargetReverseDTO);
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmPushService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmPushService.java
@@ -1,6 +1,7 @@
 package com.cozymate.cozymate_server.domain.fcm.service;
 
 import com.cozymate.cozymate_server.domain.fcm.Fcm;
+import com.cozymate.cozymate_server.domain.fcm.dto.push.content.FcmPushContentDTO;
 import com.cozymate.cozymate_server.domain.fcm.dto.push.target.GroupRoomNameWithOutMeTargetDTO;
 import com.cozymate.cozymate_server.domain.fcm.dto.push.target.GroupTargetDTO;
 import com.cozymate.cozymate_server.domain.fcm.dto.push.target.GroupWithOutMeTargetDTO;
@@ -12,6 +13,7 @@ import com.cozymate.cozymate_server.domain.fcm.repository.FcmRepositoryService;
 import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.fcm.dto.MessageResult;
 import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
+import com.cozymate.cozymate_server.domain.notificationlog.dto.NotificationLogCreateDTO;
 import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
 import com.cozymate.cozymate_server.domain.notificationlog.repository.NotificationLogRepositoryService;
 import com.cozymate.cozymate_server.domain.room.Room;
@@ -89,6 +91,16 @@ public class FcmPushService {
         Member recipientMember = target.recipientMember();
         NotificationType notificationType = target.notificationType();
 
+        // 방 참여 요청의 경우 요청자는 fcm 알림 전송 x, 알림 내역만 저장 (토스트 팝업 대체)
+        if (target.room() != null) {
+            String content = NotificationType.SENT_ROOM_JOIN_REQUEST.generateContent(
+                FcmPushContentDTO.create(recipientMember));
+            NotificationLog notificationLog = NotificationType.SENT_ROOM_JOIN_REQUEST.generateNotificationLog(
+                NotificationLogCreateDTO.createNotificationLogCreateDTO(contentMember,
+                    recipientMember, target.room(), content));
+            notificationLogRepositoryService.createNotificationLog(notificationLog);
+        }
+
         sendNotificationToMember(messageUtil.createMessage(contentMember, recipientMember,
             notificationType));
     }
@@ -104,8 +116,12 @@ public class FcmPushService {
         NotificationType hostNotificationType = target.hostNotificationType();
         NotificationType memberNotificationType = target.memberNotificationType();
 
-        sendNotificationToMember(
-            messageUtil.createMessage(member, room, host, hostNotificationType));
+        // 방장은 fcm 알림 전송 x, 알림 내역만 저장 (토스트 팝업 대체)
+        String content = hostNotificationType.generateContent(
+            FcmPushContentDTO.create(member, room));
+        NotificationLog notificationLog = hostNotificationType.generateNotificationLog(
+            NotificationLogCreateDTO.createNotificationLogCreateDTO(host, member, room, content));
+        notificationLogRepositoryService.createNotificationLog(notificationLog);
 
         sendNotificationToMember(
             messageUtil.createMessage(host, room, member, memberNotificationType));

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/enums/NotificationType.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/enums/NotificationType.java
@@ -188,7 +188,7 @@ public enum NotificationType {
         @Override
         public NotificationLog generateNotificationLog(NotificationLogCreateDTO createDTO) {
             return NotificationLogConverter.toEntity(createDTO.getRecipientMember(), getCategory(),
-                createDTO.getContent(), createDTO.getRoom().getId());
+                createDTO.getContent(), createDTO.getContentMember().getId());
         }
     },
 
@@ -265,6 +265,20 @@ public enum NotificationType {
         public NotificationLog generateNotificationLog(NotificationLogCreateDTO createDTO) {
             return NotificationLogConverter.toEntity(createDTO.getRecipientMember(), getCategory(),
                 createDTO.getContent(), createDTO.getContentMember().getId());
+        }
+    },
+
+    SENT_ROOM_JOIN_REQUEST(NotificationCategory.ROOM_JOIN_REQUEST) {
+        @Override
+        public String generateContent(FcmPushContentDTO fcmPushContentDTO) {
+            return fcmPushContentDTO.member().getNickname()
+                + "님에게 방 참여 요청을 보냈어요";
+        }
+
+        @Override
+        public NotificationLog generateNotificationLog(NotificationLogCreateDTO createDTO) {
+            return NotificationLogConverter.toEntity(createDTO.getRecipientMember(), getCategory(),
+                createDTO.getContent(), createDTO.getRoom().getId());
         }
     }
     ;


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

1. 방 초대 or 참여 요청 시 요청자 본인에게도 알림이 가고 있었는데, 본인에게는 알림은 전송되지 않고 알림 로그만 저장되도록 수정했습니다.
2. 초대 요청, 참여 요청 모두 targetId에 상대 memberId를 저장하고 있었는데 roomId가 필요한 경우가 있다해서 그에 맞게 수정했습니다.
- 초대 요청
방장의 경우
-> 본인에게 알림 x, 알림 내역에 저장은 o, 이 때 targetId : 초대 대상 memberId
상대의 경우
-> 알림 o, 알림 내역 저장 o, 이 때 targetId : 초대 받은 roomId

- 참여 요청
사용자의 경우
-> 본인에게 알림 x, 알림 내역에 저장은 o, 이 때 targetId : 참여 요청 보낸 roomId
방장의 경우
-> 알림 o, 알림 내역 저장 o, 이때 targetId : 참여 요청을 한 memberId

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

방장인 밖에비옴의 memberId : 370
방이 없는 사용자 포포븽의 memberId : 337
방만들거야의 roomId : 135

방장이 밖에비옴인 방만들거야 방으로 포포븽이 방 참여 요청을 보낸 경우
<img width="578" alt="image" src="https://github.com/user-attachments/assets/7d1197ab-9ef8-49b8-98a2-7c29a5843500" />

밖에비옴이 포포븽에게 방 초대 요청을 보낸 경우
<img width="604" alt="image" src="https://github.com/user-attachments/assets/04f103ba-1481-49de-9fbc-13caf0d12220" />

알림은 안가고 알림 내역만 저장되는 경우는 로컬에서 로그랑 실제 알림 안오는거 확인했습니다

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

FcmPushService 클래스 코드가 지저분해졌는데, 이 부분은 targetDTO 상황별로 더 분리하는 리팩토링 나중에 하겠슴다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 알림 유형에 "방 참여 요청 전송"이 추가되어, 방 참여 요청 시 새로운 알림이 제공됩니다.

- **버그 수정**
  - 일부 알림 로그 생성 시 잘못된 정보가 저장되던 문제가 수정되었습니다.

- **기타 변경**
  - 방 참여 요청 관련 알림에서, 요청자와 수신자에게 맞는 알림 및 로그가 보다 정확하게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->