### PR TITLE
[COZY-648] feat: ROLE_TODO 관련 코드 제거

### DIFF
--- a/src/main/java/com/cozymate/cozymate_server/domain/role/repository/RoleRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/role/repository/RoleRepositoryService.java
@@ -26,10 +26,6 @@ public class RoleRepositoryService {
             .orElseThrow(() -> new GeneralException(ErrorStatus._ROLE_NOT_FOUND));
     }
 
-    public List<Role> getRoleList() {
-        return roleRepository.findAll();
-    }
-
     public List<Role> getRoleListByRoomId(Long roomId) {
         return roleRepository.findAllByRoomId(roomId);
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/role/service/RoleCommandService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/role/service/RoleCommandService.java
@@ -57,11 +57,6 @@ public class RoleCommandService {
             RoleConverter.toEntity(mate, mateIdList, requestDto.content(), repeatDayBitmask)
         );
 
-        DayOfWeek dayOfWeek = LocalDate.now(clock).getDayOfWeek();
-        int dayBitmask = DayListBitmask.getBitmaskByDayOfWeek(dayOfWeek);
-        if ((role.getRepeatDays() & dayBitmask) != 0) {
-            todoCommandService.createRoleTodo(role);
-        }
         return RoleConverter.toRoleSimpleResponseDTOWithEntity(role);
     }
 
@@ -74,8 +69,6 @@ public class RoleCommandService {
         Mate mate = getMate(member.getId(), roomId);
 
         roleValidator.checkUpdatePermission(role, mate);
-
-        todoCommandService.deleteTodoByRoleId(role);
         roleRepositoryService.deleteRole(role);
     }
 
@@ -120,17 +113,6 @@ public class RoleCommandService {
         // role 수정
         role.updateEntity(mateIdList, requestDto.content(),
             RoleConverter.convertDayListToBitmask(requestDto.repeatDayList()));
-    }
-
-    /**
-     * 오늘 요일에 해당하는 Role을 투두로 추가 (SCHEDULED)
-     */
-    public void addRoleToTodo() {
-        DayOfWeek dayOfWeek = LocalDate.now(clock).getDayOfWeek();
-        int dayBitmask = DayListBitmask.getBitmaskByDayOfWeek(dayOfWeek);
-        List<Role> roleList = roleRepositoryService.getRoleList();
-        roleList.stream().filter(role -> (role.getRepeatDays() & dayBitmask) != 0).toList()
-            .forEach(todoCommandService::createRoleTodo);
     }
 
     // mate의 name과 id가 일치하는지 여부 체크

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/Todo.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/Todo.java
@@ -48,10 +48,6 @@ public class Todo extends BaseTimeEntity {
     private TodoType todoType;
 
     public void updateTodoType(List<Mate> assignmentMateList) {
-        if (this.role != null) {
-            this.todoType = TodoType.ROLE_TODO;
-            return;
-        }
         if (assignmentMateList.size() == 1) {
             this.todoType = TodoType.SINGLE_TODO;
             return;
@@ -61,10 +57,6 @@ public class Todo extends BaseTimeEntity {
 
     // 객체에 저장된 AssignedMateCount 값으로 체크 -> 해당 값이 정확해야함
     public void updateTodoType() {
-        if (this.role != null) {
-            this.todoType = TodoType.ROLE_TODO;
-            return;
-        }
         if (this.assignedMateCount == 1) {
             this.todoType = TodoType.SINGLE_TODO;
             return;

--- a/src/main/java/com/cozymate/cozymate_server/domain/todo/enums/TodoType.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todo/enums/TodoType.java
@@ -5,12 +5,11 @@ import lombok.Getter;
 @Getter
 public enum TodoType {
     SINGLE_TODO("single"), // 남 투두
-    GROUP_TODO("group"), // 그룹 투두
-    ROLE_TODO("role"); // 롤 투두
+    GROUP_TODO("group"); // 그룹 투투
 
     private String todoName;
 
-    private TodoType(String todoName) {
+    TodoType(String todoName) {
         this.todoName = todoName;
 
     }

--- a/src/main/java/com/cozymate/cozymate_server/domain/todoassignment/repository/TodoAssignmentRepository.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todoassignment/repository/TodoAssignmentRepository.java
@@ -30,17 +30,6 @@ public interface TodoAssignmentRepository extends JpaRepository<TodoAssignment, 
         @Param("timePoint") LocalDate timePoint);
 
     @Query("""
-        SELECT ta
-        FROM TodoAssignment ta
-        JOIN FETCH ta.todo
-        JOIN FETCH ta.mate
-        WHERE ta.todo.timePoint = :timePoint
-        AND ta.todo.role IS NOT NULL
-        """)
-    List<TodoAssignment> findByTodoTimePointAndTodoRoleIsNotNull(
-        @Param("timePoint") LocalDate timePoint);
-
-    @Query("""
         SELECT COUNT(ta)
         FROM TodoAssignment ta
         JOIN ta.mate

--- a/src/main/java/com/cozymate/cozymate_server/domain/todoassignment/repository/TodoAssignmentRepositoryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todoassignment/repository/TodoAssignmentRepositoryService.java
@@ -79,15 +79,6 @@ public class TodoAssignmentRepositoryService {
     }
 
     /**
-     * <p>Role 투두 중 특정 시점에 할당된 Assignment 객체 리스트를 조회</p>
-     * <p>Schedular에서 사용</p>
-     */
-    public List<TodoAssignment> getAssignmentListByTimePointAndTodoRoleIsNotNull(
-        LocalDate timePoint) {
-        return todoAssignmentRepository.findByTodoTimePointAndTodoRoleIsNotNull(timePoint);
-    }
-
-    /**
      * Assignment 생성
      */
     public TodoAssignment createAssignment(TodoAssignment todoAssignment) {
@@ -106,17 +97,6 @@ public class TodoAssignmentRepositoryService {
      */
     public void deleteAssignmentListInAssignmentList(List<TodoAssignment> todoAssignmentList) {
         todoAssignmentRepository.deleteAll(todoAssignmentList);
-    }
-
-    /**
-     * 투두 리스트에 할당된 Assignment 삭제
-     */
-    public void deleteAssignmentListInTodoList(List<Todo> todoList) {
-        deleteAssignmentListInTodoIdList(todoList.stream().map(Todo::getId).toList());
-    }
-
-    public void deleteAssignmentListInTodoIdList(List<Long> todoIdList) {
-        todoAssignmentRepository.deleteAllByTodoIdIn(todoIdList);
     }
 
 

--- a/src/main/java/com/cozymate/cozymate_server/domain/todoassignment/service/TodoAssignmentQueryService.java
+++ b/src/main/java/com/cozymate/cozymate_server/domain/todoassignment/service/TodoAssignmentQueryService.java
@@ -1,14 +1,8 @@
 package com.cozymate.cozymate_server.domain.todoassignment.service;
 
-import com.cozymate.cozymate_server.domain.fcm.dto.push.target.OneTargetDTO;
-import com.cozymate.cozymate_server.domain.fcm.service.FcmPushService;
 import com.cozymate.cozymate_server.domain.mate.Mate;
-import com.cozymate.cozymate_server.domain.notificationlog.enums.NotificationType;
-import com.cozymate.cozymate_server.domain.roomlog.service.RoomLogCommandService;
-import com.cozymate.cozymate_server.domain.todo.Todo;
 import com.cozymate.cozymate_server.domain.todoassignment.TodoAssignment;
 import com.cozymate.cozymate_server.domain.todoassignment.repository.TodoAssignmentRepositoryService;
-import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,43 +13,11 @@ import org.springframework.stereotype.Service;
 public class TodoAssignmentQueryService {
 
     private final TodoAssignmentRepositoryService todoAssignmentRepositoryService;
-    private final RoomLogCommandService roomLogCommandService;
-    private final FcmPushService fcmPushService;
-    private final Clock clock;
-
 
     public List<TodoAssignment> getAssignmentList(List<Mate> mateList, LocalDate timePoint) {
         List<Long> mateIdList = mateList.stream().map(Mate::getId).toList();
         return todoAssignmentRepositoryService.getAssignmentListByMateIdListAndTimePoint(mateIdList,
             timePoint);
-    }
-
-    /**
-     * 매일 자정에 완료하지 않은 RoomLog에 대해서 알림 추가 (SCHEDULED)
-     */
-    public void addReminderRoleRoomLog() {
-        List<TodoAssignment> todoAssignmentList = todoAssignmentRepositoryService.getAssignmentListByTimePointAndTodoRoleIsNotNull(
-            LocalDate.now(clock));
-
-        roomLogCommandService.addRoomLogRemindingRole(todoAssignmentList);
-    }
-
-    /**
-     * 매일 21시에 완료하지 않은 투두에 대한 알림 전송 (SCHEDULED)
-     */
-    public void sendReminderRoleNotification() {
-        List<TodoAssignment> todoAssignmentList = todoAssignmentRepositoryService.getAssignmentListByTimePointAndTodoRoleIsNotNull(
-            LocalDate.now(clock));
-
-        // TODO: remide할 size가 여러개면 ~~ 외 몇개로 수정
-        todoAssignmentList.forEach(todoAssignment -> {
-            Mate mate = todoAssignment.getMate();
-            Todo todo = todoAssignment.getTodo();
-            fcmPushService.sendNotification(
-                OneTargetDTO.create(mate.getMember(),
-                    NotificationType.REMINDER_ROLE,
-                    todo.getContent()));
-        });
     }
 
 }

--- a/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/response/code/status/ErrorStatus.java
@@ -129,8 +129,6 @@ public enum ErrorStatus implements BaseErrorCode {
     _TODO_EDIT_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "TODO401", "수정할 수 있는 권한이 없습니다."),
     _TODO_DAILY_LIMIT(HttpStatus.BAD_REQUEST, "TODO402", "생성할 수 있는 하루 최대 Todo 개수를 초과했습니다."),
     _TODO_NOT_IN_ROOM(HttpStatus.BAD_REQUEST, "TODO403", "해당하는 방에 해당 Todo가 없습니다."),
-    _ROLE_TODO_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "TODO404", "Role Todo는 삭제할 수 없습니다."),
-    _ROLE_TODO_CANNOT_UPDATE(HttpStatus.BAD_REQUEST, "TODO405", "Role Todo는 수정할 수 없습니다."),
     _TODO_ASSIGNED_MATE_LIMIT(HttpStatus.BAD_REQUEST, "TODO406", "하나의 Todo에 할당할 수 있는 할당자를 초과했습니다."),
 
     // TodoAssignment 관련

--- a/src/main/java/com/cozymate/cozymate_server/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/cozymate/cozymate_server/global/scheduler/NotificationScheduler.java
@@ -1,15 +1,9 @@
 package com.cozymate.cozymate_server.global.scheduler;
 
-import com.cozymate.cozymate_server.domain.fcm.service.FcmPushService;
 import com.cozymate.cozymate_server.domain.mate.Mate;
 import com.cozymate.cozymate_server.domain.mate.enums.EntryStatus;
 import com.cozymate.cozymate_server.domain.mate.repository.MateRepository;
-import com.cozymate.cozymate_server.domain.role.service.RoleCommandService;
-import com.cozymate.cozymate_server.domain.room.repository.RoomRepository;
 import com.cozymate.cozymate_server.domain.roomlog.service.RoomLogCommandService;
-import com.cozymate.cozymate_server.domain.todo.repository.TodoRepository;
-import com.cozymate.cozymate_server.domain.todoassignment.service.TodoAssignmentQueryService;
-import io.sentry.spring.jakarta.checkin.SentryCheckIn;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,59 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class NotificationScheduler {
 
-    private final FcmPushService fcmPushService;
     private final MateRepository mateRepository;
-    private final TodoRepository todoRepository;
 
     private final RoomLogCommandService roomLogCommandService;
-    private final RoomRepository roomRepository;
-    private final TodoAssignmentQueryService todoAssignmentQueryService;
-    private final RoleCommandService roleCommandService;
-
-    // 매일 자정 반복 (해당하는 날 역할을 Todo에 추가) 작업 자정에 먼저하고 나서 시작하도록 30초로 설정
-    // TODO: 20241223 Todo 할당자에게 알림 보내도록 수정해야함
-//    @Scheduled(cron = "30 0 0 * * *")
-//    public void sendDailyNotification() {
-//        LocalDate today = LocalDate.now();
-//        List<Todo> todoList = todoRepository.findByTimePoint(today);
-//
-//        Map<Member, List<String>> todoMap = todoList.stream()
-//            .collect(Collectors.groupingBy(
-//                todo -> mateRepository.findById(todo.getMateId())
-//                    .orElse()
-//                    .getMember(),
-//                Collectors.mapping(
-//                    Todo::getContent,
-//                    Collectors.toList()
-//                )
-//
-//            ));
-//
-//        todoMap.forEach((member, todoContents) -> {
-//            fcmPushService.sendNotification(
-//                OneTargetDto.create(member, NotificationType.TODO_LIST, todoContents));
-//        });
-//    }
-
-//    @Scheduled(cron = "0 0 12 L * ?")
-//    public void sendMonthlyNotification() {
-//        List<Mate> mates = mateRepository.findFetchAll();
-//
-//        List<Member> memberList = mates.stream()
-//            .map(Mate::getMember)
-//            .toList();
-//
-//        memberList.forEach(member -> {
-//            fcmPushService.sendNotification(
-//                OneTargetDto.create(member, NotificationType.SELECT_COZY_MATE));
-//        });
-//
-//        //  각 Room에 대해 로그 추가 (이달의 베스트 코지메이트, 워스트 코지메이트 선정 알림)
-//        LocalDateTime now = LocalDateTime.now();
-//        String month = now.format(DateTimeFormatter.ofPattern("M월"));
-//        List<Room> roomList = roomRepository.findAll();
-//        roomList.forEach(room -> roomLogCommandService.addRoomLogChoiceCozyMate(room, month));
-//    }
 
     // 매일 자정 반복 (생일인 사람 확인해서 해당 방에 로그 추가)
     @Scheduled(cron = "0 0 0 * * *")
@@ -91,28 +35,5 @@ public class NotificationScheduler {
         );
     }
 
-    /**
-     * Role 투두 잊지 않았는지 FCM 알림
-     */
-    @Scheduled(cron = "00 00 21 * * *")
-    public void sendReminderRoleNotification() {
-        todoAssignmentQueryService.sendReminderRoleNotification();
-    }
 
-    /**
-     * 매일 자정에 완료하지 않은 RoomLog에 대해서 알림 추가
-     */
-    @Scheduled(cron = "0 0 0 * * *")
-    public void addReminderRoleRoomLog() {
-        todoAssignmentQueryService.addReminderRoleRoomLog();
-    }
-
-    /**
-     * 매일 자정 반복 (해당하는 날 역할을 Todo에 추가)
-     */
-    @SentryCheckIn("createtodobyrole")
-    @Scheduled(cron = "0 0 0 * * *")
-    public void addRoleToTodo() {
-        roleCommandService.addRoleToTodo();
-    }
 }

--- a/src/test/java/com/cozymate/cozymate_server/domain/role/service/RoleCommandServiceTest.java
+++ b/src/test/java/com/cozymate/cozymate_server/domain/role/service/RoleCommandServiceTest.java
@@ -317,45 +317,5 @@ public class RoleCommandServiceTest {
 
     }
 
-    @Nested
-    @MockitoSettings(strictness = Strictness.LENIENT)
-    class addRoleToTodo {
-
-        private Role role2;
-        private Role role3;
-        private Role role4;
-        private Role role5;
-
-        @BeforeEach
-        void setUp() {
-            role = RoleFixture.정상_1(room, mate, List.of(mate));  // 월
-            role2 = RoleFixture.정상_2(room, mate, List.of(mate)); // 매일
-            role3 = RoleFixture.정상_3(room, mate, List.of(mate)); // 화, 목
-            role4 = RoleFixture.정상_4(room, mate, List.of(mate)); // 월 ~ 금
-            role5 = RoleFixture.정상_5(room, mate, List.of(mate)); // X
-
-            given(clock.getZone()).willReturn(ZoneId.of("Asia/Seoul"));
-            given(clock.instant()).willReturn(Instant.parse("2025-03-24T00:00:01Z")); // 월요일
-            willDoNothing().given(todoCommandService).createRoleTodo(any(Role.class));
-
-        }
-
-        @Test
-        @DisplayName("오늘 요일에 해당하는 Role을 투두로 추가한다.")
-        void success_add_role_to_todo() {
-            //given
-            given(roleRepositoryService.getRoleList())
-                .willReturn(List.of(role, role2, role3, role4, role5));
-
-            //when
-            roleCommandService.addRoleToTodo();
-
-            //then
-            // 1, 2, 4번 Role -> 투두 추가.
-            verify(todoCommandService, times(3))
-                .createRoleTodo(any(Role.class));
-        }
-    }
-
 
 }

--- a/src/test/java/com/cozymate/cozymate_server/fixture/TodoFixture.java
+++ b/src/test/java/com/cozymate/cozymate_server/fixture/TodoFixture.java
@@ -72,27 +72,6 @@ public class TodoFixture {
         return Pair.of(todo, todoAssignmentList);
     }
 
-
-    // 정상 더미데이터, 오늘 투두, 롤에서 생성된 투두
-    public static Pair<Todo, List<TodoAssignment>> 정상_6(Room room, Mate mate, Role role,
-        List<Mate> mateList) {
-        Todo todo = Todo.builder()
-            .id(6L)
-            .room(room)
-            .mateId(mate.getId())
-            .role(role)
-            .content("마트가서 간식 사오기")
-            .timePoint(LocalDate.now())
-            .todoType(TodoType.ROLE_TODO) // Todotype은 mate와 assignedMateList에 따라 결정
-            .build();
-
-        List<TodoAssignment> todoAssignmentList = mateList.stream()
-            .map(mate1 -> new TodoAssignment(mate1, todo, false)
-            ).toList();
-
-        return Pair.of(todo, todoAssignmentList);
-    }
-
     // 에러 더미데이터, content의 최대 길이는 35자인데, 36자로 너무 긴 content
     public static Pair<Todo, List<TodoAssignment>> 너무_긴_content(Room room, Mate mate,
         TodoType todoType, List<Mate> mateList) {


### PR DESCRIPTION
# ⚒️develop의 최신 커밋을 pull 받았나요?
넵

## #️⃣ 작업 내용
> 어떤 기능을 구현했나요?
> 기존 기능에서 어떤 점이 달라졌나요?
> 자세한 로직이 필요하다면 함께 적어주세요!
> 코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!

- RoleTodo 관련 코드를 모두 제거했습니다.
- 나중에 다시 부활하게 되면 해당 commit 참고해서 다시 부활시키겠습니다.
- ROLE_TODO가 사라져서 데이터베이스의 모든 TODO를 제거했습니다. 쿼리로 하려고 했는데 몇개 없어서 그냥 지웠어요
- 투두 추가삭제 기능을 모두 실험해본결과 기존 기능들은 모두 정상 동작 합니다.
- 스케줄러에 롤 투두 관련 알림이 몇개 있었는데 그것도 모두 지웠습니다 (3개)

## 동작 확인
> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요
![image](https://github.com/user-attachments/assets/fe993e82-dabc-4120-a9ae-d90d8510bbbd)
![image](https://github.com/user-attachments/assets/d44ab3fc-3a40-410a-8477-c6da445a98ef)
![image](https://github.com/user-attachments/assets/adc57201-1d5c-46c2-b5c5-5ed1d3aca920)
![image](https://github.com/user-attachments/assets/fc190e47-23b7-4da8-9b4f-a395b84e71d3)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 고민사항도 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 변경**
  * 역할(Role) 기반 할 일(투두) 생성, 삭제, 알림, 리마인더 기능이 모두 제거되었습니다.
  * 역할과 연동된 할 일의 자동 생성 및 삭제, 관련 알림 및 로그 기능이 더 이상 제공되지 않습니다.
  * 할 일 유형에서 역할 기반 유형이 삭제되어, 할 일 유형이 단일 또는 그룹으로만 분류됩니다.

* **버그 수정**
  * 역할 기반 할 일의 수정 및 삭제 제한이 제거되어, 일반 할 일과 동일하게 관리할 수 있습니다.

* **테스트**
  * 역할 기반 할 일 관련 테스트 코드와 테스트 데이터가 삭제되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->