### PR TITLE
[COZY-638] fix: 롤 투두를 추가한 당일의 요일이 일치할 경우 투두 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/role/service/RoleCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/role/service/RoleCommandService.java
@@ -56,6 +56,12 @@ public class RoleCommandService {
         Role role = roleRepositoryService.createRole(
             RoleConverter.toEntity(mate, mateIdList, requestDto.content(), repeatDayBitmask)
         );
+
+        DayOfWeek dayOfWeek = LocalDate.now(clock).getDayOfWeek();
+        int dayBitmask = DayListBitmask.getBitmaskByDayOfWeek(dayOfWeek);
+        if ((role.getRepeatDays() & dayBitmask) != 0) {
+            todoCommandService.createRoleTodo(role);
+        }
         return RoleConverter.toRoleSimpleResponseDTOWithEntity(role);
     }
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

네

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

### 아래 기능 구현했습니다.

작업한 코드양은 매우 적습니다. 기존 롤 투두 로직을 재활용하기도 했고요.

![image](https://github.com/user-attachments/assets/6161ee4b-3947-479f-a9b6-5f0b1c132dd4)


## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요
### 추가했을 때
![image](https://github.com/user-attachments/assets/6e7ecd4b-585f-40f7-a01a-29de9e0ae7e0)

### 25번 데이터 추가 완료
![image](https://github.com/user-attachments/assets/be2482e3-f42e-4006-9f85-80f0bd784a93)

### 25번 투두에도 추가 완료
![image](https://github.com/user-attachments/assets/96aaa560-70ba-4488-82ab-cec5c10ac66f)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.
