### PR TITLE
[COZY-628] feat: 회원 탈퇴 시 Role이 먼저 삭제되어 연관된 Todo가 있을 때 에러가 발생하는 경우 해결

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/member/service/MemberWithdrawService.java
@@ -159,6 +159,8 @@ public class MemberWithdrawService {
 
         postCommentRepository.deleteAllByCommenterId(mate.getId());
 
+        todoCommandService.updateAssignedMateIfMateExitRoom(mate);
+
         roleRepository.findAllByMateId(mate.getId()).forEach(role -> {
             role.removeAssignee(mate.getId());
 
@@ -170,7 +172,7 @@ public class MemberWithdrawService {
 
         log.debug("role 삭제 완료");
 
-        todoCommandService.updateAssignedMateIfMateExitRoom(mate);
+
         log.debug("todo 삭제 완료");
         log.debug("mate 관련 엔티티 삭제 완료");
     }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
넹

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

회원 탈퇴 시 기존의 플로우는 Role 삭제 -> Todo 삭제 순으로 진행되고 있었습니다.
이 경우 Todo의 roleId가 role에 연관되어있기에, Role이 먼저 삭제될 경우 연관된 Todo가 존재할 때 외래 키 연관 에러가 발생하게 됩니다.
따라서 Todo 객체를 먼저 삭제하게 한 후 Role을 삭제하도록 순서를 살짝 수정하였습니다.
실제로도 코드의 변경 사항은 순서 변경 이외에 없습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

### 기존에 에러가 발생하는 상황 재현
![image](https://github.com/user-attachments/assets/d2947bb4-79d8-4020-aa1f-a72650940202)

### 코드 변경 후 작성되는 로그 데이터 (로그가 엄청 길긴 한데, 정상적으로 Response가 반환되는 것을 확인할 수 있음)
![image](https://github.com/user-attachments/assets/a8fead74-1917-4c2a-86a0-7e993edd699c)
![image](https://github.com/user-attachments/assets/2f47571f-5d74-406c-9d42-041018f33805)
![image](https://github.com/user-attachments/assets/dde21fa6-1c8b-4fd3-ae6b-2cb8146846a6)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
