### PR TITLE
[COZY-640] feat: 일부 알림 종류에 대해 알림 전송 시 Message 객체에 targetId 값을 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/RejectedJoinEvent.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/RejectedJoinEvent.java
@@ -1,12 +1,14 @@
 package com.cozymate.cozymate_server.domain.fcm.event;
 
 import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.room.Room;
 import lombok.Builder;
 
 @Builder
 public record RejectedJoinEvent(
     Member manager,
-    Member requester
+    Member requester,
+    Room room
 ) {
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/converter/EventConverter.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/converter/EventConverter.java
@@ -69,10 +69,11 @@ public class EventConverter {
             .build();
     }
 
-    public static RejectedJoinEvent toRejectedJoinEvent(Member manager, Member requester) {
+    public static RejectedJoinEvent toRejectedJoinEvent(Member manager, Member requester, Room room) {
         return RejectedJoinEvent.builder()
             .manager(manager)
             .requester(requester)
+            .room(room)
             .build();
     }
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/listener/EventListener.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/listener/EventListener.java
@@ -169,9 +169,10 @@ public class EventListener {
     public void sendNotification(RejectedJoinEvent event) {
         Member manager = event.manager();
         Member requester = event.requester();
+        Room room = event.room();
 
         OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(manager, requester,
-            NotificationType.REJECT_ROOM_JOIN);
+            NotificationType.REJECT_ROOM_JOIN, room);
 
         fcmPushService.sendNotification(oneTargetReverseDTO);
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmPushService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/FcmPushService.java
@@ -91,21 +91,25 @@ public class FcmPushService {
         Member recipientMember = target.recipientMember();
         NotificationType notificationType = target.notificationType();
 
-        // 방 참여 요청의 경우 요청자는 fcm 알림 전송 x, 알림 내역만 저장 (토스트 팝업 대체)
-        if (target.room() != null) {
-            String content = NotificationType.SENT_ROOM_JOIN_REQUEST.generateContent(
-                FcmPushContentDTO.create(recipientMember));
-            NotificationLog notificationLog = NotificationType.SENT_ROOM_JOIN_REQUEST.generateNotificationLog(
-                NotificationLogCreateDTO.createNotificationLogCreateDTO(contentMember,
-                    recipientMember, target.room(), content));
-            notificationLogRepositoryService.createNotificationLog(notificationLog);
-        }
-
-        if (target.chatContent() != null) {
+        if (NotificationType.ARRIVE_CHAT.equals(notificationType)) {
             sendNotificationToMember(
                 messageUtil.createMessage(contentMember, recipientMember, target.chatContent(),
                     notificationType, target.chatRoom()));
+        } else if (NotificationType.REJECT_ROOM_JOIN.equals(notificationType)) {
+            sendNotificationToMember(
+                messageUtil.createMessage(contentMember, target.room(), recipientMember,
+                    notificationType));
         } else {
+            // 방 참여 요청의 경우 요청자는 fcm 알림 전송 x, 알림 내역만 저장 (토스트 팝업 대체)
+            if (NotificationType.ARRIVE_ROOM_JOIN_REQUEST.equals(notificationType)) {
+                String content = NotificationType.SENT_ROOM_JOIN_REQUEST.generateContent(
+                    FcmPushContentDTO.create(recipientMember));
+                NotificationLog notificationLog = NotificationType.SENT_ROOM_JOIN_REQUEST.generateNotificationLog(
+                    NotificationLogCreateDTO.createNotificationLogCreateDTO(contentMember,
+                        recipientMember, target.room(), content));
+                notificationLogRepositoryService.createNotificationLog(notificationLog);
+            }
+
             sendNotificationToMember(messageUtil.createMessage(contentMember, recipientMember,
                 notificationType));
         }

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/MessageUtil.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/service/MessageUtil.java
@@ -66,9 +66,6 @@ public class MessageUtil {
         return getMessageResult(fcmList, content, notificationType, notificationLog);
     }
 
-    /**
-     * 여기의 contentMemberId를 fcm Message에 넣어야함
-     */
     public MessageResult createMessage(Member contentMember, Member recipientMember,
         NotificationType notificationType) {
         List<Fcm> fcmList = getFcmList(recipientMember);

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -466,7 +466,7 @@ public class RoomCommandService {
             mateRepository.delete(requester); // 거절 시 요청자 삭제
 
             eventPublisher.publishEvent(
-                EventConverter.toRejectedJoinEvent(manager.getMember(), requestMember));
+                EventConverter.toRejectedJoinEvent(manager.getMember(), requestMember, room));
         }
     }
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

REJECT_ROOM_JOIN (방장이 방 참여 요청을 거절한 경우)
targetId : roomId (거절한 방)

REJECT_ROOM_INVITE (유저가 방 초대 요청을 거절한 경우)
targetId : memberId (거절한 유저)

ARRIVE_CHAT (쪽지)
targetId : chatRoomId

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/7ec6d25a-5afa-4a86-88e4-3de26b02d455" />

푸시 알림 Message 객체에 담긴 값이 잘 가는지는 제가 확인을 못해서 일단 동작 이상 없는지만 확인했습니다

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 방 참여 요청 거절 알림에 방 정보가 추가되어, 알림 수신 시 더 많은 정보를 확인할 수 있습니다.

* **버그 수정**
  * 다양한 알림 유형별로 알림 전송 및 기록 방식이 명확하게 구분되어, 알림 처리의 일관성이 향상되었습니다.

* **리팩터링**
  * 알림 메시지 생성 및 데이터 구조가 통일되고, 내부 로직이 개선되어 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->