### PR TITLE
[COZY-643] fix: 공개방 생성 시 방 있는 사용자 캐시 정보 추가

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/room/service/RoomCommandService.java
@@ -129,6 +129,12 @@ public class RoomCommandService {
         Mate mate = MateConverter.toEntity(room, member, true);
         mateRepository.save(mate);
 
+        memberStatCacheService.addUserToHasRoom(
+            room.getUniversity().getId(),
+            room.getGender().name(),
+            mate.getMember().getId()
+        );
+
         Feed feed = FeedConverter.toEntity(room);
         feedRepository.save(feed);
 


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
네

## #️⃣ 작업 내용
방장도 방 있는 사용자 캐시에 포함되도록 수정했습니다

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 사용자가 새로운 프라이빗 룸을 생성할 때, 해당 사용자가 방을 보유하고 있음을 통계에 즉시 반영하도록 개선되었습니다.
  * 새로운 퍼블릭 룸 생성 시에도 사용자의 방 보유 상태가 통계에 정확히 반영되도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->