### PR TITLE
fix: 방 정원 꽉 찬 경우 대기중인 참여 요청 삭제 처리

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mate/repository/MateRepository.java
@@ -85,6 +85,8 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     void deleteAllByMemberIdAndEntryStatusIn(Long memberId, List<EntryStatus> entryStatuses);
 
+    void deleteAllByRoomIdAndEntryStatusIn(Long roomId, List<EntryStatus> entryStatuses);
+
     @Query("select mt from Mate mt join fetch mt.member m left join fetch m.memberStat where mt.room = :room and mt.entryStatus = :entryStatus")
     List<Mate> findFetchMemberAndMemberStatByRoom(@Param("room") Room room,
         @Param("entryStatus") EntryStatus entryStatus);

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -328,6 +328,11 @@ public class RoomCommandService {
             processJoinRequest(invitee, room);
             clearOtherRoomRequests(inviteeMember.getId());
 
+            // 방 정원 꽉찬 경우 다른 요청들 모두 날림
+            if (room.getMaxMateNum()==room.getNumOfArrival()) {
+                clearOtherMateRequests(roomId);
+            }
+
             eventPublisher.publishEvent(
                 EventConverter.toAcceptedInvitationEvent(inviteeMember, room));
         } else {
@@ -442,6 +447,11 @@ public class RoomCommandService {
             processJoinRequest(requester, room);
             clearOtherRoomRequests(requesterId);
 
+            // 방 정원 꽉찬 경우 다른 요청들 모두 날림
+            if (room.getMaxMateNum()==room.getNumOfArrival()) {
+                clearOtherMateRequests(room.getId());
+            }
+
             eventPublisher.publishEvent(
                 EventConverter.toAcceptedJoinEvent(manager.getMember(), requestMember, room));
         } else {
@@ -514,6 +524,12 @@ public class RoomCommandService {
     private void clearOtherRoomRequests(Long memberId) {
         mateRepository.deleteAllByMemberIdAndEntryStatusIn(
             memberId, List.of(EntryStatus.PENDING, EntryStatus.INVITED)
+        );
+    }
+
+    private void clearOtherMateRequests(Long roomId) {
+        mateRepository.deleteAllByRoomIdAndEntryStatusIn(
+            roomId, List.of(EntryStatus.PENDING, EntryStatus.INVITED)
         );
     }
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
1. 방에 정원이 꽉 찬 경우 남아있는 참여요청 모두 삭제
    - 방장이 마지막 사람 승인하는 경우
    - 사용자가 마지막 정원으로 들어가는 경우
2. 사용자가 방에 참여하거나 나가는 경우 `addUserToHasRoom()`, `removeUserFromHasRoom()` 호출 @genius00hwan 
3. 메서드 이름을 변경했습니다
    - `deleteJoinRequestsByMember`: 특정 사용자가 보낸 참여 요청 전부 삭제
    - `deleteJoinRequestsByRoom`: 특정 방에 대한 다른 사용자의 참여 요청 전부 삭제

## 동작 확인
1. 사용자가 요청 수락하는 경우
![image](https://github.com/user-attachments/assets/3fc73941-903d-4de4-8ee9-80e7e241a94e)
![image](https://github.com/user-attachments/assets/621237d1-f5ae-49b8-a073-90331529d3c0)
마지막 인원이 요청을 수락하면 대기 중인 모든 요청이 삭제되고 방에는 참여 중인 인원만 남습니다.
![image](https://github.com/user-attachments/assets/fe93d3fc-a269-4fdb-a3cb-11c4c2a5bbd3)

2. 방장이 마지막 요청 수락하는 경우
![image](https://github.com/user-attachments/assets/d2a93a5a-74bf-4c77-be84-0c175223eb24)
![image](https://github.com/user-attachments/assets/19fdfa10-0512-4fee-9a06-ddcf4d526cad)
방장이 마지막 요청을 수락하면 마찬가지로 대기중인 요청들이 모두 삭제되고 방에 참여중인 사람들만 남습니다
![image](https://github.com/user-attachments/assets/dc91e406-81bb-4003-a286-a16a39acf300)



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요
## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 방 참여 및 퇴장 시 멤버 통계 캐시가 자동으로 동기화됩니다.

* **버그 수정**
  * 방이 가득 찬 경우, 해당 방의 모든 대기 또는 초대된 참가 요청이 자동으로 삭제됩니다.
  * 멤버가 방에 참여하거나 초대를 수락할 때, 중복된 참가 요청이 더 효과적으로 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->