### PR TITLE
[COZY-642] feat: 탈퇴한 사용자/삭제된 방에 대해 NotificationLog의 targetId를 null로 수정

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/repository/NotificationLogRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/repository/NotificationLogRepository.java
@@ -18,4 +18,31 @@ public interface NotificationLogRepository extends JpaRepository<NotificationLog
     @Modifying
     @Query("delete from NotificationLog n where n.member.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("""
+        update NotificationLog nl
+        set nl.targetId = null
+        where nl.targetId = :memberId
+        and nl.category in :categoryList
+        and (nl.content not like concat('%', :pattern1) and nl.content not like concat('%', :pattern2))
+    """
+    )
+    void updateTargetIdToNullByMemberId(
+        @Param("memberId") Long memberId, @Param("categoryList") List<String> categoryList,
+        @Param("pattern1") String pattern1, @Param("pattern2") String pattern2
+    );
+
+    @Modifying
+    @Query("""
+        update NotificationLog nl
+        set nl.targetId = null
+        where nl.targetId = :roomId
+        and (nl.category = 'ROOM' or (nl.category in :categoryList and (nl.content like concat('%', :pattern1) or nl.content like concat('%', :pattern2))))
+    """
+    )
+    void updateTargetIdToNullByRoomId(
+        @Param("roomId") Long roomId, @Param("categoryList") List<String> categoryList,
+        @Param("pattern1") String pattern1, @Param("pattern2") String pattern2
+    );
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/repository/NotificationLogRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/repository/NotificationLogRepositoryService.java
@@ -16,13 +16,19 @@ public class NotificationLogRepositoryService {
     private final NotificationLogRepository notificationLogRepository;
     private final NotificationLogBulkRepository notificationLogBulkRepository;
 
+    private static final List<String> patterns = List.of("으로 나를 초대했어요", "님에게 방 참여 요청을 보냈어요");
+    private static final List<String> categoryList = List.of(
+        NotificationCategory.ROOM_INVITE_REQUEST.toString(),
+        NotificationCategory.ROOM_JOIN_REQUEST.toString());
+
     public void createNotificationLog(NotificationLog notificationLog) {
         notificationLogRepository.save(notificationLog);
     }
 
     public Slice<NotificationLog> getNotificationLogListByMember(Member member, Pageable pageable) {
         return notificationLogRepository.findByMemberAndCategoryNotInOrderByIdDesc(
-            member, List.of(NotificationCategory.COZY_HOME, NotificationCategory.COZY_ROLE), pageable);
+            member, List.of(NotificationCategory.COZY_HOME, NotificationCategory.COZY_ROLE),
+            pageable);
     }
 
     public void createNoticeNotificationLog(List<Long> successMemberIdList, String content,
@@ -33,5 +39,16 @@ public class NotificationLogRepositoryService {
 
     public void deleteNotificationLogByMemberId(Long memberId) {
         notificationLogRepository.deleteAllByMemberId(memberId);
+        updateNotificationLogTargetIdToNullByMemberId(memberId);
+    }
+
+    public void updateNotificationLogTargetIdToNullByRoomId(Long roomId) {
+        notificationLogRepository.updateTargetIdToNullByRoomId(roomId, categoryList,
+            patterns.get(0), patterns.get(1));
+    }
+
+    private void updateNotificationLogTargetIdToNullByMemberId(Long memberId) {
+        notificationLogRepository.updateTargetIdToNullByMemberId(memberId, categoryList,
+            patterns.get(0), patterns.get(1));
     }
 }

--- a/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/service/NotificationLogCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/notificationlog/service/NotificationLogCommandService.java
@@ -1,0 +1,18 @@
+package com.cozymate.cozymate_server.domain.notificationlog.service;
+
+import com.cozymate.cozymate_server.domain.notificationlog.repository.NotificationLogRepositoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationLogCommandService {
+
+    private final NotificationLogRepositoryService notificationLogRepositoryService;
+
+    public void updateTargetIdToNullByRoomId(Long roomId) {
+        notificationLogRepositoryService.updateNotificationLogTargetIdToNullByRoomId(roomId);
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -13,6 +13,7 @@ import com.cozymate.cozymate_server.domain.member.Member;
 import com.cozymate.cozymate_server.domain.member.enums.Gender;
 import com.cozymate.cozymate_server.domain.member.repository.MemberRepository;
 import com.cozymate.cozymate_server.domain.memberstat.memberstat.redis.service.MemberStatCacheService;
+import com.cozymate.cozymate_server.domain.notificationlog.service.NotificationLogCommandService;
 import com.cozymate.cozymate_server.domain.post.Post;
 import com.cozymate.cozymate_server.domain.post.repository.PostRepository;
 import com.cozymate.cozymate_server.domain.postcomment.PostCommentRepository;
@@ -77,6 +78,7 @@ public class RoomCommandService {
     private final RoomRepositoryService roomRepositoryService;
     private final MateRepositoryService mateRepositoryService;
     private final MemberStatCacheService memberStatCacheService;
+    private final NotificationLogCommandService notificationLogCommandService;
 
     @Transactional
     public RoomDetailResponseDTO createPrivateRoom(PrivateRoomCreateRequestDTO request,
@@ -170,6 +172,7 @@ public class RoomCommandService {
         // 연관된 Mate, Rule, RoomLog, Feed 엔티티 삭제
         deleteRoomDatas(roomId);
         roomRepositoryService.delete(room);
+        notificationLogCommandService.updateTargetIdToNullByRoomId(roomId);
     }
 
     public Boolean checkRoomName(String roomName) {
@@ -211,6 +214,7 @@ public class RoomCommandService {
             // 연관된 Mate, Rule, RoomLog, Feed 엔티티 삭제
             deleteRoomDatas(roomId);
             roomRepositoryService.delete(room);
+            notificationLogCommandService.updateTargetIdToNullByRoomId(roomId);
             return;
         }
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

탈퇴한 사용자/삭제된 방에 대해 NotificationLog의 targetId를 null로 수정하는 기능을 추가했습니다

- targetId가 roomId인 경우
ROOM 뛰쳐나갔어요
ROOM 뛰어들어왔어요
ROOM_INVITE_REQUEST && 으로 나를 초대했어요
ROOM_JOIN_REQUEST && 님에게 방 참여 요청을 보냈어요

- targetId가 memberId인 경우
ROOM_JOIN_REQUEST && 님이 방 참여 요청을 보냈어요
ROOM_JOIN_REQUEST && 님이 방 참여 요청을 수락했어요
ROOM_JOIN_REQUEST && 님이 방 참여 요청을 거절했어요
ROOM_INVITE_REQUEST && 으로 초대 요청을 보냈어요
ROOM_INVITE_REQUEST && 방 초대 요청을 수락했어요
ROOM_INVITE_REQUEST && 초대 요청을 거절했어요

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요
API 테스트는 해당 메서드 실행만 따로 테스트용 만들어서 진행했습니다 (그 다음 탈퇴, 방 나가기 로직에 추가)

targetId가 129번이고 해당 targetId가 roomId인 데이터들
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/b27b73df-b361-4a5c-ac13-0924e45162ab" />

전부 사라짐
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/d5febf12-f3a0-4934-a0a5-abda582f81eb" />

null 처리된 데이터들이 중간중간 보입니다
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/e8a871f7-5b4c-4126-a16e-3f80012b6623" />

이번에는 중간중간 보이는 targetId가 337번이고 해당 targetId가 memberId인 데이터들을 날려보겠습니다
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/8fe17d5e-8b10-4b5d-95f0-984985d6fd9a" />

null 처리가 잘 된 것 같습니다
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/4693c8b0-dd5b-4000-b684-4ee07b8e5a54" />

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 방 삭제 및 퇴장 시, 해당 방과 관련된 알림의 대상 ID가 자동으로 비워집니다.
  * 알림 관리 서비스에 방 ID를 기준으로 알림의 대상 ID를 비우는 기능이 추가되었습니다.

* **버그 수정**
  * 삭제된 방이나 멤버와 관련된 알림에서 더 이상 잘못된 대상 정보가 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->