### PR TITLE
[COZY-639] feat : 메일도메인 여러개 허용

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -153,7 +153,6 @@ public class MailService {
             helper.setSubject("cozymate 대학교 메일인증");
             helper.setText(emailBody, true);
             mailSender.send(message);
-            log.info("메일 보내기 완료");
 
             return MailConverter.toMailAuthenticationWithParams(clientId, mailAddress,
                 authenticationCode, false);
@@ -165,8 +164,6 @@ public class MailService {
     private void validateMailAddress(String mailAddress, List<String> mailPatterns) {
         String domain = mailAddress.substring(mailAddress.indexOf('@') + 1);
         if (!mailPatterns.contains(domain)) {
-            log.info("allow pattern : {}",mailPatterns.toString());
-            log.info("[Debug] mail domain :{} origin address :{}", domain, mailAddress);
             throw new GeneralException(ErrorStatus._INVALID_MAIL_ADDRESS_DOMAIN);
         }
         List<MailAuthentication> mailAuthentications = mailAuthenticationRepositoryService.getMailAuthenticationListByMailAddress(

--- a/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/mail/service/MailService.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,7 +57,7 @@ public class MailService {
             sendDTO.universityId());
 
         String mailAddress = sendDTO.mailAddress();
-        validateMailAddress(mailAddress, university.getMailPattern());
+        validateMailAddress(mailAddress, university.getMailPatterns());
 
         MailAuthentication mailAuthentication = createAndSendMail(clientId,
             mailAddress, university.getName());
@@ -76,7 +77,7 @@ public class MailService {
                 verifyDTO.majorName());
         }
 
-        verifyAuthenticationCode(clientId, verifyDTO.code(), memberUniversity.getMailPattern());
+        verifyAuthenticationCode(clientId, verifyDTO.code(), memberUniversity.getMailPatterns());
 
         return authService.signInByPreMember(clientId, memberUniversity,
             verifyDTO.majorName());
@@ -107,7 +108,8 @@ public class MailService {
         }
     }
 
-    private void verifyAuthenticationCode(String clientId, String requestCode, String mailPattern) {
+    private void verifyAuthenticationCode(String clientId, String requestCode,
+        List<String> mailPatterns) {
 
         MailAuthentication mailAuthentication = mailAuthenticationRepositoryService.getMailAuthenticationByIdOrThrow(
             clientId);
@@ -119,7 +121,7 @@ public class MailService {
         }
 
         // 메일 중복 확인
-        validateMailAddress(mailAuthentication.getMailAddress(), mailPattern);
+        validateMailAddress(mailAuthentication.getMailAddress(), mailPatterns);
 
         // 메일 인증 코드 일치 여부 확인
         if (!mailAuthentication.getCode().equals(requestCode)) {
@@ -151,6 +153,7 @@ public class MailService {
             helper.setSubject("cozymate 대학교 메일인증");
             helper.setText(emailBody, true);
             mailSender.send(message);
+            log.info("메일 보내기 완료");
 
             return MailConverter.toMailAuthenticationWithParams(clientId, mailAddress,
                 authenticationCode, false);
@@ -159,8 +162,11 @@ public class MailService {
         }
     }
 
-    private void validateMailAddress(String mailAddress, String mailPattern) {
-        if (!mailAddress.contains(mailPattern)) {
+    private void validateMailAddress(String mailAddress, List<String> mailPatterns) {
+        String domain = mailAddress.substring(mailAddress.indexOf('@') + 1);
+        if (!mailPatterns.contains(domain)) {
+            log.info("allow pattern : {}",mailPatterns.toString());
+            log.info("[Debug] mail domain :{} origin address :{}", domain, mailAddress);
             throw new GeneralException(ErrorStatus._INVALID_MAIL_ADDRESS_DOMAIN);
         }
         List<MailAuthentication> mailAuthentications = mailAuthenticationRepositoryService.getMailAuthenticationListByMailAddress(

--- a/src/main/java/com/cozymate/cozymate_server/domain/university/University.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/university/University.java
@@ -28,8 +28,9 @@ public class University extends BaseTimeEntity {
 
     private String name;
 
-    private String mailPattern;
-
+    @Type(JsonType.class)
+    @Column(columnDefinition = "json")
+    private List<String> mailPatterns;
     @Type(JsonType.class)
     @Column(columnDefinition = "json")
     private List<String> departments;
@@ -38,8 +39,8 @@ public class University extends BaseTimeEntity {
     @Column(columnDefinition = "json")
     private List<String> dormitoryNames;
 
-    public void update(String mailPattern, List<String> departments, List<String> dormitoryNames) {
-        this.mailPattern = mailPattern;
+    public void update(List<String> mailPatterns, List<String> departments, List<String> dormitoryNames) {
+        this.mailPatterns = mailPatterns;
         this.departments = departments;
         this.dormitoryNames = dormitoryNames;
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/university/converter/UniversityConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/university/converter/UniversityConverter.java
@@ -13,7 +13,7 @@ public class UniversityConverter {
   public static University toUniversity(UniversityRequestDTO universityDTO) {
     return University.builder()
         .name(universityDTO.name())
-        .mailPattern(universityDTO.mailPattern())
+        .mailPatterns(universityDTO.mailPatterns())
         .dormitoryNames(universityDTO.dormitoryNames())
         .departments(universityDTO.departments())
         .build();
@@ -23,7 +23,8 @@ public class UniversityConverter {
     return UniversityDetailResponseDTO.builder()
         .id(university.getId())
         .name(university.getName())
-        .mailPattern(university.getMailPattern())
+        .mailPatterns(university.getMailPatterns())
+        .mailPattern(university.getMailPatterns().get(0))
         .dormitoryNames(university.getDormitoryNames().stream().sorted().toList())
         .departments(university.getDepartments().stream().sorted().toList())
         .build();

--- a/src/main/java/com/cozymate/cozymate_server/domain/university/dto/request/UniversityRequestDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/university/dto/request/UniversityRequestDTO.java
@@ -5,10 +5,11 @@ import lombok.Builder;
 
 @Builder
 public record UniversityRequestDTO(
-        String name,
-        String mailPattern,
-        List<String>dormitoryNames,
-        List<String> departments
+    String name,
+    List<String> mailPatterns,
+    List<String> dormitoryNames,
+    List<String> departments
 
 ) {
+
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/university/dto/response/UniversityDetailResponseDTO.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/university/dto/response/UniversityDetailResponseDTO.java
@@ -8,6 +8,7 @@ public record UniversityDetailResponseDTO(
         Long id,
         String name,
         String mailPattern,
+        List<String> mailPatterns,
         List<String> dormitoryNames,
         List<String> departments) {
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/university/service/UniversityService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/university/service/UniversityService.java
@@ -33,7 +33,7 @@ public class UniversityService {
     public UniversityDetailResponseDTO updateUniversity(UniversityRequestDTO requestDTO) {
         University university = universityRepositoryService.getUniversityByNameOrThrow(requestDTO.name());
 
-        university.update(requestDTO.mailPattern(), requestDTO.departments(), requestDTO.dormitoryNames());
+        university.update(requestDTO.mailPatterns(), requestDTO.departments(), requestDTO.dormitoryNames());
 
         return UniversityConverter.toUniversityDTOFromEntity(university);
     }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

네
## #️⃣ 작업 내용
메일 도메인 여러개 허용하게 했습니다.
디비에 mail_patterns라는 필드를 두고 검증합니다.

## 동작 확인
![get-info?universityId=1](https://github.com/user-attachments/assets/7bfb5b59-e5ec-40e5-a692-7e6a39758541)

인하대에 gmail이 허용되도록 해봤습니다.

![image](https://github.com/user-attachments/assets/c1773ff7-4cb5-4df8-b9a9-c9d69192a317)


![gmail](https://github.com/user-attachments/assets/3fd6cb09-4513-4e73-bc49-4299748d4fe4)
![inha edu](https://github.com/user-attachments/assets/175d349a-8800-4ff2-bcc6-8e8f6b490481)
둘다 되네요
## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 대학 이메일 인증 및 관리에서 하나의 이메일 패턴이 아닌 여러 개의 이메일 도메인 패턴을 지원하도록 개선되었습니다.
  * 대학 상세 정보 응답에 여러 이메일 패턴 리스트가 추가되었습니다.

* **버그 수정**
  * 이메일 도메인 유효성 검사 로직이 여러 패턴을 올바르게 처리하도록 수정되었습니다.

* **기타**
  * 관련 요청/응답 데이터 구조가 복수의 이메일 패턴을 반영하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->