### PR TITLE
[COZY-641] fix: 인원이 가득 찬 방에 대한 찜 제약 조건 삭제

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/controller/RoomFavoriteController.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/controller/RoomFavoriteController.java
@@ -36,7 +36,6 @@ public class RoomFavoriteController {
     @SwaggerApiError({
         ErrorStatus._ROOM_NOT_FOUND,
         ErrorStatus._ROOMFAVORITE_CANNOT_PRIVATE_ROOM,
-        ErrorStatus._ROOMFAVORITE_CANNOT_FULL_ROOM,
         ErrorStatus._ROOMFAVORITE_CANNOT_DISABLE_ROOM,
         ErrorStatus._ROOMFAVORITE_ALREADY_EXISTS,
     })

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/repository/RoomFavoriteRepository.java
@@ -40,7 +40,6 @@ public interface RoomFavoriteRepository extends JpaRepository<RoomFavorite, Long
         select rf from RoomFavorite rf 
         where rf.member = :member 
         and rf.room.status <> :roomStatus 
-        and rf.room.numOfArrival < rf.room.maxMateNum
         """)
     Slice<RoomFavorite> findPagingByMemberAndRoomStatusNot(@Param("member") Member member,
         @Param("roomStatus") RoomStatus roomStatus, Pageable pageable);

--- a/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/validator/RoomFavoriteValidator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/roomfavorite/validator/RoomFavoriteValidator.java
@@ -22,10 +22,6 @@ public class RoomFavoriteValidator {
             throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_PRIVATE_ROOM);
         }
 
-        if (room.getNumOfArrival() == room.getMaxMateNum()) {
-            throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_FULL_ROOM);
-        }
-
         if (RoomStatus.DISABLE.equals(room.getStatus())) {
             throw new GeneralException(ErrorStatus._ROOMFAVORITE_CANNOT_DISABLE_ROOM);
         }

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -206,8 +206,6 @@ public enum ErrorStatus implements BaseErrorCode {
     _ROOMFAVORITE_MEMBER_MISMATCH(HttpStatus.BAD_REQUEST, "ROOMFAVORITE402", "해당 찜에 대한 권한이 없습니다."),
     _ROOMFAVORITE_CANNOT_PRIVATE_ROOM(HttpStatus.BAD_REQUEST, "ROOMFAVORITE403",
         "비공개 방은 찜을 할 수 없습니다."),
-    _ROOMFAVORITE_CANNOT_FULL_ROOM(HttpStatus.BAD_REQUEST, "ROOMFAVORITE404",
-        "인원이 가득 찬 방은 찜을 할 수 없습니다."),
     _ROOMFAVORITE_CANNOT_DISABLE_ROOM(HttpStatus.BAD_REQUEST, "ROOMFAVORITE405",
         "삭제된 방은 찜을 할 수 없습니다."),
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

인원이 가득 찬 방도 찜을 할 수 있도록 예외 처리를 수정했습니다

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

방 인원이 가득 찬 7번 방
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/fc6bdfa8-c3f4-4567-99a1-b24db98d7430" />

7번 방 찜 성공
<img width="306" alt="image" src="https://github.com/user-attachments/assets/f836c4cf-087f-4234-95fd-6464fe5c86fa" />

방 찜 목록 조회도 성공
<img width="325" alt="image" src="https://github.com/user-attachments/assets/400b1bd7-74fa-46cd-9472-8614d7177e14" />



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

제가 방쪽 로직을 잘 몰라서 그런데 방 상태값이 DISABLE인 경우가 여전히 존재하나요??
없어진거면 DISABLE 관련된 코드들도 뺴려구여


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인원이 가득 찬 방도 이제 찜하기가 가능합니다. 더 이상 방 인원 제한으로 인해 찜하기가 차단되지 않습니다.  
* **문서**
  * 방 찜하기 기능의 오류 응답 목록에서 "인원이 가득 찬 방은 찜을 할 수 없습니다" 관련 안내가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->