### PR TITLE
[COZY-647] feat: 푸시 알림 전송 요청 SQS + Lambda로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,9 @@ dependencies {
     // actuator (health check)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // AWS SQS
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/listener/EventListener.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/listener/EventListener.java
@@ -1,191 +1,191 @@
-package com.cozymate.cozymate_server.domain.fcm.event.listener;
-
-import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
-import com.cozymate.cozymate_server.domain.fcm.dto.push.target.GroupRoomNameWithOutMeTargetDTO;
-import com.cozymate.cozymate_server.domain.fcm.dto.push.target.HostAndMemberAndRoomTargetDTO;
-import com.cozymate.cozymate_server.domain.fcm.dto.push.target.OneTargetReverseDTO;
-import com.cozymate.cozymate_server.domain.fcm.event.AcceptedJoinEvent;
-import com.cozymate.cozymate_server.domain.fcm.event.RejectedJoinEvent;
-import com.cozymate.cozymate_server.domain.fcm.event.SentChatEvent;
-import com.cozymate.cozymate_server.domain.fcm.service.FcmPushService;
-import com.cozymate.cozymate_server.domain.mate.Mate;
-import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
-import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
-import com.cozymate.cozymate_server.domain.member.Member;
-import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
-import com.cozymate.cozymate_server.domain.room.Room;
-import com.cozymate.cozymate_server.domain.fcm.event.AcceptedInvitationEvent;
-import com.cozymate.cozymate_server.domain.fcm.event.JoinedRoomEvent;
-import com.cozymate.cozymate_server.domain.fcm.event.QuitRoomEvent;
-import com.cozymate.cozymate_server.domain.fcm.event.RejectedInvitationEvent;
-import com.cozymate.cozymate_server.domain.fcm.event.RequestedJoinRoomEvent;
-import com.cozymate.cozymate_server.domain.fcm.event.SentInvitationEvent;
-import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
-import com.cozymate.cozymate_server.global.response.exception.GeneralException;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
-
-@Component
-@RequiredArgsConstructor
-public class EventListener {
-
-    private final FcmPushService fcmPushService;
-    private final MateRepository mateRepository;
-
-    @TransactionalEventListener
-    public void sendNotification(JoinedRoomEvent event) {
-        Member member = event.member();
-        Room room = event.room();
-
-        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
-
-        List<Member> memberList = findRoomMates.stream()
-            .map(Mate::getMember)
-            .filter(findMember -> !findMember.getId().equals(member.getId()))
-            .toList();
-
-        GroupRoomNameWithOutMeTargetDTO groupRoomNameWithOutMeTargetDTO = GroupRoomNameWithOutMeTargetDTO.create(
-            member, memberList, room, NotificationType.ROOM_IN);
-
-        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDTO);
-    }
-
-    @TransactionalEventListener
-    public void sendNotification(QuitRoomEvent event) {
-        Member member = event.member();
-        Room room = event.room();
-
-        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
-
-        List<Member> memberList = findRoomMates.stream()
-            .map(Mate::getMember)
-            .filter(findMember -> !findMember.getId().equals(member.getId()))
-            .toList();
-
-        GroupRoomNameWithOutMeTargetDTO groupRoomNameWithOutMeTargetDTO = GroupRoomNameWithOutMeTargetDTO.create(
-            member, memberList, room, NotificationType.ROOM_OUT);
-
-        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDTO);
-    }
-
-    @TransactionalEventListener
-    public void sendNotification(SentInvitationEvent event) {
-        Member inviter = event.inviter();
-        Member invitee = event.invitee();
-        Room room = event.room();
-
-        HostAndMemberAndRoomTargetDTO hostAndMemberAndRoomTargetDTO = HostAndMemberAndRoomTargetDTO.create(
-            inviter, NotificationType.SEND_ROOM_INVITE, invitee,
-            NotificationType.ARRIVE_ROOM_INVITE, room);
-
-        fcmPushService.sendNotification(hostAndMemberAndRoomTargetDTO);
-    }
-
-    @TransactionalEventListener
-    public void sendNotification(AcceptedInvitationEvent event) {
-        Member invitee = event.invitee();
-        Room room = event.room();
-
-        Mate inviterMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
-        Member inviter = inviterMate.getMember();
-
-        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(invitee, inviter,
-            NotificationType.ACCEPT_ROOM_INVITE);
-
-        fcmPushService.sendNotification(oneTargetReverseDTO);
-
-        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
-
-        List<Member> memberList = findRoomMates.stream()
-            .map(Mate::getMember)
-            .filter(findMember -> !findMember.getId().equals(invitee.getId()))
-            .toList();
-
-        GroupRoomNameWithOutMeTargetDTO groupRoomNameWithOutMeTargetDTO = GroupRoomNameWithOutMeTargetDTO.create(
-            invitee, memberList, room, NotificationType.ROOM_IN);
-
-        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDTO);
-    }
-
-    @TransactionalEventListener
-    public void sendNotification(RejectedInvitationEvent event) {
-        Member invitee = event.invitee();
-        Room room = event.room();
-
-        Mate inviterMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
-        Member inviter = inviterMate.getMember();
-
-        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(invitee, inviter,
-            NotificationType.REJECT_ROOM_INVITE);
-
-        fcmPushService.sendNotification(oneTargetReverseDTO);
-    }
-
-    @TransactionalEventListener
-    public void sendNotification(RequestedJoinRoomEvent event) {
-        Member member = event.member();
-        Room room = event.room();
-
-        Mate managerMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
-
-        Member managerMember = managerMate.getMember();
-
-        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(member, managerMember,
-            NotificationType.ARRIVE_ROOM_JOIN_REQUEST, room);
-
-        fcmPushService.sendNotification(oneTargetReverseDTO);
-    }
-
-    @TransactionalEventListener
-    public void sendNotification(AcceptedJoinEvent event) {
-        Member manager = event.manager();
-        Member requester = event.requester();
-        Room room = event.room();
-
-        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(manager, requester,
-            NotificationType.ACCEPT_ROOM_JOIN);
-
-        fcmPushService.sendNotification(oneTargetReverseDTO);
-
-        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
-
-        List<Member> memberList = findRoomMates.stream()
-            .map(Mate::getMember)
-            .filter(findMember -> !findMember.getId().equals(requester.getId()))
-            .toList();
-
-        GroupRoomNameWithOutMeTargetDTO groupRoomNameWithOutMeTargetDTO = GroupRoomNameWithOutMeTargetDTO.create(
-            requester, memberList, room, NotificationType.ROOM_IN);
-
-        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDTO);
-    }
-
-    @TransactionalEventListener
-    public void sendNotification(RejectedJoinEvent event) {
-        Member manager = event.manager();
-        Member requester = event.requester();
-        Room room = event.room();
-
-        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(manager, requester,
-            NotificationType.REJECT_ROOM_JOIN, room);
-
-        fcmPushService.sendNotification(oneTargetReverseDTO);
-    }
-
-    @TransactionalEventListener
-    public void sendNotification(SentChatEvent event) {
-        Member sender = event.sender();
-        Member recipient = event.recipient();
-        ChatRoom chatRoom = event.chatRoom();
-
-        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(sender, recipient,
-            NotificationType.ARRIVE_CHAT, event.content(), chatRoom);
-
-        fcmPushService.sendNotification(oneTargetReverseDTO);
-    }
-}
+//package com.cozymate.cozymate_server.domain.fcm.event.listener;
+//
+//import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+//import com.cozymate.cozymate_server.domain.fcm.dto.push.target.GroupRoomNameWithOutMeTargetDTO;
+//import com.cozymate.cozymate_server.domain.fcm.dto.push.target.HostAndMemberAndRoomTargetDTO;
+//import com.cozymate.cozymate_server.domain.fcm.dto.push.target.OneTargetReverseDTO;
+//import com.cozymate.cozymate_server.domain.fcm.event.AcceptedJoinEvent;
+//import com.cozymate.cozymate_server.domain.fcm.event.RejectedJoinEvent;
+//import com.cozymate.cozymate_server.domain.fcm.event.SentChatEvent;
+//import com.cozymate.cozymate_server.domain.fcm.service.FcmPushService;
+//import com.cozymate.cozymate_server.domain.mate.Mate;
+//import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
+//import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
+//import com.cozymate.cozymate_server.domain.member.Member;
+//import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
+//import com.cozymate.cozymate_server.domain.room.Room;
+//import com.cozymate.cozymate_server.domain.fcm.event.AcceptedInvitationEvent;
+//import com.cozymate.cozymate_server.domain.fcm.event.JoinedRoomEvent;
+//import com.cozymate.cozymate_server.domain.fcm.event.QuitRoomEvent;
+//import com.cozymate.cozymate_server.domain.fcm.event.RejectedInvitationEvent;
+//import com.cozymate.cozymate_server.domain.fcm.event.RequestedJoinRoomEvent;
+//import com.cozymate.cozymate_server.domain.fcm.event.SentInvitationEvent;
+//import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+//import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+//import java.util.List;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Component;
+//import org.springframework.transaction.event.TransactionalEventListener;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class EventListener {
+//
+//    private final FcmPushService fcmPushService;
+//    private final MateRepository mateRepository;
+//
+//    @TransactionalEventListener
+//    public void sendNotification(JoinedRoomEvent event) {
+//        Member member = event.member();
+//        Room room = event.room();
+//
+//        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
+//
+//        List<Member> memberList = findRoomMates.stream()
+//            .map(Mate::getMember)
+//            .filter(findMember -> !findMember.getId().equals(member.getId()))
+//            .toList();
+//
+//        GroupRoomNameWithOutMeTargetDTO groupRoomNameWithOutMeTargetDTO = GroupRoomNameWithOutMeTargetDTO.create(
+//            member, memberList, room, NotificationType.ROOM_IN);
+//
+//        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDTO);
+//    }
+//
+//    @TransactionalEventListener
+//    public void sendNotification(QuitRoomEvent event) {
+//        Member member = event.member();
+//        Room room = event.room();
+//
+//        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
+//
+//        List<Member> memberList = findRoomMates.stream()
+//            .map(Mate::getMember)
+//            .filter(findMember -> !findMember.getId().equals(member.getId()))
+//            .toList();
+//
+//        GroupRoomNameWithOutMeTargetDTO groupRoomNameWithOutMeTargetDTO = GroupRoomNameWithOutMeTargetDTO.create(
+//            member, memberList, room, NotificationType.ROOM_OUT);
+//
+//        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDTO);
+//    }
+//
+//    @TransactionalEventListener
+//    public void sendNotification(SentInvitationEvent event) {
+//        Member inviter = event.inviter();
+//        Member invitee = event.invitee();
+//        Room room = event.room();
+//
+//        HostAndMemberAndRoomTargetDTO hostAndMemberAndRoomTargetDTO = HostAndMemberAndRoomTargetDTO.create(
+//            inviter, NotificationType.SEND_ROOM_INVITE, invitee,
+//            NotificationType.ARRIVE_ROOM_INVITE, room);
+//
+//        fcmPushService.sendNotification(hostAndMemberAndRoomTargetDTO);
+//    }
+//
+//    @TransactionalEventListener
+//    public void sendNotification(AcceptedInvitationEvent event) {
+//        Member invitee = event.invitee();
+//        Room room = event.room();
+//
+//        Mate inviterMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
+//            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
+//        Member inviter = inviterMate.getMember();
+//
+//        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(invitee, inviter,
+//            NotificationType.ACCEPT_ROOM_INVITE);
+//
+//        fcmPushService.sendNotification(oneTargetReverseDTO);
+//
+//        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
+//
+//        List<Member> memberList = findRoomMates.stream()
+//            .map(Mate::getMember)
+//            .filter(findMember -> !findMember.getId().equals(invitee.getId()))
+//            .toList();
+//
+//        GroupRoomNameWithOutMeTargetDTO groupRoomNameWithOutMeTargetDTO = GroupRoomNameWithOutMeTargetDTO.create(
+//            invitee, memberList, room, NotificationType.ROOM_IN);
+//
+//        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDTO);
+//    }
+//
+//    @TransactionalEventListener
+//    public void sendNotification(RejectedInvitationEvent event) {
+//        Member invitee = event.invitee();
+//        Room room = event.room();
+//
+//        Mate inviterMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
+//            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
+//        Member inviter = inviterMate.getMember();
+//
+//        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(invitee, inviter,
+//            NotificationType.REJECT_ROOM_INVITE);
+//
+//        fcmPushService.sendNotification(oneTargetReverseDTO);
+//    }
+//
+//    @TransactionalEventListener
+//    public void sendNotification(RequestedJoinRoomEvent event) {
+//        Member member = event.member();
+//        Room room = event.room();
+//
+//        Mate managerMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
+//            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
+//
+//        Member managerMember = managerMate.getMember();
+//
+//        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(member, managerMember,
+//            NotificationType.ARRIVE_ROOM_JOIN_REQUEST, room);
+//
+//        fcmPushService.sendNotification(oneTargetReverseDTO);
+//    }
+//
+//    @TransactionalEventListener
+//    public void sendNotification(AcceptedJoinEvent event) {
+//        Member manager = event.manager();
+//        Member requester = event.requester();
+//        Room room = event.room();
+//
+//        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(manager, requester,
+//            NotificationType.ACCEPT_ROOM_JOIN);
+//
+//        fcmPushService.sendNotification(oneTargetReverseDTO);
+//
+//        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
+//
+//        List<Member> memberList = findRoomMates.stream()
+//            .map(Mate::getMember)
+//            .filter(findMember -> !findMember.getId().equals(requester.getId()))
+//            .toList();
+//
+//        GroupRoomNameWithOutMeTargetDTO groupRoomNameWithOutMeTargetDTO = GroupRoomNameWithOutMeTargetDTO.create(
+//            requester, memberList, room, NotificationType.ROOM_IN);
+//
+//        fcmPushService.sendNotification(groupRoomNameWithOutMeTargetDTO);
+//    }
+//
+//    @TransactionalEventListener
+//    public void sendNotification(RejectedJoinEvent event) {
+//        Member manager = event.manager();
+//        Member requester = event.requester();
+//        Room room = event.room();
+//
+//        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(manager, requester,
+//            NotificationType.REJECT_ROOM_JOIN, room);
+//
+//        fcmPushService.sendNotification(oneTargetReverseDTO);
+//    }
+//
+//    @TransactionalEventListener
+//    public void sendNotification(SentChatEvent event) {
+//        Member sender = event.sender();
+//        Member recipient = event.recipient();
+//        ChatRoom chatRoom = event.chatRoom();
+//
+//        OneTargetReverseDTO oneTargetReverseDTO = OneTargetReverseDTO.create(sender, recipient,
+//            NotificationType.ARRIVE_CHAT, event.content(), chatRoom);
+//
+//        fcmPushService.sendNotification(oneTargetReverseDTO);
+//    }
+//}

--- a/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/listener/NotificationEventListener.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/fcm/event/listener/NotificationEventListener.java
@@ -1,0 +1,330 @@
+package com.cozymate.cozymate_server.domain.fcm.event.listener;
+
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.fcm.dto.push.content.FcmPushContentDTO;
+import com.cozymate.cozymate_server.domain.fcm.event.AcceptedInvitationEvent;
+import com.cozymate.cozymate_server.domain.fcm.event.AcceptedJoinEvent;
+import com.cozymate.cozymate_server.domain.fcm.event.JoinedRoomEvent;
+import com.cozymate.cozymate_server.domain.fcm.event.QuitRoomEvent;
+import com.cozymate.cozymate_server.domain.fcm.event.RejectedInvitationEvent;
+import com.cozymate.cozymate_server.domain.fcm.event.RejectedJoinEvent;
+import com.cozymate.cozymate_server.domain.fcm.event.RequestedJoinRoomEvent;
+import com.cozymate.cozymate_server.domain.fcm.event.SentChatEvent;
+import com.cozymate.cozymate_server.domain.fcm.event.SentInvitationEvent;
+import com.cozymate.cozymate_server.domain.sqs.dto.SQSMessageResult;
+import com.cozymate.cozymate_server.domain.sqs.service.SQSMessageSender;
+import com.cozymate.cozymate_server.domain.sqs.service.SQSMessageCreator;
+import com.cozymate.cozymate_server.domain.mate.Mate;
+import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
+import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
+import com.cozymate.cozymate_server.domain.notificationlog.dto.NotificationLogCreateDTO;
+import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
+import com.cozymate.cozymate_server.domain.notificationlog.repository.NotificationLogRepositoryService;
+import com.cozymate.cozymate_server.domain.room.Room;
+import com.cozymate.cozymate_server.global.response.code.status.ErrorStatus;
+import com.cozymate.cozymate_server.global.response.exception.GeneralException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final MateRepository mateRepository;
+    private final SQSMessageSender sqsMessageSender;
+    private final SQSMessageCreator sqsMessageCreator;
+    private final NotificationLogRepositoryService notificationLogRepositoryService;
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(JoinedRoomEvent event) {
+        Member member = event.member();
+        Room room = event.room();
+
+        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
+
+        List<Member> memberList = findRoomMates.stream()
+            .map(Mate::getMember)
+            .filter(findMember -> !findMember.getId().equals(member.getId()))
+            .toList();
+
+        // SQSMessageResult 리스트 생성
+        List<SQSMessageResult> sqsMessageResultList = memberList.stream()
+            .map(
+                alreadyRoomMember -> sqsMessageCreator.create(member, alreadyRoomMember,
+                    room, NotificationType.ROOM_IN))
+            .toList();
+
+        // NotificationLog 저장
+        sqsMessageResultList
+            .forEach(smr -> notificationLogRepositoryService.createNotificationLog(
+                smr.notificationLog()));
+
+        // sqs 전송
+        sqsMessageResultList
+            .stream()
+            .filter(smr -> !smr.fcmSQSMessageList().isEmpty())
+            .forEach(smr -> sqsMessageSender.sendMessage(smr.fcmSQSMessageList()));
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(QuitRoomEvent event) {
+        Member member = event.member();
+        Room room = event.room();
+
+        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
+
+        List<Member> memberList = findRoomMates.stream()
+            .map(Mate::getMember)
+            .filter(findMember -> !findMember.getId().equals(member.getId()))
+            .toList();
+
+        // SQSMessageResult 리스트 생성
+        List<SQSMessageResult> sqsMessageResultList = memberList.stream()
+            .map(yetRoomMember -> sqsMessageCreator.create(member, yetRoomMember, room,
+                NotificationType.ROOM_OUT))
+            .toList();
+
+        // NotificationLog 저장
+        sqsMessageResultList
+            .forEach(smr -> notificationLogRepositoryService.createNotificationLog(
+                smr.notificationLog()));
+
+        // sqs 전송
+        sqsMessageResultList
+            .stream()
+            .filter(smr -> !smr.fcmSQSMessageList().isEmpty())
+            .forEach(smr -> sqsMessageSender.sendMessage(smr.fcmSQSMessageList()));
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(SentInvitationEvent event) {
+        Member inviter = event.inviter();
+        Member invitee = event.invitee();
+        Room room = event.room();
+
+        // SQSMessage Result 생성
+        SQSMessageResult sqsMessageResult = sqsMessageCreator.createWithRoomId(inviter, invitee,
+            room, NotificationType.ARRIVE_ROOM_INVITE);
+
+        // 알림 저장
+        notificationLogRepositoryService.createNotificationLog(
+            sqsMessageResult.notificationLog());
+
+        // 본인은 알림 로그만 저장 (푸시 알림 전송 x)
+        String content = NotificationType.SEND_ROOM_INVITE.generateContent(
+            FcmPushContentDTO.create(invitee, room));
+        NotificationLog notificationLog = NotificationType.SEND_ROOM_INVITE.generateNotificationLog(
+            NotificationLogCreateDTO.createNotificationLogCreateDTO(inviter, invitee, room,
+                content));
+        notificationLogRepositoryService.createNotificationLog(notificationLog);
+
+        // sqs 전송
+        if (!sqsMessageResult.fcmSQSMessageList().isEmpty()) {
+            sqsMessageSender.sendMessage(sqsMessageResult.fcmSQSMessageList());
+        }
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(AcceptedInvitationEvent event) {
+        Member invitee = event.invitee();
+        Room room = event.room();
+
+        Mate inviterMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
+        Member inviter = inviterMate.getMember();
+
+        // (방 초대 수락)
+        // SQSMessageResult 생성
+        SQSMessageResult sqsMessageResult = sqsMessageCreator.create(invitee, inviter,
+            NotificationType.ACCEPT_ROOM_INVITE);
+
+        // 알림 저장
+        notificationLogRepositoryService.createNotificationLog(
+            sqsMessageResult.notificationLog());
+
+        // sqs 전송
+        if (!sqsMessageResult.fcmSQSMessageList().isEmpty()) {
+            sqsMessageSender.sendMessage(sqsMessageResult.fcmSQSMessageList());
+        }
+
+        // (방 입장)
+        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
+
+        List<Member> memberList = findRoomMates.stream()
+            .map(Mate::getMember)
+            .filter(findMember -> !findMember.getId().equals(invitee.getId()))
+            .toList();
+
+        // SQSMessageResult 리스트 생성
+        List<SQSMessageResult> sqsMessageResultList = memberList.stream()
+            .map(alreadyRoomMember -> sqsMessageCreator.create(invitee,
+                alreadyRoomMember, room, NotificationType.ROOM_IN))
+            .toList();
+
+        // NotificationLog 저장
+        sqsMessageResultList
+            .forEach(smr -> notificationLogRepositoryService.createNotificationLog(
+                smr.notificationLog()));
+
+        // sqs 전송
+        sqsMessageResultList
+            .stream()
+            .filter(smr -> !smr.fcmSQSMessageList().isEmpty())
+            .forEach(smr -> sqsMessageSender.sendMessage(smr.fcmSQSMessageList()));
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(RejectedInvitationEvent event) {
+        Member invitee = event.invitee();
+        Room room = event.room();
+
+        Mate inviterMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
+        Member inviter = inviterMate.getMember();
+
+        // SQSMessageResult 생성
+        SQSMessageResult sqsMessageResult = sqsMessageCreator.createWithMemberId(invitee, inviter,
+            NotificationType.REJECT_ROOM_INVITE);
+
+        // 알림 저장
+        notificationLogRepositoryService.createNotificationLog(
+            sqsMessageResult.notificationLog());
+
+        // sqs 전송
+        if (!sqsMessageResult.fcmSQSMessageList().isEmpty()) {
+            sqsMessageSender.sendMessage(sqsMessageResult.fcmSQSMessageList());
+        }
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(RequestedJoinRoomEvent event) {
+        Member member = event.member();
+        Room room = event.room();
+
+        Mate managerMate = mateRepository.findFetchByRoomAndIsRoomManager(room, true)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MATE_NOT_FOUND));
+
+        Member managerMember = managerMate.getMember();
+
+        // 방 참여 요청의 경우 요청자는 fcm 알림 전송 x, 알림 내역만 저장 (토스트 팝업 대체)
+        String content = NotificationType.SENT_ROOM_JOIN_REQUEST.generateContent(
+            FcmPushContentDTO.create(managerMember));
+        NotificationLog notificationLog = NotificationType.SENT_ROOM_JOIN_REQUEST.generateNotificationLog(
+            NotificationLogCreateDTO.createNotificationLogCreateDTO(member,
+                managerMember, room, content));
+        notificationLogRepositoryService.createNotificationLog(notificationLog);
+
+        // SQSMessageResult 생성
+        SQSMessageResult sqsMessageResult = sqsMessageCreator.create(member,
+            managerMember, NotificationType.ARRIVE_ROOM_JOIN_REQUEST);
+
+        // 알림 저장
+        notificationLogRepositoryService.createNotificationLog(
+            sqsMessageResult.notificationLog());
+
+        // sqs 전송
+        if (!sqsMessageResult.fcmSQSMessageList().isEmpty()) {
+            sqsMessageSender.sendMessage(sqsMessageResult.fcmSQSMessageList());
+        }
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(AcceptedJoinEvent event) {
+        Member manager = event.manager();
+        Member requester = event.requester();
+        Room room = event.room();
+
+        // (방 참여 요청 수락)
+        // SQSMessageResult 생성
+        SQSMessageResult sqsMessageResult = sqsMessageCreator.create(manager, requester,
+            NotificationType.ACCEPT_ROOM_JOIN);
+
+        // 알림 저장
+        notificationLogRepositoryService.createNotificationLog(
+            sqsMessageResult.notificationLog());
+
+        // sqs 전송
+        if (!sqsMessageResult.fcmSQSMessageList().isEmpty()) {
+            sqsMessageSender.sendMessage(sqsMessageResult.fcmSQSMessageList());
+        }
+
+        // (방 입장)
+        List<Mate> findRoomMates = mateRepository.findFetchMemberByRoom(room, EntryStatus.JOINED);
+
+        List<Member> memberList = findRoomMates.stream()
+            .map(Mate::getMember)
+            .filter(findMember -> !findMember.getId().equals(requester.getId()))
+            .toList();
+
+        // SQSMessageResult 리스트 생성
+        List<SQSMessageResult> sqsMessageResultList = memberList.stream()
+            .map(alreadyRoomMember -> sqsMessageCreator.create(requester,
+                alreadyRoomMember, room, NotificationType.ROOM_IN))
+            .toList();
+
+        // NotificationLog 저장
+        sqsMessageResultList
+            .forEach(smr -> notificationLogRepositoryService.createNotificationLog(
+                smr.notificationLog()));
+
+        // sqs 전송
+        sqsMessageResultList
+            .stream()
+            .filter(smr -> !smr.fcmSQSMessageList().isEmpty())
+            .forEach(smr -> sqsMessageSender.sendMessage(smr.fcmSQSMessageList()));
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(RejectedJoinEvent event) {
+        Member manager = event.manager();
+        Member requester = event.requester();
+        Room room = event.room();
+
+        //SQSMessageResult 생성
+        SQSMessageResult sqsMessageResult = sqsMessageCreator.createWithRoomId(manager,
+            requester, room, NotificationType.REJECT_ROOM_JOIN);
+
+        // 알림 저장
+        notificationLogRepositoryService.createNotificationLog(
+            sqsMessageResult.notificationLog());
+
+        // sqs 전송
+        if (!sqsMessageResult.fcmSQSMessageList().isEmpty()) {
+            sqsMessageSender.sendMessage(sqsMessageResult.fcmSQSMessageList());
+        }
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void sendNotification(SentChatEvent event) {
+        Member sender = event.sender();
+        Member recipient = event.recipient();
+        ChatRoom chatRoom = event.chatRoom();
+
+        //SQSMessageResult 생성
+        SQSMessageResult sqsMessageResult = sqsMessageCreator.createWithChatRoomId(sender,
+            recipient, event.content(), chatRoom, NotificationType.ARRIVE_CHAT);
+
+        // 알림 저장
+        notificationLogRepositoryService.createNotificationLog(
+            sqsMessageResult.notificationLog());
+
+        // sqs 전송
+        if (!sqsMessageResult.fcmSQSMessageList().isEmpty()) {
+            sqsMessageSender.sendMessage(sqsMessageResult.fcmSQSMessageList());
+        }
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/sqs/dto/FcmSQSMessage.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/sqs/dto/FcmSQSMessage.java
@@ -1,0 +1,17 @@
+package com.cozymate.cozymate_server.domain.sqs.dto;
+
+import lombok.Builder;
+
+@Builder
+public record FcmSQSMessage(
+    String title,
+    String body,
+    String actionType,
+    String deviceToken,
+
+    // 상황별 키 (선택적 필드)
+    String memberId,
+    String chatRoomId,
+    String roomId
+) {
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/sqs/dto/SQSMessageResult.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/sqs/dto/SQSMessageResult.java
@@ -2,12 +2,10 @@ package com.cozymate.cozymate_server.domain.sqs.dto;
 
 import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
 import java.util.List;
-import java.util.Map;
 import lombok.Builder;
 
 @Builder
 public record SQSMessageResult(
-    Map<FcmSQSMessage, String> messageTokenMap,
     List<FcmSQSMessage> fcmSQSMessageList,
     NotificationLog notificationLog
 ) {

--- a/src/main/java/com/cozymate/cozymate_server/domain/sqs/dto/SQSMessageResult.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/sqs/dto/SQSMessageResult.java
@@ -1,0 +1,14 @@
+package com.cozymate.cozymate_server.domain.sqs.dto;
+
+import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record SQSMessageResult(
+    Map<FcmSQSMessage, String> messageTokenMap,
+    List<FcmSQSMessage> fcmSQSMessageList,
+    NotificationLog notificationLog
+) {
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/sqs/service/SQSMessageCreator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/sqs/service/SQSMessageCreator.java
@@ -1,0 +1,281 @@
+package com.cozymate.cozymate_server.domain.sqs.service;
+
+import com.cozymate.cozymate_server.domain.chatroom.ChatRoom;
+import com.cozymate.cozymate_server.domain.fcm.Fcm;
+import com.cozymate.cozymate_server.domain.fcm.dto.push.content.FcmPushContentDTO;
+import com.cozymate.cozymate_server.domain.fcm.repository.FcmRepository;
+import com.cozymate.cozymate_server.domain.sqs.dto.FcmSQSMessage;
+import com.cozymate.cozymate_server.domain.sqs.dto.SQSMessageResult;
+import com.cozymate.cozymate_server.domain.member.Member;
+import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
+import com.cozymate.cozymate_server.domain.notificationlog.dto.NotificationLogCreateDTO;
+import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
+import com.cozymate.cozymate_server.domain.room.Room;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SQSMessageCreator {
+
+    private final FcmRepository fcmRepository;
+
+    private static final String NOTIFICATION_TITLE = "cozymate";
+
+    /**
+     * ROOM_IN
+     * ROOM_OUT
+     */
+    public SQSMessageResult create(Member notRoomMember, Member roomMember,
+        Room room, NotificationType notificationType) {
+        List<Fcm> fcmList = getFcmList(roomMember);
+
+        String notificationContent = getContent(notRoomMember, room, notificationType);
+
+        NotificationLog notificationLog = notificationType.generateNotificationLog(
+            NotificationLogCreateDTO.createNotificationLogCreateDTO(roomMember, notRoomMember,
+                room, notificationContent));
+
+        if (fcmList.isEmpty()) {
+            return getEmptySQSMessageResult(notificationLog);
+        }
+
+        return getSQSMessageResult(fcmList, notificationContent, notificationType,
+            notificationLog);
+    }
+
+    /**
+     * ACCEPT_ROOM_INVITE
+     * ARRIVE_ROOM_JOIN_REQUEST
+     * ACCEPT_ROOM_JOIN
+     */
+    public SQSMessageResult create(Member contentMember, Member recipientMember,
+        NotificationType notificationType) {
+        List<Fcm> fcmList = getFcmList(recipientMember);
+
+        String notificationContent = getContent(contentMember, notificationType);
+
+        NotificationLog notificationLog = notificationType.generateNotificationLog(
+            NotificationLogCreateDTO.createNotificationLogCreateDTO(recipientMember, contentMember,
+                notificationContent));
+
+        if (fcmList.isEmpty()) {
+            return getEmptySQSMessageResult(notificationLog);
+        }
+
+        return getSQSMessageResult(fcmList, notificationContent, notificationType,
+            notificationLog);
+    }
+
+    /**
+     * ARRIVE_ROOM_INVITE
+     * REJECT_ROOM_JOIN
+     */
+    public SQSMessageResult createWithRoomId(Member inviter, Member invitee, Room room,
+        NotificationType notificationType) {
+        List<Fcm> fcmList = getFcmList(invitee);
+
+        String notificationContent = getContent(inviter, room, notificationType);
+
+        NotificationLog notificationLog = notificationType.generateNotificationLog(
+            NotificationLogCreateDTO.createNotificationLogCreateDTO(invitee, inviter,
+                room, notificationContent));
+
+        if (fcmList.isEmpty()) {
+            return getEmptySQSMessageResult(notificationLog);
+        }
+
+        return getSQSMessageResultWithRoomId(fcmList, notificationContent, room, notificationType,
+            notificationLog);
+    }
+
+    /**
+     * REJECT_ROOM_INVITE
+     */
+    public SQSMessageResult createWithMemberId(Member contentMember, Member recipientMember,
+        NotificationType notificationType) {
+        List<Fcm> fcmList = getFcmList(recipientMember);
+
+        String notificationContent = getContent(contentMember, notificationType);
+
+        NotificationLog notificationLog = notificationType.generateNotificationLog(
+            NotificationLogCreateDTO.createNotificationLogCreateDTO(recipientMember, contentMember,
+                notificationContent));
+
+        if (fcmList.isEmpty()) {
+            return getEmptySQSMessageResult(notificationLog);
+        }
+
+        return getSQSMessageResultWithMemberId(fcmList, notificationContent, contentMember,
+            notificationType, notificationLog);
+    }
+
+    /**
+     * ARRIVE_CHAT
+     */
+    public SQSMessageResult createWithChatRoomId(Member sender, Member recipient,
+        String chatContent, ChatRoom chatRoom, NotificationType notificationType) {
+        List<Fcm> fcmList = getFcmList(recipient);
+
+        String notificationContent = getContent(sender, notificationType, chatContent);
+
+        NotificationLog notificationLog = notificationType.generateNotificationLog(
+            NotificationLogCreateDTO.createNotificationLogCreateDTO(recipient, sender,
+                notificationContent, chatRoom));
+
+        if (fcmList.isEmpty()) {
+            return getEmptySQSMessageResult(notificationLog);
+        }
+
+        return getMessageResultWithChatRoomId(fcmList, notificationContent, notificationType,
+            notificationLog, chatRoom);
+    }
+
+
+    private String getContent(Member member, Room room, NotificationType notificationType) {
+        return notificationType.generateContent(FcmPushContentDTO.create(member, room));
+    }
+
+    private String getContent(Member member, NotificationType notificationType) {
+        return notificationType.generateContent(FcmPushContentDTO.create(member));
+    }
+
+    private String getContent(Member member, NotificationType notificationType,
+        String chatContent) {
+        return notificationType.generateContent(FcmPushContentDTO.create(member, chatContent));
+    }
+
+    private SQSMessageResult getSQSMessageResult(List<Fcm> fcmList, String content,
+        NotificationType notificationType, NotificationLog notificationLog) {
+        Map<FcmSQSMessage, String> sqsMessageTokenMap = new HashMap<>();
+
+        List<FcmSQSMessage> fcmSQSMessageList = fcmList.stream()
+            .map(fcm -> {
+                String token = fcm.getToken();
+
+                FcmSQSMessage fcmSqsMessage = FcmSQSMessage.builder()
+                    .title(NOTIFICATION_TITLE)
+                    .body(content)
+                    .actionType(String.valueOf(notificationType))
+                    .deviceToken(token)
+                    .build();
+
+                sqsMessageTokenMap.put(fcmSqsMessage, token);
+
+                return fcmSqsMessage;
+            }).toList();
+
+        SQSMessageResult sqsMessageResult = SQSMessageResult.builder()
+            .messageTokenMap(sqsMessageTokenMap)
+            .fcmSQSMessageList(fcmSQSMessageList)
+            .notificationLog(notificationLog)
+            .build();
+
+        return sqsMessageResult;
+    }
+
+    private SQSMessageResult getSQSMessageResultWithRoomId(List<Fcm> fcmList, String content,
+        Room room, NotificationType notificationType, NotificationLog notificationLog) {
+
+        Map<FcmSQSMessage, String> sqsMessageTokenMap = new HashMap<>();
+
+        List<FcmSQSMessage> fcmSQSMessageList = fcmList.stream()
+            .map(fcm -> {
+                String token = fcm.getToken();
+
+                FcmSQSMessage fcmSqsMessage = FcmSQSMessage.builder()
+                    .title(NOTIFICATION_TITLE)
+                    .body(content)
+                    .actionType(String.valueOf(notificationType))
+                    .deviceToken(token)
+                    .roomId(room.getId().toString())
+                    .build();
+
+                sqsMessageTokenMap.put(fcmSqsMessage, token);
+
+                return fcmSqsMessage;
+            }).toList();
+
+        SQSMessageResult sqsMessageResult = SQSMessageResult.builder()
+            .messageTokenMap(sqsMessageTokenMap)
+            .fcmSQSMessageList(fcmSQSMessageList)
+            .notificationLog(notificationLog)
+            .build();
+
+        return sqsMessageResult;
+    }
+
+    private SQSMessageResult getSQSMessageResultWithMemberId(List<Fcm> fcmList, String content,
+        Member member, NotificationType notificationType, NotificationLog notificationLog) {
+        Map<FcmSQSMessage, String> sqsMessageTokenMap = new HashMap<>();
+
+        List<FcmSQSMessage> fcmSQSMessageList = fcmList.stream()
+            .map(fcm -> {
+                String token = fcm.getToken();
+
+                FcmSQSMessage fcmSqsMessage = FcmSQSMessage.builder()
+                    .title(NOTIFICATION_TITLE)
+                    .body(content)
+                    .actionType(String.valueOf(notificationType))
+                    .deviceToken(token)
+                    .roomId(member.getId().toString())
+                    .build();
+
+                sqsMessageTokenMap.put(fcmSqsMessage, token);
+
+                return fcmSqsMessage;
+            }).toList();
+
+        SQSMessageResult sqsMessageResult = SQSMessageResult.builder()
+            .messageTokenMap(sqsMessageTokenMap)
+            .fcmSQSMessageList(fcmSQSMessageList)
+            .notificationLog(notificationLog)
+            .build();
+
+        return sqsMessageResult;
+    }
+
+    private SQSMessageResult getMessageResultWithChatRoomId(List<Fcm> fcmList, String content,
+        NotificationType notificationType, NotificationLog notificationLog, ChatRoom chatRoom) {
+        Map<FcmSQSMessage, String> sqsMessageTokenMap = new HashMap<>();
+
+        List<FcmSQSMessage> fcmSQSMessageList = fcmList.stream()
+            .map(fcm -> {
+                String token = fcm.getToken();
+
+                FcmSQSMessage fcmSqsMessage = FcmSQSMessage.builder()
+                    .title(NOTIFICATION_TITLE)
+                    .body(content)
+                    .actionType(String.valueOf(notificationType))
+                    .deviceToken(token)
+                    .roomId(chatRoom.getId().toString())
+                    .build();
+
+                sqsMessageTokenMap.put(fcmSqsMessage, token);
+
+                return fcmSqsMessage;
+            }).toList();
+
+        SQSMessageResult sqsMessageResult = SQSMessageResult.builder()
+            .messageTokenMap(sqsMessageTokenMap)
+            .fcmSQSMessageList(fcmSQSMessageList)
+            .notificationLog(notificationLog)
+            .build();
+
+        return sqsMessageResult;
+    }
+
+    private List<Fcm> getFcmList(Member member) {
+        return fcmRepository.findByMemberAndIsValidIsTrue(member);
+    }
+
+    private SQSMessageResult getEmptySQSMessageResult(NotificationLog notificationLog) {
+        return SQSMessageResult.builder()
+            .fcmSQSMessageList(List.of())
+            .notificationLog(notificationLog)
+            .build();
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/domain/sqs/service/SQSMessageCreator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/sqs/service/SQSMessageCreator.java
@@ -221,7 +221,7 @@ public class SQSMessageCreator {
                     .body(content)
                     .actionType(String.valueOf(notificationType))
                     .deviceToken(token)
-                    .roomId(member.getId().toString())
+                    .memberId(member.getId().toString())
                     .build();
 
                 sqsMessageTokenMap.put(fcmSqsMessage, token);
@@ -251,7 +251,7 @@ public class SQSMessageCreator {
                     .body(content)
                     .actionType(String.valueOf(notificationType))
                     .deviceToken(token)
-                    .roomId(chatRoom.getId().toString())
+                    .chatRoomId(chatRoom.getId().toString())
                     .build();
 
                 sqsMessageTokenMap.put(fcmSqsMessage, token);

--- a/src/main/java/com/cozymate/cozymate_server/domain/sqs/service/SQSMessageCreator.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/sqs/service/SQSMessageCreator.java
@@ -11,9 +11,7 @@ import com.cozymate.cozymate_server.domain.notificationlog.NotificationLog;
 import com.cozymate.cozymate_server.domain.notificationlog.dto.NotificationLogCreateDTO;
 import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
 import com.cozymate.cozymate_server.domain.room.Room;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -150,7 +148,6 @@ public class SQSMessageCreator {
 
     private SQSMessageResult getSQSMessageResult(List<Fcm> fcmList, String content,
         NotificationType notificationType, NotificationLog notificationLog) {
-        Map<FcmSQSMessage, String> sqsMessageTokenMap = new HashMap<>();
 
         List<FcmSQSMessage> fcmSQSMessageList = fcmList.stream()
             .map(fcm -> {
@@ -163,13 +160,10 @@ public class SQSMessageCreator {
                     .deviceToken(token)
                     .build();
 
-                sqsMessageTokenMap.put(fcmSqsMessage, token);
-
                 return fcmSqsMessage;
             }).toList();
 
         SQSMessageResult sqsMessageResult = SQSMessageResult.builder()
-            .messageTokenMap(sqsMessageTokenMap)
             .fcmSQSMessageList(fcmSQSMessageList)
             .notificationLog(notificationLog)
             .build();
@@ -179,8 +173,6 @@ public class SQSMessageCreator {
 
     private SQSMessageResult getSQSMessageResultWithRoomId(List<Fcm> fcmList, String content,
         Room room, NotificationType notificationType, NotificationLog notificationLog) {
-
-        Map<FcmSQSMessage, String> sqsMessageTokenMap = new HashMap<>();
 
         List<FcmSQSMessage> fcmSQSMessageList = fcmList.stream()
             .map(fcm -> {
@@ -194,13 +186,10 @@ public class SQSMessageCreator {
                     .roomId(room.getId().toString())
                     .build();
 
-                sqsMessageTokenMap.put(fcmSqsMessage, token);
-
                 return fcmSqsMessage;
             }).toList();
 
         SQSMessageResult sqsMessageResult = SQSMessageResult.builder()
-            .messageTokenMap(sqsMessageTokenMap)
             .fcmSQSMessageList(fcmSQSMessageList)
             .notificationLog(notificationLog)
             .build();
@@ -210,7 +199,6 @@ public class SQSMessageCreator {
 
     private SQSMessageResult getSQSMessageResultWithMemberId(List<Fcm> fcmList, String content,
         Member member, NotificationType notificationType, NotificationLog notificationLog) {
-        Map<FcmSQSMessage, String> sqsMessageTokenMap = new HashMap<>();
 
         List<FcmSQSMessage> fcmSQSMessageList = fcmList.stream()
             .map(fcm -> {
@@ -224,13 +212,10 @@ public class SQSMessageCreator {
                     .memberId(member.getId().toString())
                     .build();
 
-                sqsMessageTokenMap.put(fcmSqsMessage, token);
-
                 return fcmSqsMessage;
             }).toList();
 
         SQSMessageResult sqsMessageResult = SQSMessageResult.builder()
-            .messageTokenMap(sqsMessageTokenMap)
             .fcmSQSMessageList(fcmSQSMessageList)
             .notificationLog(notificationLog)
             .build();
@@ -240,7 +225,6 @@ public class SQSMessageCreator {
 
     private SQSMessageResult getMessageResultWithChatRoomId(List<Fcm> fcmList, String content,
         NotificationType notificationType, NotificationLog notificationLog, ChatRoom chatRoom) {
-        Map<FcmSQSMessage, String> sqsMessageTokenMap = new HashMap<>();
 
         List<FcmSQSMessage> fcmSQSMessageList = fcmList.stream()
             .map(fcm -> {
@@ -254,13 +238,10 @@ public class SQSMessageCreator {
                     .chatRoomId(chatRoom.getId().toString())
                     .build();
 
-                sqsMessageTokenMap.put(fcmSqsMessage, token);
-
                 return fcmSqsMessage;
             }).toList();
 
         SQSMessageResult sqsMessageResult = SQSMessageResult.builder()
-            .messageTokenMap(sqsMessageTokenMap)
             .fcmSQSMessageList(fcmSQSMessageList)
             .notificationLog(notificationLog)
             .build();

--- a/src/main/java/com/cozymate/cozymate_server/domain/sqs/service/SQSMessageSender.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/sqs/service/SQSMessageSender.java
@@ -1,0 +1,43 @@
+package com.cozymate.cozymate_server.domain.sqs.service;
+
+import com.cozymate.cozymate_server.domain.sqs.dto.FcmSQSMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.operations.SendResult;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SQSMessageSender {
+
+    private final SqsTemplate sqsTemplate;
+    private final ObjectMapper om;
+
+    @Value("${cloud_sqs.aws.sqs.queue-name}")
+    private String QUEUE_NAME;
+
+    public void sendMessage(List<FcmSQSMessage> fcmSqsMessageList) {
+        String payload;
+        try {
+            payload = om.writeValueAsString(fcmSqsMessageList);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("SQS 전송용 JSON 직렬화 실패", e);
+        }
+
+        try {
+            SendResult<String> sendResult = sqsTemplate.send(to -> to
+                .queue(QUEUE_NAME)
+                .payload(payload));
+
+            log.info("SQS 메시지 전송 성공, 메시지 id : {}", sendResult.messageId());
+        } catch (Exception e) {
+            log.error("SQS 메시지 전송 실패. payload: {}, 이유: {}", payload, e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/config/AwsSQSConfig.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/config/AwsSQSConfig.java
@@ -1,0 +1,47 @@
+package com.cozymate.cozymate_server.global.config;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+@Configuration
+public class AwsSQSConfig {
+
+    @Value("${cloud_sqs.aws.credentials.accessKey}")
+    private String AWS_ACCESS_KEY;
+
+    @Value("${cloud_sqs.aws.credentials.secretKey}")
+    private String AWS_SECRET_KEY;
+
+    @Value("${cloud_sqs.aws.region.static}")
+    private String AWS_REGION;
+
+    // 클라이언트 설정: region과 자격증명
+    @Bean
+    public SqsAsyncClient sqsAsyncClient() {
+        return SqsAsyncClient.builder()
+            .credentialsProvider(() -> new AwsCredentials() {
+                @Override
+                public String accessKeyId() {
+                    return AWS_ACCESS_KEY;
+                }
+
+                @Override
+                public String secretAccessKey() {
+                    return AWS_SECRET_KEY;
+                }
+            })
+            .region(Region.of(AWS_REGION))
+            .build();
+    }
+
+    // 메시지 발송을 위한 SQS 템플릿 설정 (Sender 쪽)
+    @Bean
+    public SqsTemplate sqsTemplate() {
+        return SqsTemplate.newTemplate(sqsAsyncClient());
+    }
+}

--- a/src/main/java/com/cozymate/cozymate_server/global/config/AwsSQSConfig.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/config/AwsSQSConfig.java
@@ -4,7 +4,8 @@ import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
@@ -24,17 +25,8 @@ public class AwsSQSConfig {
     @Bean
     public SqsAsyncClient sqsAsyncClient() {
         return SqsAsyncClient.builder()
-            .credentialsProvider(() -> new AwsCredentials() {
-                @Override
-                public String accessKeyId() {
-                    return AWS_ACCESS_KEY;
-                }
-
-                @Override
-                public String secretAccessKey() {
-                    return AWS_SECRET_KEY;
-                }
-            })
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(AWS_ACCESS_KEY, AWS_SECRET_KEY)))
             .region(Region.of(AWS_REGION))
             .build();
     }


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

변경 이유 :
<img width="600" alt="image" src="https://github.com/user-attachments/assets/19074d83-3f84-47e8-b655-fe3a3f59b3d2" />
Number of Threads : 15, Ramp-up : 5, Loop Count : 3

Jmeter로 푸시 알림을 여러개 보낼 때 CPU 사용률이 얼마나 될지 궁금해서 확인해보니 위 조건일 때 77.4퍼센트까지 오르는걸 보고
SQS + Lambda 조합으로 변경을 시도해봤습니다

---

1. 기존 서버에서 firebase로 푸시 알림을 요청하던 부분을 SQS + Lambda로 요청하도록 변경했습니다.
- 기존 : 우리 서버 -> firebase -> device
- 변경 : 우리 서버 -> SQS -> Lambda -> firebase -> device

2. 기존 코드는 알림 요청이 실제로 성공한 알림에 대해서만 알림 내역을 저장하고 있었지만, 현재 알림 내역에서도 화면 이동이 되는 기능이 있어 알림 내역은 무조건 저장되도록 수정했습니다.

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요

Jmeter로 푸시 알림 80개 요청
<img width="800" alt="image" src="https://github.com/user-attachments/assets/f74a8a54-248d-404a-8780-dad22fbb8065" />

푸시 알림 정확히 80개가 도착했습니다
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d7706b43-e7f6-4c36-9746-9c9d0b7bd3d4" />

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.

일단 AWS는 제 계정에서 진행했고, 해당 기능들을 처음 사용해보는거라 에러가 발생하지 않는다는 확신은 없어서 일단 기존 Listener 주석처리 해두고 QA하다 문제 생기면 Listener만 다시 되돌리겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * AWS SQS 연동을 위한 설정 및 메시지 전송 기능이 추가되었습니다.
  * 다양한 이벤트(방 입장/퇴장, 초대, 채팅 등)에 대해 알림을 비동기로 SQS를 통해 발송하는 기능이 도입되었습니다.
  * FCM 메시지 및 SQS 메시지 생성 로직이 구현되어 알림 발송이 체계화되었습니다.

* **리팩터**
  * 기존 이벤트 리스너가 비활성화되고, 새로운 알림 이벤트 리스너가 도입되었습니다.

* **환경 구성**
  * AWS SQS 관련 라이브러리 및 Spring Cloud AWS 의존성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->